### PR TITLE
Add logging for SmartCar refresh token exchanges

### DIFF
--- a/server/src/services/vehicle/client.ts
+++ b/server/src/services/vehicle/client.ts
@@ -41,7 +41,15 @@ async function refreshAccessToken(): Promise<string> {
     mode: 'live',
   });
 
-  const result = await authClient.exchangeRefreshToken(config.smartcar.refresh_token);
+  const oldRefreshToken = config.smartcar.refresh_token;
+
+  if (!tokenCache) {
+    logger.info(`SmartCar: starting with refresh token ...${oldRefreshToken?.slice(-8)}`);
+  }
+
+  const result = await authClient.exchangeRefreshToken(oldRefreshToken);
+
+  logger.info(`SmartCar: exchanged refresh token ...${oldRefreshToken?.slice(-8)} → ...${result.refreshToken?.slice(-8)}`);
 
   config.smartcar.refresh_token = result.refreshToken;
   saveConfig();


### PR DESCRIPTION
## Summary
Enhanced observability for SmartCar authentication token refresh operations by adding detailed logging around refresh token exchanges.

## Key Changes
- Store the old refresh token in a variable before exchange for logging purposes
- Add initial startup log when token cache is empty, displaying the last 8 characters of the refresh token
- Add completion log after successful token exchange, showing the transition from old to new refresh token (last 8 characters of each)

## Implementation Details
- Sensitive token values are masked by only logging the last 8 characters to maintain security
- Logging is conditional on token cache state to avoid redundant logs during normal operation
- The changes maintain the existing token refresh flow while improving debugging and monitoring capabilities

https://claude.ai/code/session_01LAyhmD25r4S5jB1eyJBJ6s