### PR TITLE
Add configurable greeting window to motion sensor automation

### DIFF
--- a/server/src/automations/greeting.ts
+++ b/server/src/automations/greeting.ts
@@ -2,6 +2,7 @@ import bus, { FIRST_USER_HOME } from '../bus';
 import { Device, Stay } from '../models';
 import { createBackgroundTransaction } from '../helpers/newrelic';
 import { DeviceCapabilityEvents } from '../models/capabilities';
+import logger from '../logger';
 
 const greetings: ((name: string) => string)[] = [
   (name) => `<voice name="Mizuki"><lang xml:lang="ja-JP">こんにちは ${name}</lang></voice>. That's hello, in Japanese!'`,
@@ -13,13 +14,15 @@ const greetings: ((name: string) => string)[] = [
   (name) => `<voice name="Geraint"><amazon:emotion name="excited" intensity="high">Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch ${name}</amazon:emotion></voice>. That's G, saying hello!`
 ];
 
+type GreetingAutomationParameters = {
+  alexa_name: string;
+  greeting_window_minutes?: number;
+};
+
 export default async function ({
   alexa_name: alexaName,
   greeting_window_minutes: greetingWindowMinutes = 10,
-}: {
-  alexa_name: string;
-  greeting_window_minutes?: number;
-}) {
+}: GreetingAutomationParameters) {
   let unannouncedStay: Stay | null = null;
 
   DeviceCapabilityEvents.onMotionSensorHasMotionStart(createBackgroundTransaction('automations:greeting', async (event) => {
@@ -29,6 +32,7 @@ export default async function ({
 
       const millisecondsSinceArrival = event.start.getTime() - stay.arrival!.getTime();
       if (millisecondsSinceArrival > greetingWindowMinutes * 60 * 1000) {
+        logger.info(`Suppressing greeting for stay ${stay.id}: first motion at ${event.start.toISOString()} was ${Math.round(millisecondsSinceArrival / 1000 / 60)} minutes after arrival at ${stay.arrival!.toISOString()}, outside ${greetingWindowMinutes} minute window`);
         return;
       }
 

--- a/server/src/automations/greeting.ts
+++ b/server/src/automations/greeting.ts
@@ -13,20 +13,30 @@ const greetings: ((name: string) => string)[] = [
   (name) => `<voice name="Geraint"><amazon:emotion name="excited" intensity="high">Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch ${name}</amazon:emotion></voice>. That's G, saying hello!`
 ];
 
-export default async function ({ alexa_name: alexaName }: { alexa_name: string }) {
+export default async function ({
+  alexa_name: alexaName,
+  greeting_window_minutes: greetingWindowMinutes = 10,
+}: {
+  alexa_name: string;
+  greeting_window_minutes?: number;
+}) {
   let unannouncedStay: Stay | null = null;
 
   DeviceCapabilityEvents.onMotionSensorHasMotionStart(createBackgroundTransaction('automations:greeting', async (event) => {
     if (unannouncedStay !== null) {
-      const [
-        device,
-        user
-      ] = await Promise.all([
+      const stay = unannouncedStay;
+      unannouncedStay = null;
+
+      const millisecondsSinceArrival = event.start.getTime() - stay.arrival!.getTime();
+      if (millisecondsSinceArrival > greetingWindowMinutes * 60 * 1000) {
+        return;
+      }
+
+      const [device, user] = await Promise.all([
         Device.findByNameOrError(alexaName),
-        unannouncedStay.getUser()
+        stay.getUser()
       ]);
 
-      unannouncedStay = null;
       device.getSpeakerCapability().emitSound(greetings[Math.floor(Math.random() * greetings.length)](user.handle));
     }
   }));


### PR DESCRIPTION
## Summary
Enhanced the greeting automation to support a configurable time window for announcing guest arrivals, preventing greetings from being triggered too long after motion is detected.

## Key Changes
- Added `greeting_window_minutes` parameter (defaults to 10 minutes) to control how long after arrival a greeting can be announced
- Implemented time-based validation that checks if motion was detected within the configured window since the guest's arrival time
- Refactored event handler logic to clear the `unannouncedStay` flag earlier and store it in a local variable for safer reference
- Improved code organization by moving the greeting window check before the async device/user lookup

## Implementation Details
- The greeting will only be announced if motion is detected within `greeting_window_minutes * 60 * 1000` milliseconds of the recorded arrival time
- If motion is detected outside this window, the automation silently returns without announcing
- The parameter is optional and maintains backward compatibility with a sensible 10-minute default

https://claude.ai/code/session_01JQaVzBYi6uEkgng1bK1bH3