### PR TITLE
Remove Humidity from Thermostat capability; use HumiditySensor instead

### DIFF
--- a/server/src/capabilities.json
+++ b/server/src/capabilities.json
@@ -269,12 +269,6 @@
       "eventName": "setback"
     },
     {
-      "name": "Humidity",
-      "isWriteable": false,
-      "type": "number",
-      "eventName": "humidity"
-    },
-    {
       "name": "CurrentTemperature",
       "isWriteable": false,
       "type": "number",

--- a/server/src/services/tado/index.ts
+++ b/server/src/services/tado/index.ts
@@ -180,7 +180,7 @@ nowAndSetInterval(createBackgroundTransaction('tado:sync', async () => {
   const zonesState = await client.getZonesState();
 
   for (const device of devices) {
-    const deviceCapability = device.getThermostatCapability();
+    const thermostatCapability = device.getThermostatCapability();
     const zoneState = zonesState[Number(device.providerId)];
 
     if (zoneState === undefined) {
@@ -189,11 +189,12 @@ nowAndSetInterval(createBackgroundTransaction('tado:sync', async () => {
     }
 
     await Promise.all([
-      deviceCapability.setPowerState(zoneState.activityDataPoints.heatingPower.percentage, new Date(zoneState.activityDataPoints.heatingPower.timestamp)),
-      deviceCapability.setIsOnState(zoneState.activityDataPoints.heatingPower.percentage > 0, new Date(zoneState.activityDataPoints.heatingPower.timestamp)),
       device.getHumiditySensorCapability().setHumidityState(zoneState.sensorDataPoints.humidity.percentage, new Date(zoneState.sensorDataPoints.humidity.timestamp)),
-      deviceCapability.setCurrentTemperatureState(zoneState.sensorDataPoints.insideTemperature.celsius, new Date(zoneState.sensorDataPoints.insideTemperature.timestamp)),
-      deviceCapability.setTargetTemperatureState(zoneState.setting.power === 'ON' ? zoneState.setting.temperature.celsius : 0, new Date())
+
+      thermostatCapability.setPowerState(zoneState.activityDataPoints.heatingPower.percentage, new Date(zoneState.activityDataPoints.heatingPower.timestamp)),
+      thermostatCapability.setIsOnState(zoneState.activityDataPoints.heatingPower.percentage > 0, new Date(zoneState.activityDataPoints.heatingPower.timestamp)),
+      thermostatCapability.setCurrentTemperatureState(zoneState.sensorDataPoints.insideTemperature.celsius, new Date(zoneState.sensorDataPoints.insideTemperature.timestamp)),
+      thermostatCapability.setTargetTemperatureState(zoneState.setting.power === 'ON' ? zoneState.setting.temperature.celsius : 0, new Date())
     ]);
   }
 }), Math.max(config.tado.sync_interval_seconds, 10) * 1000);

--- a/server/src/services/tado/index.ts
+++ b/server/src/services/tado/index.ts
@@ -191,7 +191,7 @@ nowAndSetInterval(createBackgroundTransaction('tado:sync', async () => {
     await Promise.all([
       deviceCapability.setPowerState(zoneState.activityDataPoints.heatingPower.percentage, new Date(zoneState.activityDataPoints.heatingPower.timestamp)),
       deviceCapability.setIsOnState(zoneState.activityDataPoints.heatingPower.percentage > 0, new Date(zoneState.activityDataPoints.heatingPower.timestamp)),
-      deviceCapability.setHumidityState(zoneState.sensorDataPoints.humidity.percentage, new Date(zoneState.sensorDataPoints.humidity.timestamp)),
+      device.getHumiditySensorCapability().setHumidityState(zoneState.sensorDataPoints.humidity.percentage, new Date(zoneState.sensorDataPoints.humidity.timestamp)),
       deviceCapability.setCurrentTemperatureState(zoneState.sensorDataPoints.insideTemperature.celsius, new Date(zoneState.sensorDataPoints.insideTemperature.timestamp)),
       deviceCapability.setTargetTemperatureState(zoneState.setting.power === 'ON' ? zoneState.setting.temperature.celsius : 0, new Date())
     ]);


### PR DESCRIPTION
Not all thermostats report humidity, so it shouldn't be a Thermostat
property. The Tado service already registered HUMIDITY_SENSOR as a
capability; this wires up the setter to use it directly.

https://claude.ai/code/session_01HEGApay2PNC5rhLgyEaqM3