### PR TITLE
Show target date in EV schedule StatusItem footer

### DIFF
--- a/server/src/components/capabilities/registry.tsx
+++ b/server/src/components/capabilities/registry.tsx
@@ -595,17 +595,13 @@ export const registry: CapabilityUIRegistry = {
           icon: faCalendarCheck,
           title: 'Schedule',
           value: cap.chargeSchedule
-            ? `${cap.chargeSchedule.targetPercentage}% by ${dayjs(cap.chargeSchedule.targetTime).format('HH:mm')}`
+            ? `${cap.chargeSchedule.targetPercentage}% by ${dayjs(cap.chargeSchedule.targetTime).format('HH:mm')} ${humanDate(dayjs(cap.chargeSchedule.targetTime))}`
             : 'No schedule',
-          footer: (() => {
-            if (!cap.chargeSchedule) return undefined;
-            const humanTargetDate = humanDate(dayjs(cap.chargeSchedule.targetTime));
-            const dateStr = humanTargetDate.startsWith('on ') ? humanTargetDate.slice(3) : humanTargetDate;
-            if (cap.chargeSchedule.calculatedStartTime) {
-              return `${dateStr} · starts ${dayjs(cap.chargeSchedule.calculatedStartTime).format('HH:mm')}`;
-            }
-            return dateStr;
-          })(),
+          footer: cap.chargeSchedule
+            ? cap.chargeSchedule.calculatedStartTime
+              ? `starts ${dayjs(cap.chargeSchedule.calculatedStartTime).format('HH:mm')} ${humanDate(dayjs(cap.chargeSchedule.calculatedStartTime))}`
+              : 'start TBC'
+            : undefined,
           iconColor: cap.chargeSchedule ? '#3498db' : undefined,
           onIconClick: ({ openModal, closeModal }) => {
             openModal(

--- a/server/src/components/capabilities/registry.tsx
+++ b/server/src/components/capabilities/registry.tsx
@@ -597,9 +597,15 @@ export const registry: CapabilityUIRegistry = {
           value: cap.chargeSchedule
             ? `${cap.chargeSchedule.targetPercentage}% by ${dayjs(cap.chargeSchedule.targetTime).format('HH:mm')}`
             : 'No schedule',
-          footer: cap.chargeSchedule?.calculatedStartTime
-            ? `starts ${dayjs(cap.chargeSchedule.calculatedStartTime).format('HH:mm')} ${humanDate(dayjs(cap.chargeSchedule.calculatedStartTime))}`
-            : undefined,
+          footer: (() => {
+            if (!cap.chargeSchedule) return undefined;
+            const humanTargetDate = humanDate(dayjs(cap.chargeSchedule.targetTime));
+            const dateStr = humanTargetDate.startsWith('on ') ? humanTargetDate.slice(3) : humanTargetDate;
+            if (cap.chargeSchedule.calculatedStartTime) {
+              return `${dateStr} · starts ${dayjs(cap.chargeSchedule.calculatedStartTime).format('HH:mm')}`;
+            }
+            return dateStr;
+          })(),
           iconColor: cap.chargeSchedule ? '#3498db' : undefined,
           onIconClick: ({ openModal, closeModal }) => {
             openModal(

--- a/server/src/components/status-item.module.css
+++ b/server/src/components/status-item.module.css
@@ -1,7 +1,7 @@
 .value {
   font-size: 24px;
   font-weight: 700;
-  line-height: 1;
+  line-height: 1.2;
 }
 
 .icon {

--- a/server/src/components/status-item.tsx
+++ b/server/src/components/status-item.tsx
@@ -77,7 +77,7 @@ export function StatusItem(props: StatusItemProps) {
         />
       </Group>
 
-      <Group align="flex-end" gap="xs" mt={typeof value === 'string' ? 25 : 0}>
+      <Group align="flex-end" gap="xs" mt={typeof value === 'string' ? 20 : 0}>
         <Text className={styles.value}>{value}</Text>
       </Group>
 

--- a/server/src/helpers/date.ts
+++ b/server/src/helpers/date.ts
@@ -11,9 +11,9 @@ export function humanDate(date: Dayjs): string {
     return 'tomorrow';
   } else {
     return 'on ' + (
-      date.diff(now, 'months')
-        ? date.format('ddd Do MMM')
-        : date.format('ddd Do')
+      date.isSame(now, 'month')
+        ? date.format('ddd Do')
+        : date.format('ddd Do MMM')
     );
   }
 }


### PR DESCRIPTION
The schedule value ("100% by 10:00") only showed the time. Now the footer
shows the target date (e.g. "Wed 6th May") alongside the calculated start
time when available (e.g. "Wed 6th May · starts 08:00"). Uses humanDate()
so "today"/"tomorrow" appear for near-term schedules.

https://claude.ai/code/session_01FwQVZ7HsGywfi5VA6qPi9o