### PR TITLE
Reset handler to app.handler before NR CLI runs

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -54,13 +54,6 @@ jobs:
           aws lambda wait function-updated \
             --function-name "$LAMBDA_FUNCTION_NAME" \
             --region eu-west-1
-          aws lambda update-function-configuration \
-            --function-name "$LAMBDA_FUNCTION_NAME" \
-            --handler "app.handler" \
-            --region eu-west-1
-          aws lambda wait function-updated \
-            --function-name "$LAMBDA_FUNCTION_NAME" \
-            --region eu-west-1
           newrelic-lambda layers install \
             --function "$LAMBDA_FUNCTION_NAME" \
             --nr-account-id "$NEW_RELIC_ACCOUNT_ID" \

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -54,6 +54,13 @@ jobs:
           aws lambda wait function-updated \
             --function-name "$LAMBDA_FUNCTION_NAME" \
             --region eu-west-1
+          aws lambda update-function-configuration \
+            --function-name "$LAMBDA_FUNCTION_NAME" \
+            --handler "app.handler" \
+            --region eu-west-1
+          aws lambda wait function-updated \
+            --function-name "$LAMBDA_FUNCTION_NAME" \
+            --region eu-west-1
           newrelic-lambda layers install \
             --function "$LAMBDA_FUNCTION_NAME" \
             --nr-account-id "$NEW_RELIC_ACCOUNT_ID" \

--- a/lambdas/smart-home/src/app.ts
+++ b/lambdas/smart-home/src/app.ts
@@ -8,6 +8,7 @@ export const handler: SmartHomeHandler = async function (request, context) {
 
   console.log(JSON.stringify(request));
 
+  newrelic.setTransactionName(`${interfaceName}/${interfaceHandler}`);
   newrelic.addCustomAttributes({
     'alexa.namespace': interfaceName,
     'alexa.action': interfaceHandler,


### PR DESCRIPTION
The NR CLI reads the current handler to determine what to save as NEW_RELIC_LAMBDA_HANDLER. If the handler is already newrelic-lambda-wrapper.handler (from a prior run) and NEW_RELIC_LAMBDA_HANDLER has been cleared, the CLI cannot derive the real handler and leaves the env var unset.

Resetting to app.handler first gives the CLI a clean starting state on every deploy.

https://claude.ai/code/session_01QzYx6ZCDJz5bjjx1Ghw9yH