### PR TITLE
Document that config.json must be edited from inside the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@
     7. Go to More, Skills & Games, Your Skills, Dev, (the skill)
     8. Click "Enable to use".
 
+## Updating config.json in production
+
+Always edit `config.json` from **inside** the container, not from the host:
+
+```bash
+docker exec -it george-karen-1 vi /usr/src/app/config.json
+```
+
+**Why:** Editors like vim save by writing to a temp file and then renaming it over the original. This creates a new inode at the host path. Docker bind mounts attach to the inode that existed when the container started — so after a host-side vim edit, the running container's bind mount silently points to the old inode. Karen keeps writing `saveConfig()` updates to that old inode while the host file (new inode) stays frozen at whatever you typed. The next time Watchtower recreates the container from a new image, it picks up the stale host file and loads outdated tokens.
+
+Editing from inside the container writes directly through the bind mount to the correct inode, avoiding this problem entirely.
+
 ## Deploy
 
 Deploys should be automated upon push to master, because of the webhook in the GHA pipeline, which calls out to the karen-updater container of watchtower. But, to do manually;


### PR DESCRIPTION
## Summary

- Adds a "Updating config.json in production" section to README.md
- Explains that host-side editors (vim, etc.) use rename-based saves which create a new inode, silently breaking the running container's bind mount
- Documents the correct approach: edit from inside the container via `docker exec`

## Background

Investigated a production incident where Karen's config reset to a 5-day-old state on container recreation. Root cause: a manual vim edit on the host created a new inode at the bind-mount path. The running container's bind mount stayed attached to the old inode, so all subsequent `saveConfig()` writes went to the old inode — the host file was never updated. When Watchtower recreated the container from a new image, it read the stale host file (the vim-edited version) and loaded outdated tokens.

## Test plan

- [ ] README renders correctly on GitHub
- [ ] The `docker exec` command in the docs is correct for the production container name

https://claude.ai/code/session_01DY12SrNFbQCtq634caHXb4

---
_Generated by [Claude Code](https://claude.ai/code/session_01DY12SrNFbQCtq634caHXb4)_