### PR TITLE
Fix Z-Wave crash on Fibaro Button press

### DIFF
--- a/server/src/services/zwave/index.ts
+++ b/server/src/services/zwave/index.ts
@@ -115,6 +115,15 @@ deviceHandlers.set('Zooz ZSE44', [
   }
 ]);
 
+deviceHandlers.set('Fibargroup FGPB-101', [
+  {
+    propertyKey: 'Battery.level',
+    propertyMapper(device: Device, value: number) {
+      return device.getBatteryLevelIndicatorCapability().setBatteryPercentageState(value);
+    }
+  }
+]);
+
 deviceHandlers.set('Yale SD-L1000-CH', [
   {
     propertyKey: 'Door Lock.boltStatus',
@@ -171,7 +180,7 @@ async function getClient() {
             const device = await Device.findByProviderIdOrError('zwave', deviceId);
             const node = Array.from(client.getNodes()).find((x: any) => x.nodeId === deviceId) as any;
             const nodeType = `${node.deviceConfig.manufacturer} ${node.deviceConfig.label}`;
-            const eventHandler = deviceHandlers.get(nodeType)!.find(x => x.propertyKey === `${data.args.commandClassName}.${data.args.property}`);
+            const eventHandler = deviceHandlers.get(nodeType)?.find(x => x.propertyKey === `${data.args.commandClassName}.${data.args.property}`);
 
             if (eventHandler) {
               eventHandler.propertyMapper(device, data.args.newValue);

--- a/server/src/services/zwave/index.ts
+++ b/server/src/services/zwave/index.ts
@@ -180,10 +180,16 @@ async function getClient() {
             const device = await Device.findByProviderIdOrError('zwave', deviceId);
             const node = Array.from(client.getNodes()).find((x: any) => x.nodeId === deviceId) as any;
             const nodeType = `${node.deviceConfig.manufacturer} ${node.deviceConfig.label}`;
-            const eventHandler = deviceHandlers.get(nodeType)?.find(x => x.propertyKey === `${data.args.commandClassName}.${data.args.property}`);
+            const handlers = deviceHandlers.get(nodeType);
 
-            if (eventHandler) {
-              eventHandler.propertyMapper(device, data.args.newValue);
+            if (handlers === undefined) {
+              logger.warn(`No Z-Wave deviceHandlers registered for node type "${nodeType}" (Device Id ${deviceId})`);
+            } else {
+              const eventHandler = handlers.find(x => x.propertyKey === `${data.args.commandClassName}.${data.args.property}`);
+
+              if (eventHandler) {
+                eventHandler.propertyMapper(device, data.args.newValue);
+              }
             }
           }
 


### PR DESCRIPTION
## Summary
- Pressing the FGPB-101 emits a `value updated` event alongside the Central Scene `value notification`. With no `deviceHandlers` entry registered for `'Fibargroup FGPB-101'`, `deviceHandlers.get(nodeType)!.find(...)` (`server/src/services/zwave/index.ts:174`) threw `Cannot read properties of undefined (reading 'find')` in production.
- Swap the unsafe non-null assertion for optional chaining so unknown device types / unhandled property events no longer crash the service — the existing `if (eventHandler)` guard already covers `undefined`.
- Register a `Battery.level` handler for the FGPB-101 so its declared `BATTERY_LEVEL_INDICATOR` capability is actually populated.

## Test plan
- [x] `npm run codegen`
- [x] `npm run lint` (zero warnings)
- [x] `npm run test` (26/26 passing)
- [x] `npm run build`
- [ ] After deploy: pressing the Fibaro Button no longer crashes the Z-Wave service, and the button's battery percentage starts reporting

https://claude.ai/code/session_01AXMvRf63tPhAgZXJs27AfS

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXMvRf63tPhAgZXJs27AfS)_