### PR TITLE
Add logging to debug intermittent Fibaro button press failures

### DIFF
--- a/server/src/services/alexa/index.ts
+++ b/server/src/services/alexa/index.ts
@@ -119,5 +119,18 @@ Device.registerProvider('alexa', {
 
 DeviceCapabilityEvents.onButtonPressed(async (event) => {
   const device = await event.getDevice();
-  await sendSimpleEventSource(device.id);
+
+  logger.info({
+    deviceId: device.id,
+    deviceName: device.name,
+    provider: device.provider
+  }, 'Alexa onButtonPressed handler fired; notifying Alexa');
+
+  try {
+    await sendSimpleEventSource(device.id);
+    logger.info({ deviceId: device.id }, 'Alexa SimpleEventSource sent for button press');
+  } catch (err) {
+    logger.error({ err, deviceId: device.id }, 'Alexa failed to send SimpleEventSource for button press');
+    throw err;
+  }
 });

--- a/server/src/services/zwave/index.ts
+++ b/server/src/services/zwave/index.ts
@@ -194,15 +194,15 @@ async function getClient() {
           }
 
           if (data.source === 'node' && data.event === 'value notification') {
-            logger.info({
-              nodeId: data.nodeId,
-              commandClassName: data.args.commandClassName,
-              property: data.args.property,
-              propertyKey: data.args.propertyKey,
-              value: data.args.value
-            }, 'ZWave value notification received');
-
             if (data.args.commandClassName === 'Central Scene' && data.args.value === 0) {
+              logger.info({
+                nodeId: data.nodeId,
+                commandClassName: data.args.commandClassName,
+                property: data.args.property,
+                propertyKey: data.args.propertyKey,
+                value: data.args.value
+              }, 'ZWave value notification received');
+
               const device = await Device.findByProviderIdOrError('zwave', data.nodeId);
               const pressedAt = new Date();
 

--- a/server/src/services/zwave/index.ts
+++ b/server/src/services/zwave/index.ts
@@ -194,15 +194,15 @@ async function getClient() {
           }
 
           if (data.source === 'node' && data.event === 'value notification') {
-            if (data.args.commandClassName === 'Central Scene' && data.args.value === 0) {
-              logger.info({
-                nodeId: data.nodeId,
-                commandClassName: data.args.commandClassName,
-                property: data.args.property,
-                propertyKey: data.args.propertyKey,
-                value: data.args.value
-              }, 'ZWave value notification received');
+            logger.info({
+              nodeId: data.nodeId,
+              commandClassName: data.args.commandClassName,
+              property: data.args.property,
+              propertyKey: data.args.propertyKey,
+              value: data.args.value
+            }, 'ZWave value notification received');
 
+            if (data.args.commandClassName === 'Central Scene' && data.args.value === 0) {
               const device = await Device.findByProviderIdOrError('zwave', data.nodeId);
               const pressedAt = new Date();
 

--- a/server/src/services/zwave/index.ts
+++ b/server/src/services/zwave/index.ts
@@ -194,10 +194,32 @@ async function getClient() {
           }
 
           if (data.source === 'node' && data.event === 'value notification') {
+            logger.info({
+              nodeId: data.nodeId,
+              commandClassName: data.args.commandClassName,
+              property: data.args.property,
+              propertyKey: data.args.propertyKey,
+              value: data.args.value
+            }, 'ZWave value notification received');
+
             if (data.args.commandClassName === 'Central Scene' && data.args.value === 0) {
               const device = await Device.findByProviderIdOrError('zwave', data.nodeId);
               const pressedAt = new Date();
-              await device.getButtonCapability().setPressedState(true, pressedAt);
+
+              logger.info({
+                nodeId: data.nodeId,
+                deviceId: device.id,
+                deviceName: device.name,
+                pressedAt: pressedAt.toISOString()
+              }, 'ZWave button press detected; setting pressed state');
+
+              try {
+                await device.getButtonCapability().setPressedState(true, pressedAt);
+                logger.info({ deviceId: device.id }, 'ZWave button pressed state set');
+              } catch (err) {
+                logger.error({ err, deviceId: device.id }, 'ZWave failed to set button pressed state');
+                throw err;
+              }
             }
           }
         });


### PR DESCRIPTION
## Summary

The Fibaro button is intermittently not triggering on press. This adds diagnostic logging at the two relevant points in the pipeline so we can narrow down where presses are being lost.

- **`services/zwave/index.ts`** — logs every Z-Wave `value notification` (including `commandClassName`, `property`, `propertyKey`, `value`) before the Central Scene filter, then logs the matched press and the success/failure of `setPressedState`.
- **`services/alexa/index.ts`** — logs entry into the `onButtonPressed` handler with the device info, plus success/failure of the `sendSimpleEventSource` call.

Together these let us distinguish between three failure modes:
1. Press never reaches the server (no notification log).
2. Press reaches the server but fails the filter (notification logged, no "press detected" log) — would suggest a different `commandClassName` or `value`.
3. Press is recognised but the capability state change or Alexa notification errors out.

## Test plan

- [ ] Press the Fibaro button and confirm the new "ZWave value notification received" and "ZWave button press detected" log lines appear.
- [ ] Confirm the "Alexa onButtonPressed handler fired" and "Alexa SimpleEventSource sent" lines follow.
- [ ] After a few intermittent failures, inspect logs to determine which stage is dropping the press.

https://claude.ai/code/session_01Wbkwprbt868d8SU1Qfffb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wbkwprbt868d8SU1Qfffb9)_