### PR TITLE
Automated NPM Updates

### DIFF
--- a/lambdas/smart-home/src/client.ts
+++ b/lambdas/smart-home/src/client.ts
@@ -1,5 +1,3 @@
-import fetch from 'cross-fetch';
-
 const BASE_URL = `https://${process.env.KAREN_HOST}/api`;
 const AUTH_HEADER = `Bearer ${process.env.KAREN_AUTH_TOKEN}`;
 
@@ -14,7 +12,7 @@ export async function apiGet<T>(endpoint: string): Promise<T> {
     throw new Error(`API GET ${endpoint} failed: ${res.status}`);
   }
 
-  return res.json();
+  return res.json() as Promise<T>;
 }
 
 export async function apiPut<T>(endpoint: string, body: object): Promise<T> {
@@ -31,5 +29,5 @@ export async function apiPut<T>(endpoint: string, body: object): Promise<T> {
     throw new Error(`API PUT ${endpoint} failed: ${res.status}`);
   }
 
-  return res.json();
+  return res.json() as Promise<T>;
 }

--- a/lambdas/smart-home/src/handlers/alexa-authorization.ts
+++ b/lambdas/smart-home/src/handlers/alexa-authorization.ts
@@ -1,5 +1,4 @@
 import { Context, SmartHomeRequest, SmartHomeResponse } from "../custom-typings/lambda";
-import fetch from 'cross-fetch';
 
 export async function AcceptGrant(request: SmartHomeRequest<{ grant: { code: string }}>, context: Context): Promise<SmartHomeResponse<{ type?: 'ACCEPT_GRANT_FAILED', message?: string }>> {
   try {

--- a/lambdas/smart-home/src/package-lock.json
+++ b/lambdas/smart-home/src/package-lock.json
@@ -8,9 +8,6 @@
       "name": "smart-home-lambda",
       "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "cross-fetch": "^4.1.0"
-      },
       "devDependencies": {
         "@tsconfig/node24": "^24.0.0",
         "@types/aws-lambda": "^8.10.160",
@@ -48,38 +45,6 @@
         "undici-types": "~7.18.0"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/typescript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
@@ -98,20 +63,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     }
   },
   "dependencies": {
@@ -142,27 +93,6 @@
         "undici-types": "~7.18.0"
       }
     },
-    "cross-fetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-      "requires": {
-        "node-fetch": "^2.7.0"
-      }
-    },
-    "node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
-    },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "typescript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
@@ -174,20 +104,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     }
   }
 }

--- a/lambdas/smart-home/src/package.json
+++ b/lambdas/smart-home/src/package.json
@@ -4,9 +4,7 @@
   "main": "app.js",
   "author": "mattlunn",
   "license": "MIT",
-  "dependencies": {
-    "cross-fetch": "^4.1.0"
-  },
+  "dependencies": {},
   "scripts": {
     "build": "rm -rf ../dist/ && tsc && cp -r node_modules ../dist"
   },

--- a/server/src/package-lock.json
+++ b/server/src/package-lock.json
@@ -47,9 +47,9 @@
         "smartcar": "^10.4.0",
         "suncalc": "^1.8.0",
         "tplink-smarthome-api": "^5.0.0",
-        "twilio": "^5.13.1",
+        "twilio": "^6.0.0",
         "umzug": "^3.8.2",
-        "uuid": "^13.0.0",
+        "uuid": "^14.0.0",
         "ws": "^8.18.0",
         "yargs": "^18.0.0"
       },
@@ -15574,9 +15574,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -18202,9 +18202,9 @@
       "dev": true
     },
     "node_modules/twilio": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-5.13.1.tgz",
-      "integrity": "sha512-sT+PkhptF4Mf7t8eXFFvPQx4w5VHnBIPXbltGPMFRe+R2GxfRdMuFbuNA/cEm0aQR6LFQOn33+fhClg+TjRVqQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-6.0.0.tgz",
+      "integrity": "sha512-MAie5DJ3KLpcKlDaYtNzsKMQXcCi+YHWKvZjuSpm27vJAO/l8PanJA0LkkJ03sbh+Kwe5NeL0Q2+y6IjNUYeUA==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.5",
@@ -18216,7 +18216,7 @@
         "xmlbuilder": "^13.0.2"
       },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/twilio/node_modules/https-proxy-agent": {
@@ -18758,9 +18758,9 @@
       "integrity": "sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw=="
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/server/src/package.json
+++ b/server/src/package.json
@@ -42,9 +42,9 @@
     "smartcar": "^10.4.0",
     "suncalc": "^1.8.0",
     "tplink-smarthome-api": "^5.0.0",
-    "twilio": "^5.13.1",
+    "twilio": "^6.0.0",
     "umzug": "^3.8.2",
-    "uuid": "^13.0.0",
+    "uuid": "^14.0.0",
     "ws": "^8.18.0",
     "yargs": "^18.0.0"
   },


### PR DESCRIPTION
## Summary

Priority-first NPM dependency updates: security fixes and major version upgrades.

### Security vulnerabilities fixed

- **postcss 8.5.6 → 8.5.12** — fixes [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93): XSS via unescaped `</style>` in CSS stringify output. Update is within the existing `^8.5.6` range; no code changes required.
- **uuid 13 → 14** — fixes [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq): missing buffer bounds check in v3/v5/v6 when a `buf` argument is provided. The `import { v4 }` named export is unchanged.

### Major upgrades

- **twilio 5 → 6** — the existing API surface (`new TwilioClient(sid, token)` + `client.calls.create(...)`) is unchanged in v6.
- **uuid 13 → 14** — see above.

### Lambda: cross-fetch removed

`cross-fetch` was the only runtime dependency in the Alexa smart-home Lambda. The Lambda targets the Node.js 24 runtime which ships native `fetch` as a global, so the package is redundant. Removed the package and both `import` statements; added `as Promise<T>` casts where needed because native `Response.json()` returns `Promise<unknown>` instead of `Promise<any>`.

### What was skipped

- **`ajv` moderate vulnerability** (via `umzug` → `@rushstack/*`): `umzug` has no newer stable release, so unfixable without overriding transitive deps.
- **`fast-xml-parser` moderate vulnerability** (via `@aws-sdk/xml-builder`): even the latest `@aws-sdk` 3.x pins the vulnerable `fast-xml-parser` version; unfixable without overriding transitive deps.
- **`uuid` vulnerability in `sequelize` / `@newrelic/security-agent`**: both packages bundle their own internal uuid — upgrading our direct `uuid` dependency does not affect those; sequelize v7 is not yet stable.
- **ESLint 9 → 10**: skipped because `eslint-plugin-react` does not yet declare support for ESLint 10 in its peer dependencies.
- **Minor/patch sweep** (mantine, tanstack, aws-sdk, etc.): deferred to a follow-up PR.

https://claude.ai/code/session_01GYqbjY79whX4YLNRYjXtMK

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYqbjY79whX4YLNRYjXtMK)_