### PR TITLE
Fix Fibaro button not firing on multi-press events

### DIFF
--- a/server/src/services/zwave/index.ts
+++ b/server/src/services/zwave/index.ts
@@ -202,7 +202,8 @@ async function getClient() {
               value: data.args.value
             }, 'ZWave value notification received');
 
-            if (data.args.commandClassName === 'Central Scene' && data.args.value === 0) {
+            // Central Scene key attribute values: 0=single press, 1=released, 2=held, 3+=multi-press
+            if (data.args.commandClassName === 'Central Scene' && data.args.value !== 1 && data.args.value !== 2) {
               const device = await Device.findByProviderIdOrError('zwave', data.nodeId);
               const pressedAt = new Date();
 

--- a/server/src/services/zwave/index.ts
+++ b/server/src/services/zwave/index.ts
@@ -203,7 +203,7 @@ async function getClient() {
             }, 'ZWave value notification received');
 
             // Central Scene key attribute values: 0=single press, 1=released, 2=held, 3+=multi-press
-            if (data.args.commandClassName === 'Central Scene' && data.args.value !== 1 && data.args.value !== 2) {
+            if (data.args.commandClassName === 'Central Scene' && data.args.value !== 1) {
               const device = await Device.findByProviderIdOrError('zwave', data.nodeId);
               const pressedAt = new Date();
 


### PR DESCRIPTION
## Summary

The Z-Wave Central Scene handler was only triggering on `value === 0` (single press). Multi-press and held events were silently dropped. Now fires for all press types, excluding only key released (1).

Central Scene key attribute values:
- `0` = single press → **fire** ✓
- `1` = key released → **ignore**
- `2` = key held down → **fire** ✓
- `3` = double press → **fire** ✓
- `4` = triple press → **fire** ✓
- `5` = 4x press → **fire** ✓
- `6` = 5x press → **fire** ✓

## Example payloads

**Single press** (was working):
```
commandClassName: Central Scene
property: scene
propertyKey: 001
value: 0
stateless: true
```

**Double press** (was broken):
```
commandClassName: Central Scene
property: scene
propertyKey: 001
value: 3
stateless: true
```

**Triple press** (was broken):
```
commandClassName: Central Scene
property: scene
propertyKey: 001
value: 4
stateless: true
```

**Key held down** (was broken):
```
commandClassName: Central Scene
property: scene
propertyKey: 001
value: 2
stateless: true
```

**Key released** (correctly ignored — release fires after held, not a distinct press):
```
commandClassName: Central Scene
property: scene
propertyKey: 001
value: 1
stateless: true
```

## Test plan

- [ ] Single press fires the button event
- [ ] Double press fires the button event
- [ ] Triple press fires the button event
- [ ] Holding the button fires the button event
- [ ] Releasing after hold does NOT fire the button event

https://claude.ai/code/session_01EmxGaxumbusTQEE7q6DKSj