### PR TITLE
Show button press counts (today + all time) on device card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,22 @@ The registry provides:
 
 Interactive controls use `onIconClick` which receives `{ openModal, closeModal, queryClient }`. The `value` field can be a React component for interactive controls (e.g., brightness dropdown).
 
+**Exposing capability data in the UI registry**: To surface a value (live state, derived metric, or aggregate) on a device card, follow this layered flow — never short-circuit it:
+
+1. **Source of truth**: read via the codegen'd capability methods, never the raw `Event` model. For a `Foo` property:
+   - Latest event → `capability.getFooEvent()`
+   - History over a window → `capability.getFooHistory({ since, until })`
+   - `HistorySelector` requires both `since` and `until` — there is no all-time variant. Use `device.createdAt` as the lower bound when you genuinely want everything (e.g. a lifetime count).
+2. **API mapping**: in `routes/api/device-helpers.ts`, inside the relevant `case` of `getCapabilityData`, await the capability call(s) and shape the response. Run independent capability calls in `Promise.all`. Derived values (counts, filters, sums over a momentary-event history) are computed here, not in the registry.
+3. **API type**: add the new field(s) to the matching variant of `CapabilityApiResponse` in `api/types.ts`. This is the single source of truth for the wire format and is consumed by the registry.
+4. **Registry**: in `components/capabilities/registry.tsx`, read the new field(s) off `cap` inside `getCapabilityMetrics`. The function is **synchronous** — no fetching here, only formatting. Each `CapabilityMetric` needs either `since + lastReported` (for live state) or an optional `footer` (for derived/aggregate values that have no single timestamp).
+
+Two patterns for "today's X" / "this week's X" aggregates:
+- *On-demand* (cheap source data, e.g. button press counts, last-pressed): query in `device-helpers.ts` per request. See the `BUTTON` case.
+- *Pre-computed* (expensive integration over time-series, e.g. heat-pump watt-hours, vehicle weekly mileage): a scheduled service writes a numeric event (`setDayPowerState` etc.) and the API just reads the latest event. See `services/ebusd/history.ts` and `services/vehicle/mileage.ts`.
+
+Pick on-demand unless the calculation is too heavy to do per-request. Adding a brand-new capability property (not just exposing an existing one) instead requires a `capabilities.json` edit and `npm run codegen` — see "Capability Codegen" above.
+
 ### Data Flow
 
 1. Integration service detects device change

--- a/server/src/api/types.ts
+++ b/server/src/api/types.ts
@@ -51,6 +51,8 @@ export type CapabilityApiResponse = {
 } | {
   type: 'BUTTON';
   lastPressed: BooleanEventApiResponse | null;
+  pressesToday: number;
+  totalPresses: number;
 } | {
   type: 'SWITCH';
   isOn: BooleanEventApiResponse;

--- a/server/src/components/capabilities/registry.tsx
+++ b/server/src/components/capabilities/registry.tsx
@@ -32,6 +32,8 @@ import {
   faTrash,
   faHandPointer,
   faSnowflake,
+  faCalendarDay,
+  faHashtag,
 } from '@fortawesome/free-solid-svg-icons';
 import { useQueryClient, QueryClient } from '@tanstack/react-query';
 import type { CapabilityApiResponse, RestDeviceResponse, DeviceApiResponse, LightUpdateRequest, LockUpdateRequest } from '../../api/types';
@@ -558,6 +560,19 @@ export const registry: CapabilityUIRegistry = {
             value: 'Never',
             iconColor: '#04A7F4',
           },
+      {
+        icon: faCalendarDay,
+        title: "Today's Presses",
+        value: cap.pressesToday.toString(),
+        iconColor: '#04A7F4',
+        iconHighlighted: cap.pressesToday > 0,
+      },
+      {
+        icon: faHashtag,
+        title: 'Total Presses',
+        value: cap.totalPresses.toString(),
+        iconColor: '#04A7F4',
+      },
     ],
   },
 

--- a/server/src/routes/api/device-helpers.ts
+++ b/server/src/routes/api/device-helpers.ts
@@ -180,7 +180,17 @@ export async function getCapabilityData(device: Device, capability: string): Pro
 
     case 'BUTTON': {
       const button = device.getButtonCapability();
-      const pressedEvent = await button.getPressedEvent();
+      const now = new Date();
+      const startOfToday = dayjs().startOf('day').toDate();
+
+      const [pressedEvent, pressedHistory] = await Promise.all([
+        button.getPressedEvent(),
+        button.getPressedHistory({ since: device.createdAt, until: now }),
+      ]);
+
+      const totalPresses = pressedHistory.length;
+      const pressesToday = pressedHistory.filter(event => event.start >= startOfToday).length;
+
       return {
         type: 'BUTTON',
         lastPressed: pressedEvent ? {
@@ -189,6 +199,8 @@ export async function getCapabilityData(device: Device, capability: string): Pro
           lastReported: pressedEvent.lastReported.toISOString(),
           value: Boolean(pressedEvent.value),
         } : null,
+        pressesToday,
+        totalPresses,
       };
     }
 


### PR DESCRIPTION
## Summary

- Adds two new metrics to the `BUTTON` capability in `components/capabilities/registry.tsx`: **Today's Presses** and **Total Presses**, alongside the existing "Last Pressed".
- Counts are derived inside `getCapabilityData` (`routes/api/device-helpers.ts`) from a single `button.getPressedHistory({ since: device.createdAt, until: now })` call. `totalPresses` is `history.length`; `pressesToday` filters by `event.start >= startOfToday`. This keeps the registry synchronous and avoids reaching past the capability layer into the raw `Event` model.
- Extends the `BUTTON` variant of `CapabilityApiResponse` in `api/types.ts` with `pressesToday: number` and `totalPresses: number`.
- Documents the standard layered flow (capability ? device-helpers ? api/types ? registry) and the on-demand vs pre-computed aggregate patterns in `CLAUDE.md` so future capability-surfacing work follows the same recipe.

## Test plan

- [x] `npm run codegen` succeeds (no `capabilities.json` change, but verified no regression).
- [x] `npm run lint` passes with zero warnings.
- [x] `npm test` passes (3 suites / 26 tests).
- [ ] Manual: open a device page for a Button device and confirm "Last Pressed", "Today's Presses", and "Total Presses" all render. Cross-check counts against `SELECT COUNT(*) FROM events WHERE deviceId=? AND type='pressed' [AND start >= CURDATE()]`.
- [ ] Manual: trigger a press (physical button or simulated Z-Wave event) and confirm both counts increment after re-fetch.
- [ ] Manual: confirm a never-pressed button still shows `0` / `0` / "Never" without crashing.

https://claude.ai/code/session_015MhQdLhiDBYZ1ZCJLDVbrU

---
_Generated by [Claude Code](https://claude.ai/code/session_015MhQdLhiDBYZ1ZCJLDVbrU)_