### PR TITLE
Fix passive thermostats triggering lockout end & rounding in message

### DIFF
--- a/server/src/automations/heating.ts
+++ b/server/src/automations/heating.ts
@@ -92,9 +92,14 @@ export default function ({ heatingSwitchName, temperatureDeltaSwitchOffThreshold
   }));
 
   DeviceCapabilityEvents.onThermostatCurrentTemperatureChanged(createBackgroundTransaction('automations:heating:thermostat-temperature-changed', async (event) => {
-    const heatingDevice = await Device.findByNameOrError(heatingSwitchName);
     const thermostat = await event.getDevice();
-    const target = await thermostat.getThermostatCapability().getTargetTemperature(); 
+
+    if (await thermostat.getThermostatCapability().getIsPassive()) {
+      return;
+    }
+
+    const heatingDevice = await Device.findByNameOrError(heatingSwitchName);
+    const target = await thermostat.getThermostatCapability().getTargetTemperature();
     const temperatureDelta = target - event.value;
 
     if (temperatureDelta > temperatureDeltaSwitchOnThreshold && compressorLockedOutForCooldown) {
@@ -102,8 +107,8 @@ export default function ({ heatingSwitchName, temperatureDeltaSwitchOffThreshold
 
       compressorLockedOutForCooldown = false;
 
-      bus.emit(NOTIFICATION_TO_ADMINS, { 
-        message: `Ending lockout and turning heating on, as ${thermostat.name} is ${temperatureDelta}° below target of ${target}°C`
+      bus.emit(NOTIFICATION_TO_ADMINS, {
+        message: `Ending lockout and turning heating on, as ${thermostat.name} is ${temperatureDelta.toFixed(1)}° below target of ${target}°C`
       });
     }
   }));


### PR DESCRIPTION
## Summary

Two fixes in `automations/heating.ts` for the thermostat-temperature-changed handler:

- **Passive thermostats no longer end the compressor lockout.** The handler had no `getIsPassive()` check, so a temperature reading from a passive device (e.g. Landing Thermostat) could end the lockout and turn heating on. Mirrors the passive check already in `onThermostatPowerChanged`.
- **Round `temperatureDelta` in the admin notification.** Previously the raw subtraction leaked floating-point noise like `0.7899999999999991°`; now formatted with `.toFixed(1)`.

## Test plan

- [ ] Confirm passive thermostats (e.g. Landing Thermostat) no longer trigger an "Ending lockout..." notification when their temperature drops below target during a lockout window.
- [ ] Confirm an active thermostat dropping >threshold below target during a lockout still ends the lockout and shows the formatted delta (e.g. `0.8°` rather than `0.7899999999999991°`).


---
_Generated by [Claude Code](https://claude.ai/code/session_0173aCKrCdvSDWjjou6QvDoC)_