### PR TITLE
Add export-prod-to-dev script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 config.json
+.env.prod
 .idea
 .DS_Store
 *.pem

--- a/server/src/package.json
+++ b/server/src/package.json
@@ -102,6 +102,7 @@
     "create-user": "babel-node scripts/create-user.js",
     "migrate": "babel-node scripts/migrate.js",
     "reset-daily-metrics": "babel-node scripts/reset-daily-metrics.js",
+    "export-prod-to-dev": "babel-node scripts/export-prod-to-dev.js",
     "codegen": "npx --yes ts-node codegen/index.ts",
     "build": "npm run build:server && npm run build:browser",
     "build:server": "babel . -d ../dist --extensions '.ts,.tsx,.js' --copy-files --include-dotfiles",

--- a/server/src/scripts/export-prod-to-dev.js
+++ b/server/src/scripts/export-prod-to-dev.js
@@ -1,0 +1,102 @@
+import mysql from 'mysql2/promise';
+import config from '../config';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import readline from 'readline';
+
+const argv = yargs(hideBin(process.argv))
+  .option('prod-host', { type: 'string', demandOption: true, description: 'PROD database host' })
+  .option('prod-name', { type: 'string', demandOption: true, description: 'PROD database name' })
+  .option('prod-user', { type: 'string', demandOption: true, description: 'PROD database user' })
+  .option('prod-password', { type: 'string', demandOption: true, description: 'PROD database password' })
+  .option('yes', { type: 'boolean', default: false, description: 'Skip confirmation prompt' })
+  .argv;
+
+const INSERT_BATCH_SIZE = 500;
+
+function confirm(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise(resolve => rl.question(question, answer => { rl.close(); resolve(answer); }));
+}
+
+async function getTables(conn) {
+  const [rows] = await conn.query('SHOW TABLES');
+  return rows.map(row => Object.values(row)[0]);
+}
+
+async function getCreateTable(conn, table) {
+  const [rows] = await conn.query(`SHOW CREATE TABLE \`${table}\``);
+  return rows[0]['Create Table'];
+}
+
+async function main() {
+  console.log(`PROD: ${argv['prod-user']}@${argv['prod-host']}/${argv['prod-name']}`);
+  console.log(`DEV:  ${config.database.user}@${config.database.host}/${config.database.name}`);
+  console.log('');
+  console.log('WARNING: This will DROP and recreate all tables in the DEV database.');
+
+  if (!argv.yes) {
+    const answer = await confirm('Continue? (yes/no): ');
+    if (answer.trim().toLowerCase() !== 'yes') {
+      console.log('Aborted.');
+      process.exit(0);
+    }
+  }
+
+  const prod = await mysql.createConnection({
+    host: argv['prod-host'],
+    database: argv['prod-name'],
+    user: argv['prod-user'],
+    password: argv['prod-password'],
+  });
+
+  const dev = await mysql.createConnection({
+    host: config.database.host,
+    database: config.database.name,
+    user: config.database.user,
+    password: config.database.password,
+  });
+
+  try {
+    const tables = await getTables(prod);
+    console.log(`\nFound ${tables.length} tables in PROD.\n`);
+
+    await dev.query('SET FOREIGN_KEY_CHECKS = 0');
+
+    for (const table of tables) {
+      process.stdout.write(`  ${table}...`);
+
+      const createSql = await getCreateTable(prod, table);
+      await dev.query(`DROP TABLE IF EXISTS \`${table}\``);
+      await dev.query(createSql);
+
+      const [rows] = await prod.query(`SELECT * FROM \`${table}\``);
+
+      if (rows.length === 0) {
+        console.log(' empty');
+        continue;
+      }
+
+      const columns = Object.keys(rows[0]).map(c => `\`${c}\``).join(', ');
+      for (let i = 0; i < rows.length; i += INSERT_BATCH_SIZE) {
+        const batch = rows.slice(i, i + INSERT_BATCH_SIZE);
+        const placeholders = batch.map(row => `(${Object.keys(row).map(() => '?').join(', ')})`).join(', ');
+        const values = batch.flatMap(row => Object.values(row));
+        await dev.query(`INSERT INTO \`${table}\` (${columns}) VALUES ${placeholders}`, values);
+      }
+
+      console.log(` ${rows.length} rows`);
+    }
+
+    await dev.query('SET FOREIGN_KEY_CHECKS = 1');
+    console.log('\nDone.');
+  } finally {
+    await prod.end();
+    await dev.end();
+  }
+}
+
+main().catch(err => {
+  console.error('\nError:', err.message);
+  process.exit(1);
+});

--- a/server/src/scripts/export-prod-to-dev.js
+++ b/server/src/scripts/export-prod-to-dev.js
@@ -1,8 +1,8 @@
-import mysql from 'mysql2/promise';
 import config from '../config';
 import readline from 'readline';
 import fs from 'fs';
 import path from 'path';
+import { spawn } from 'child_process';
 
 const ENV_FILE = path.resolve(__dirname, '../.env.prod');
 const skipConfirm = process.argv.includes('--yes');
@@ -43,25 +43,64 @@ function confirm(question) {
   return new Promise(resolve => rl.question(question, answer => { rl.close(); resolve(answer); }));
 }
 
-async function getTables(conn) {
-  const [rows] = await conn.query('SHOW TABLES');
-  return rows.map(row => Object.values(row)[0]);
-}
+function run(prod, dev) {
+  return new Promise((resolve, reject) => {
+    const dump = spawn('mysqldump', [
+      '-h', prod.host,
+      '-u', prod.user,
+      `--password=${prod.password}`,
+      '--single-transaction',
+      '--no-tablespaces',
+      prod.name,
+    ]);
 
-async function getCreateTable(conn, table) {
-  const [rows] = await conn.query(`SHOW CREATE TABLE \`${table}\``);
-  return rows[0]['Create Table'];
-}
+    const restore = spawn('mysql', [
+      '-h', dev.host,
+      '-u', dev.user,
+      `--password=${dev.password}`,
+      dev.name,
+    ]);
 
-const INSERT_BATCH_SIZE = 500;
+    dump.stdout.pipe(restore.stdin);
+
+    dump.stderr.on('data', data => process.stderr.write(data));
+    restore.stderr.on('data', data => process.stderr.write(data));
+
+    dump.on('error', err => reject(new Error(`mysqldump: ${err.message}`)));
+    restore.on('error', err => reject(new Error(`mysql: ${err.message}`)));
+
+    dump.on('close', code => {
+      if (code !== 0) reject(new Error(`mysqldump exited with code ${code}`));
+    });
+
+    restore.on('close', code => {
+      if (code !== 0) reject(new Error(`mysql exited with code ${code}`));
+      else resolve();
+    });
+  });
+}
 
 async function main() {
   const env = loadEnvFile(ENV_FILE);
 
-  console.log(`PROD: ${env.PROD_DB_USER}@${env.PROD_DB_HOST}/${env.PROD_DB_NAME}`);
-  console.log(`DEV:  ${config.database.user}@${config.database.host}/${config.database.name}`);
+  const prod = {
+    host: env.PROD_DB_HOST,
+    name: env.PROD_DB_NAME,
+    user: env.PROD_DB_USER,
+    password: env.PROD_DB_PASSWORD,
+  };
+
+  const dev = {
+    host: config.database.host,
+    name: config.database.name,
+    user: config.database.user,
+    password: config.database.password,
+  };
+
+  console.log(`PROD: ${prod.user}@${prod.host}/${prod.name}`);
+  console.log(`DEV:  ${dev.user}@${dev.host}/${dev.name}`);
   console.log('');
-  console.log('WARNING: This will DROP and recreate all tables in the DEV database.');
+  console.log('WARNING: This will overwrite all data in the DEV database.');
 
   if (!skipConfirm) {
     const answer = await confirm('Continue? (yes/no): ');
@@ -71,57 +110,9 @@ async function main() {
     }
   }
 
-  const prod = await mysql.createConnection({
-    host: env.PROD_DB_HOST,
-    database: env.PROD_DB_NAME,
-    user: env.PROD_DB_USER,
-    password: env.PROD_DB_PASSWORD,
-  });
-
-  const dev = await mysql.createConnection({
-    host: config.database.host,
-    database: config.database.name,
-    user: config.database.user,
-    password: config.database.password,
-  });
-
-  try {
-    const tables = await getTables(prod);
-    console.log(`\nFound ${tables.length} tables in PROD.\n`);
-
-    await dev.query('SET FOREIGN_KEY_CHECKS = 0');
-
-    for (const table of tables) {
-      process.stdout.write(`  ${table}...`);
-
-      const createSql = await getCreateTable(prod, table);
-      await dev.query(`DROP TABLE IF EXISTS \`${table}\``);
-      await dev.query(createSql);
-
-      const [rows] = await prod.query(`SELECT * FROM \`${table}\``);
-
-      if (rows.length === 0) {
-        console.log(' empty');
-        continue;
-      }
-
-      const columns = Object.keys(rows[0]).map(c => `\`${c}\``).join(', ');
-      for (let i = 0; i < rows.length; i += INSERT_BATCH_SIZE) {
-        const batch = rows.slice(i, i + INSERT_BATCH_SIZE);
-        const placeholders = batch.map(row => `(${Object.keys(row).map(() => '?').join(', ')})`).join(', ');
-        const values = batch.flatMap(row => Object.values(row));
-        await dev.query(`INSERT INTO \`${table}\` (${columns}) VALUES ${placeholders}`, values);
-      }
-
-      console.log(` ${rows.length} rows`);
-    }
-
-    await dev.query('SET FOREIGN_KEY_CHECKS = 1');
-    console.log('\nDone.');
-  } finally {
-    await prod.end();
-    await dev.end();
-  }
+  console.log('\nRunning mysqldump | mysql...');
+  await run(prod, dev);
+  console.log('Done.');
 }
 
 main().catch(err => {

--- a/server/src/scripts/export-prod-to-dev.js
+++ b/server/src/scripts/export-prod-to-dev.js
@@ -4,20 +4,28 @@ import fs from 'fs';
 import path from 'path';
 import { spawn } from 'child_process';
 
-const ENV_FILE = path.resolve(__dirname, '../.env.prod');
 const skipConfirm = process.argv.includes('--yes');
 
-function loadEnvFile(filePath) {
-  if (!fs.existsSync(filePath)) {
-    console.error(`Error: ${filePath} not found.`);
-    console.error('Create it with the following contents:');
-    console.error('');
-    console.error('  PROD_DB_HOST=<host>');
-    console.error('  PROD_DB_NAME=<database>');
-    console.error('  PROD_DB_USER=<user>');
-    console.error('  PROD_DB_PASSWORD=<password>');
-    process.exit(1);
+function findEnvFile() {
+  let dir = __dirname;
+  while (true) {
+    const candidate = path.join(dir, '.env.prod');
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
   }
+  console.error('Error: .env.prod not found in any ancestor directory.');
+  console.error('Create one with the following contents:');
+  console.error('');
+  console.error('  PROD_DB_HOST=<host>');
+  console.error('  PROD_DB_NAME=<database>');
+  console.error('  PROD_DB_USER=<user>');
+  console.error('  PROD_DB_PASSWORD=<password>');
+  process.exit(1);
+}
+
+function loadEnvFile(filePath) {
 
   const env = {};
   for (const line of fs.readFileSync(filePath, 'utf8').split('\n')) {
@@ -81,7 +89,9 @@ function run(prod, dev) {
 }
 
 async function main() {
-  const env = loadEnvFile(ENV_FILE);
+  const envFile = findEnvFile();
+  const env = loadEnvFile(envFile);
+  console.log(`Using ${envFile}`);
 
   const prod = {
     host: env.PROD_DB_HOST,

--- a/server/src/scripts/export-prod-to-dev.js
+++ b/server/src/scripts/export-prod-to-dev.js
@@ -1,18 +1,42 @@
 import mysql from 'mysql2/promise';
 import config from '../config';
-import yargs from 'yargs';
-import { hideBin } from 'yargs/helpers';
 import readline from 'readline';
+import fs from 'fs';
+import path from 'path';
 
-const argv = yargs(hideBin(process.argv))
-  .option('prod-host', { type: 'string', demandOption: true, description: 'PROD database host' })
-  .option('prod-name', { type: 'string', demandOption: true, description: 'PROD database name' })
-  .option('prod-user', { type: 'string', demandOption: true, description: 'PROD database user' })
-  .option('prod-password', { type: 'string', demandOption: true, description: 'PROD database password' })
-  .option('yes', { type: 'boolean', default: false, description: 'Skip confirmation prompt' })
-  .argv;
+const ENV_FILE = path.resolve(__dirname, '../.env.prod');
+const skipConfirm = process.argv.includes('--yes');
 
-const INSERT_BATCH_SIZE = 500;
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    console.error(`Error: ${filePath} not found.`);
+    console.error('Create it with the following contents:');
+    console.error('');
+    console.error('  PROD_DB_HOST=<host>');
+    console.error('  PROD_DB_NAME=<database>');
+    console.error('  PROD_DB_USER=<user>');
+    console.error('  PROD_DB_PASSWORD=<password>');
+    process.exit(1);
+  }
+
+  const env = {};
+  for (const line of fs.readFileSync(filePath, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    env[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+
+  const required = ['PROD_DB_HOST', 'PROD_DB_NAME', 'PROD_DB_USER', 'PROD_DB_PASSWORD'];
+  const missing = required.filter(k => !env[k]);
+  if (missing.length) {
+    console.error(`Error: Missing required keys in ${filePath}: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+
+  return env;
+}
 
 function confirm(question) {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -29,13 +53,17 @@ async function getCreateTable(conn, table) {
   return rows[0]['Create Table'];
 }
 
+const INSERT_BATCH_SIZE = 500;
+
 async function main() {
-  console.log(`PROD: ${argv['prod-user']}@${argv['prod-host']}/${argv['prod-name']}`);
+  const env = loadEnvFile(ENV_FILE);
+
+  console.log(`PROD: ${env.PROD_DB_USER}@${env.PROD_DB_HOST}/${env.PROD_DB_NAME}`);
   console.log(`DEV:  ${config.database.user}@${config.database.host}/${config.database.name}`);
   console.log('');
   console.log('WARNING: This will DROP and recreate all tables in the DEV database.');
 
-  if (!argv.yes) {
+  if (!skipConfirm) {
     const answer = await confirm('Continue? (yes/no): ');
     if (answer.trim().toLowerCase() !== 'yes') {
       console.log('Aborted.');
@@ -44,10 +72,10 @@ async function main() {
   }
 
   const prod = await mysql.createConnection({
-    host: argv['prod-host'],
-    database: argv['prod-name'],
-    user: argv['prod-user'],
-    password: argv['prod-password'],
+    host: env.PROD_DB_HOST,
+    database: env.PROD_DB_NAME,
+    user: env.PROD_DB_USER,
+    password: env.PROD_DB_PASSWORD,
   });
 
   const dev = await mysql.createConnection({


### PR DESCRIPTION
Adds a script that exports the PROD MySQL database into the DEV database.

## Usage

```bash
npm run export-prod-to-dev
```

Add `--yes` to skip the confirmation prompt (useful for scripting).

## Setup

### 1. Create `server/src/.env.prod` (or any ancestor directory)

The script walks up the directory tree from its own location to find `.env.prod`, so you can place it at a subtree root if needed.

```
PROD_DB_HOST=<host>
PROD_DB_NAME=<database>
PROD_DB_USER=<user>
PROD_DB_PASSWORD=<password>
```

DEV credentials are read automatically from `config.json`.

### 2. Install MySQL 8.4 client (macOS / Homebrew)

MySQL 9.x removed the `mysql_native_password` auth plugin, so its `mysqldump` cannot connect to MySQL 8.x servers that use it. Install the 8.4 client and put it first in PATH:

```bash
brew install mysql-client@8.4
echo 'export PATH="/opt/homebrew/opt/mysql-client@8.4/bin:$PATH"' >> ~/.zshrc
source ~/.zshrc
```

Verify with `mysqldump --version` — should show 8.4.x.

### 3. Ensure the DEV MySQL user uses `caching_sha2_password`

MySQL 9.x clients also can't authenticate against accounts using `mysql_native_password`. Update the DEV user if needed:

```sql
-- Check the current plugin
SELECT user, host, plugin FROM mysql.user WHERE user = '<dev-user>';

-- Update if necessary (use the host shown above, commonly '%')
ALTER USER '<dev-user>'@'%'
  IDENTIFIED WITH caching_sha2_password BY '<password>';
FLUSH PRIVILEGES;
```

https://claude.ai/code/session_01AK8iyzESrosPA6iYFGYZh8