### PR TITLE
Shelly Gen 4 + ContactSensor capability + fire-alarm automation

### DIFF
--- a/server/src/api/types.ts
+++ b/server/src/api/types.ts
@@ -69,6 +69,10 @@ export type CapabilityApiResponse = {
   odometer: NumericEventApiResponse;
   chargeSchedule: { targetPercentage: number; targetTime: string; calculatedStartTime: string | null } | null;
 } | {
+  type: 'CONTACT_SENSOR';
+  isClosed: BooleanEventApiResponse;
+  lastTriggered: { start: string; end: string | null; durationSeconds: number | null } | null;
+} | {
   type: 'BIN_COLLECTION';
   color: string;
   rrule: string;

--- a/server/src/automations/fire-alarm.ts
+++ b/server/src/automations/fire-alarm.ts
@@ -1,77 +1,54 @@
-import { Stay, User, BooleanEvent } from '../models';
-import { call } from '../services/twilio';
+import { BooleanEvent, User } from '../models';
+import { callWithKarenMessage } from '../services/twilio';
 import bus, { NOTIFICATION_TO_ALL } from '../bus';
 import dayjs from '../dayjs';
 import logger from '../logger';
 import { createBackgroundTransaction } from '../helpers/newrelic';
 import { DeviceCapabilityEvents } from '../models/capabilities';
+import { joinWithAnd } from '../helpers/array';
 
 type FireAlarmAutomationParameters = {
   device_name: string;
 };
 
-function joinHomeUsers(handles: string[]): string {
+async function describeWhoIsHome(): Promise<string> {
+  const handles = (await User.getUsersAtHome()).map(u => u.handle);
+
   if (handles.length === 0) {
     return 'nobody is home';
   }
 
-  if (handles.length === 1) {
-    return `${handles[0]} is home`;
-  }
-
-  if (handles.length === 2) {
-    return `${handles[0]} and ${handles[1]} are home`;
-  }
-
-  const last = handles[handles.length - 1];
-  const rest = handles.slice(0, -1).join(', ');
-
-  return `${rest}, and ${last} are home`;
-}
-
-async function getHomeUserHandles(): Promise<string[]> {
-  const [currentStays, allUsers] = await Promise.all([
-    Stay.findCurrentStays(),
-    User.findAll()
-  ]);
-
-  const homeUserIds = new Set(currentStays.map(stay => stay.userId));
-
-  return allUsers
-    .filter(user => homeUserIds.has(user.id))
-    .map(user => user.handle);
+  return `${joinWithAnd(handles)} ${handles.length === 1 ? 'is' : 'are'} home`;
 }
 
 export default function ({ device_name: deviceName }: FireAlarmAutomationParameters) {
-  DeviceCapabilityEvents.onContactSensorIsClosedStart(createBackgroundTransaction('automations:fire-alarm:triggered', async (event: BooleanEvent) => {
-    const device = await event.getDevice();
+  const isThisDevice = (d: { name: string }) => d.name === deviceName;
 
-    if (device.name !== deviceName) {
-      return;
-    }
-
+  DeviceCapabilityEvents.onContactSensorIsClosedStart(isThisDevice, createBackgroundTransaction('automations:fire-alarm:triggered', async (event: BooleanEvent) => {
     const time = dayjs(event.start).format('HH:mm');
-    const homeList = joinHomeUsers(await getHomeUserHandles());
+    const homeList = await describeWhoIsHome();
     const message = `Fire alarm activated at ${time}. ${homeList}.`;
 
-    logger.warn({ deviceId: device.id, deviceName: device.name }, message);
+    logger.warn({ event: 'fire-alarm-triggered' }, message);
 
-    bus.emit(NOTIFICATION_TO_ALL, {
-      message,
-      priority: 2
-    });
+    bus.emit(NOTIFICATION_TO_ALL, { message, priority: 2 });
 
-    const allUsers = await User.findAll();
-
-    for (const user of allUsers) {
-      if (!user.mobileNumber) {
-        continue;
-      }
-
-      call(
-        user,
-        `<Response><Say voice="woman">Hi ${user.handle}. This is Karen. ${message}. I repeat. ${message}. Goodbye.</Say></Response>`
-      );
+    for (const user of await User.getUsersWithMobileNumber()) {
+      callWithKarenMessage(user, message);
     }
+  }));
+
+  DeviceCapabilityEvents.onConnectivityIsConnectedEnd(isThisDevice, createBackgroundTransaction('automations:fire-alarm:offline', async () => {
+    const message = 'Fire alarm has gone offline.';
+
+    logger.warn({ event: 'fire-alarm-offline' }, message);
+    bus.emit(NOTIFICATION_TO_ALL, { message, priority: 1 });
+  }));
+
+  DeviceCapabilityEvents.onConnectivityIsConnectedStart(isThisDevice, createBackgroundTransaction('automations:fire-alarm:online', async () => {
+    const message = 'Fire alarm is back online.';
+
+    logger.info({ event: 'fire-alarm-online' }, message);
+    bus.emit(NOTIFICATION_TO_ALL, { message, priority: 0 });
   }));
 }

--- a/server/src/automations/fire-alarm.ts
+++ b/server/src/automations/fire-alarm.ts
@@ -8,7 +8,7 @@ import { DeviceCapabilityEvents } from '../models/capabilities';
 import { joinWithAnd } from '../helpers/array';
 
 type FireAlarmAutomationParameters = {
-  device_name: string;
+  deviceName: string;
 };
 
 async function describeWhoIsHome(): Promise<string> {
@@ -21,7 +21,7 @@ async function describeWhoIsHome(): Promise<string> {
   return `${joinWithAnd(handles)} ${handles.length === 1 ? 'is' : 'are'} home`;
 }
 
-export default function ({ device_name: deviceName }: FireAlarmAutomationParameters) {
+export default function ({ deviceName }: FireAlarmAutomationParameters) {
   const isThisDevice = (d: Device) => d.name === deviceName;
 
   DeviceCapabilityEvents.onContactSensorIsClosedStart(isThisDevice, createBackgroundTransaction('automations:fire-alarm:triggered', async (event: BooleanEvent) => {

--- a/server/src/automations/fire-alarm.ts
+++ b/server/src/automations/fire-alarm.ts
@@ -31,7 +31,7 @@ export default function ({ deviceName }: FireAlarmAutomationParameters) {
 
     logger.warn({ event: 'fire-alarm-triggered' }, message);
 
-    bus.emit(NOTIFICATION_TO_ALL, { message, priority: 2 });
+    bus.emit(NOTIFICATION_TO_ALL, { message, priority: 2, retry: 60, expire: 3600 });
 
     for (const user of await User.getUsersWithMobileNumber()) {
       callWithKarenMessage(user, message);

--- a/server/src/automations/fire-alarm.ts
+++ b/server/src/automations/fire-alarm.ts
@@ -1,4 +1,4 @@
-import { BooleanEvent, User } from '../models';
+import { BooleanEvent, Device, User } from '../models';
 import { callWithKarenMessage } from '../services/twilio';
 import bus, { NOTIFICATION_TO_ALL } from '../bus';
 import dayjs from '../dayjs';
@@ -22,7 +22,7 @@ async function describeWhoIsHome(): Promise<string> {
 }
 
 export default function ({ device_name: deviceName }: FireAlarmAutomationParameters) {
-  const isThisDevice = (d: { name: string }) => d.name === deviceName;
+  const isThisDevice = (d: Device) => d.name === deviceName;
 
   DeviceCapabilityEvents.onContactSensorIsClosedStart(isThisDevice, createBackgroundTransaction('automations:fire-alarm:triggered', async (event: BooleanEvent) => {
     const time = dayjs(event.start).format('HH:mm');
@@ -38,15 +38,15 @@ export default function ({ device_name: deviceName }: FireAlarmAutomationParamet
     }
   }));
 
-  DeviceCapabilityEvents.onConnectivityIsConnectedEnd(isThisDevice, createBackgroundTransaction('automations:fire-alarm:offline', async () => {
-    const message = 'Fire alarm has gone offline.';
+  DeviceCapabilityEvents.onConnectivityIsConnectedEnd(isThisDevice, createBackgroundTransaction('automations:fire-alarm:offline', async (event: BooleanEvent) => {
+    const message = `Fire alarm has gone offline as of ${dayjs(event.start).format('HH:mm')}.`;
 
     logger.warn({ event: 'fire-alarm-offline' }, message);
     bus.emit(NOTIFICATION_TO_ALL, { message, priority: 1 });
   }));
 
-  DeviceCapabilityEvents.onConnectivityIsConnectedStart(isThisDevice, createBackgroundTransaction('automations:fire-alarm:online', async () => {
-    const message = 'Fire alarm is back online.';
+  DeviceCapabilityEvents.onConnectivityIsConnectedStart(isThisDevice, createBackgroundTransaction('automations:fire-alarm:online', async (event: BooleanEvent) => {
+    const message = `Fire alarm is back online as of ${dayjs(event.start).format('HH:mm')}.`;
 
     logger.info({ event: 'fire-alarm-online' }, message);
     bus.emit(NOTIFICATION_TO_ALL, { message, priority: 0 });

--- a/server/src/automations/fire-alarm.ts
+++ b/server/src/automations/fire-alarm.ts
@@ -1,0 +1,77 @@
+import { Stay, User, BooleanEvent } from '../models';
+import { call } from '../services/twilio';
+import bus, { NOTIFICATION_TO_ALL } from '../bus';
+import dayjs from '../dayjs';
+import logger from '../logger';
+import { createBackgroundTransaction } from '../helpers/newrelic';
+import { DeviceCapabilityEvents } from '../models/capabilities';
+
+type FireAlarmAutomationParameters = {
+  device_name: string;
+};
+
+function joinHomeUsers(handles: string[]): string {
+  if (handles.length === 0) {
+    return 'nobody is home';
+  }
+
+  if (handles.length === 1) {
+    return `${handles[0]} is home`;
+  }
+
+  if (handles.length === 2) {
+    return `${handles[0]} and ${handles[1]} are home`;
+  }
+
+  const last = handles[handles.length - 1];
+  const rest = handles.slice(0, -1).join(', ');
+
+  return `${rest}, and ${last} are home`;
+}
+
+async function getHomeUserHandles(): Promise<string[]> {
+  const [currentStays, allUsers] = await Promise.all([
+    Stay.findCurrentStays(),
+    User.findAll()
+  ]);
+
+  const homeUserIds = new Set(currentStays.map(stay => stay.userId));
+
+  return allUsers
+    .filter(user => homeUserIds.has(user.id))
+    .map(user => user.handle);
+}
+
+export default function ({ device_name: deviceName }: FireAlarmAutomationParameters) {
+  DeviceCapabilityEvents.onContactSensorIsClosedStart(createBackgroundTransaction('automations:fire-alarm:triggered', async (event: BooleanEvent) => {
+    const device = await event.getDevice();
+
+    if (device.name !== deviceName) {
+      return;
+    }
+
+    const time = dayjs(event.start).format('HH:mm');
+    const homeList = joinHomeUsers(await getHomeUserHandles());
+    const message = `Fire alarm activated at ${time}. ${homeList}.`;
+
+    logger.warn({ deviceId: device.id, deviceName: device.name }, message);
+
+    bus.emit(NOTIFICATION_TO_ALL, {
+      message,
+      priority: 2
+    });
+
+    const allUsers = await User.findAll();
+
+    for (const user of allUsers) {
+      if (!user.mobileNumber) {
+        continue;
+      }
+
+      call(
+        user,
+        `<Response><Say voice="woman">Hi ${user.handle}. This is Karen. ${message}. I repeat. ${message}. Goodbye.</Say></Response>`
+      );
+    }
+  }));
+}

--- a/server/src/automations/security.ts
+++ b/server/src/automations/security.ts
@@ -1,5 +1,5 @@
-import { Device, Arming, Stay, User, AlarmActivation, Event } from '../models';
-import { call } from '../services/twilio';
+import { Device, Arming, User, AlarmActivation, Event } from '../models';
+import { callWithKarenMessage } from '../services/twilio';
 import dayjs from '../dayjs';
 import sleep from '../helpers/sleep';
 import { createBackgroundTransaction } from '../helpers/newrelic';
@@ -23,25 +23,13 @@ async function turnOnAllTheLights() {
   }
 }
 
-async function getAbsentUsersWithMobileNumbers() {
-  const [
-    currentStays,
-    allUsers
-  ] = await Promise.all([
-    Stay.findCurrentStays(),
-    User.findAll()
-  ]);
-
-  return allUsers.filter(user => !!user.mobileNumber && !currentStays.some(stay => stay.userId === user.id));
-}
-
 async function notifyAbsentUsersOfEvent(event: Event) {
-  const usersWithNumber = await getAbsentUsersWithMobileNumbers();
+  const usersWithNumber = await User.getAbsentUsersWithMobileNumber();
   const device = await event.getDevice();
   const message = `Motion was detected by the ${device.name} at ${dayjs(event.start).format('HH:mm:ss')}`;
 
   for (const user of usersWithNumber) {
-    call(user, `<Response><Say voice="woman">Hi ${user.handle}. This is Karen. ${message}. I repeat ${message}. Stay safe. Goodbye.</Say></Response>`);
+    callWithKarenMessage(user, message);
   }
 }
 

--- a/server/src/bus.ts
+++ b/server/src/bus.ts
@@ -21,6 +21,8 @@ type NotificationPayload = {
   message: string,
   sound?: string,
   priority?: number,
+  retry?: number,
+  expire?: number,
   image?: Buffer
 };
 

--- a/server/src/bus.ts
+++ b/server/src/bus.ts
@@ -17,14 +17,15 @@ emitter.setMaxListeners(100);
 type NotificationEvents = 'NOTIFICATION_TO_ALL' | 'NOTIFICATION_TO_ADMINS';
 type StayEvents = 'FIRST_USER_HOME' | 'LAST_USER_LEAVES' | 'STAY_START' | 'STAY_END';
 
-type NotificationPayload = {
+type BaseNotificationPayload = {
   message: string,
   sound?: string,
-  priority?: number,
-  retry?: number,
-  expire?: number,
   image?: Buffer
 };
+
+type NotificationPayload =
+  | (BaseNotificationPayload & { priority: 2, retry: number, expire: number })
+  | (BaseNotificationPayload & { priority?: -2 | -1 | 0 | 1 });
 
 interface KarenEventBus extends EventEmitter {
   emit(event: NotificationEvents, payload: NotificationPayload): boolean;

--- a/server/src/capabilities.json
+++ b/server/src/capabilities.json
@@ -373,4 +373,14 @@
       "isMomentary": true
     }
   ]
+}, {
+  "name": "ContactSensor",
+  "properties": [
+    {
+      "name": "IsClosed",
+      "isWriteable": false,
+      "type": "boolean",
+      "eventName": "closed"
+    }
+  ]
 }]

--- a/server/src/components/capabilities/registry.tsx
+++ b/server/src/components/capabilities/registry.tsx
@@ -34,6 +34,7 @@ import {
   faSnowflake,
   faCalendarDay,
   faHashtag,
+  faBell,
 } from '@fortawesome/free-solid-svg-icons';
 import { useQueryClient, QueryClient } from '@tanstack/react-query';
 import type { CapabilityApiResponse, RestDeviceResponse, DeviceApiResponse, LightUpdateRequest, LockUpdateRequest } from '../../api/types';
@@ -41,8 +42,8 @@ import ThermostatModal from '../modals/thermostat-modal';
 import ChargeScheduleModal from '../modals/charge-schedule-modal';
 import ChargeLimitModal from '../modals/charge-limit-modal';
 import dayjs from '../../dayjs';
-import { humanDate } from '../../helpers/date';
-import type { MetricDisplayVariant, CapabilityUIRegistry } from './types';
+import { humanDate, formatDuration } from '../../helpers/date';
+import type { MetricDisplayVariant, CapabilityUIRegistry, CapabilityMetric } from './types';
 
 // ============================================================================
 // Mutation Functions
@@ -562,6 +563,45 @@ export const registry: CapabilityUIRegistry = {
         value: cap.totalPresses.toString(),
         iconColor: '#04A7F4',
       },
+    ],
+  },
+
+  CONTACT_SENSOR: {
+    priority: 55,
+    getCapabilityMetrics: (cap) => {
+      const isClosed = cap.isClosed.value;
+      const metrics: CapabilityMetric[] = [
+        {
+          icon: faBell,
+          title: 'Status',
+          value: isClosed ? 'TRIGGERED' : 'OK',
+          since: cap.isClosed.start,
+          lastReported: cap.isClosed.lastReported,
+          iconColor: isClosed ? '#e74c3c' : '#2ecc71',
+          iconHighlighted: isClosed,
+          isIssue: isClosed,
+        },
+      ];
+
+      if (cap.lastTriggered) {
+        const start = dayjs(cap.lastTriggered.start);
+        const footer = cap.lastTriggered.durationSeconds === null
+          ? 'Still active'
+          : `Triggered for ${formatDuration(cap.lastTriggered.durationSeconds)}`;
+
+        metrics.push({
+          icon: faBell,
+          title: 'Last Triggered',
+          value: `${humanDate(start)} at ${start.format('HH:mm')}`,
+          iconColor: '#04A7F4',
+          footer,
+        });
+      }
+
+      return metrics;
+    },
+    getGraphs: () => [
+      { id: 'contact-sensor', title: 'Activity' },
     ],
   },
 

--- a/server/src/helpers/date.ts
+++ b/server/src/helpers/date.ts
@@ -17,3 +17,26 @@ export function humanDate(date: Dayjs): string {
     );
   }
 }
+
+export function formatDuration(seconds: number): string {
+  if (seconds < 60) {
+    const rounded = Math.max(1, Math.round(seconds));
+    return `${rounded} second${rounded === 1 ? '' : 's'}`;
+  }
+
+  const totalMinutes = Math.round(seconds / 60);
+
+  if (totalMinutes < 60) {
+    return `${totalMinutes} minute${totalMinutes === 1 ? '' : 's'}`;
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  const hoursPart = `${hours} hour${hours === 1 ? '' : 's'}`;
+
+  if (minutes === 0) {
+    return hoursPart;
+  }
+
+  return `${hoursPart} ${minutes} minute${minutes === 1 ? '' : 's'}`;
+}

--- a/server/src/models/device.ts
+++ b/server/src/models/device.ts
@@ -24,7 +24,8 @@ import {
   SpeakerCapability,
   ElectricVehicleCapability,
   BinCollectionCapability,
-  ButtonCapability
+  ButtonCapability,
+  ContactSensorCapability
 } from './capabilities';
 
 export class Device extends Model<InferAttributes<Device>, InferCreationAttributes<Device>> {
@@ -128,6 +129,10 @@ export class Device extends Model<InferAttributes<Device>, InferCreationAttribut
 
   getButtonCapability(): ButtonCapability {
     return this.#getCapabilityOrThrow(() => new ButtonCapability(this));
+  }
+
+  getContactSensorCapability(): ContactSensorCapability {
+    return this.#getCapabilityOrThrow(() => new ContactSensorCapability(this));
   }
 
   getCapabilities(): Capability[] {

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -1,6 +1,7 @@
 import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, NonAttribute, CreationOptional, Op } from 'sequelize';
 import bcrypt from 'bcrypt';
 import { createHash } from 'crypto';
+import { Stay } from './stay';
 
 export class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
   declare public id: CreationOptional<number>;
@@ -57,6 +58,32 @@ export class User extends Model<InferAttributes<User>, InferCreationAttributes<U
         }
       }
     });
+  }
+
+  static async getUsersAtHome(): Promise<User[]> {
+    const [currentStays, allUsers] = await Promise.all([
+      Stay.findCurrentStays(),
+      this.findAll()
+    ]);
+    const homeUserIds = new Set(currentStays.map(s => s.userId));
+
+    return allUsers.filter(u => homeUserIds.has(u.id));
+  }
+
+  static async getAbsentUsersWithMobileNumber(): Promise<User[]> {
+    const [currentStays, allUsers] = await Promise.all([
+      Stay.findCurrentStays(),
+      this.findAll()
+    ]);
+    const homeUserIds = new Set(currentStays.map(s => s.userId));
+
+    return allUsers.filter(u => !!u.mobileNumber && !homeUserIds.has(u.id));
+  }
+
+  static async getUsersWithMobileNumber(): Promise<User[]> {
+    const allUsers = await this.findAll();
+
+    return allUsers.filter(u => !!u.mobileNumber);
   }
 }
 

--- a/server/src/routes/api/device-helpers.ts
+++ b/server/src/routes/api/device-helpers.ts
@@ -229,6 +229,23 @@ export async function getCapabilityData(device: Device, capability: string): Pro
       });
     }
 
+    case 'CONTACT_SENSOR': {
+      const sensor = device.getContactSensorCapability();
+      const event = await sensor.getIsClosedEvent();
+
+      return {
+        type: 'CONTACT_SENSOR' as const,
+        isClosed: await mapBooleanEvent(Promise.resolve(event), device),
+        lastTriggered: event ? {
+          start: event.start.toISOString(),
+          end: event.end?.toISOString() ?? null,
+          durationSeconds: event.end
+            ? Math.round((event.end.getTime() - event.start.getTime()) / 1000)
+            : null
+        } : null
+      };
+    }
+
     case 'BIN_COLLECTION': {
       const cap = device.getBinCollectionCapability();
       const schedule = cap.getScheduleData();

--- a/server/src/routes/api/device/history.ts
+++ b/server/src/routes/api/device/history.ts
@@ -300,6 +300,22 @@ const historyFetchers = new Map<string, HistoryFetcher>([
     });
   }],
 
+  // Contact Sensor (input/dry-contact, e.g. fire alarm relay)
+  ['contact-sensor', async (device, selector) => {
+    const sensor = device.getContactSensorCapability();
+
+    return {
+      lines: [],
+      modes: await mapBooleanHistoryToResponse((hs) => sensor.getIsClosedHistory(hs), selector)
+        .then(data => ({
+          data,
+          details: [
+            { value: true as const, label: 'Triggered', fillColor: 'rgba(231, 76, 60, 0.35)' }
+          ]
+        }))
+    };
+  }],
+
   // Electric Vehicle - Weekly Mileage
   ['vehicle-weekly-mileage', async (device, selector) => {
     const ev = device.getElectricVehicleCapability();

--- a/server/src/routes/shelly.js
+++ b/server/src/routes/shelly.js
@@ -15,8 +15,17 @@ router.use((req, res, next) => {
 
 router.get('/event', async (req, res) => {
   const device = await Device.findByProviderIdOrError('shelly', req.query.id);
+  const isOn = req.query.action === 'on';
+  const capabilities = device.getCapabilities();
 
-  await device.getLightCapability().setIsOnState(req.query.action === 'on');
+  if (capabilities.includes('CONTACT_SENSOR')) {
+    await device.getContactSensorCapability().setIsClosedState(isOn);
+  } else if (capabilities.includes('LIGHT')) {
+    await device.getLightCapability().setIsOnState(isOn);
+  } else if (capabilities.includes('SWITCH')) {
+    await device.getSwitchCapability().setIsOnState(isOn);
+  }
+
   res.sendStatus(200).end();
 });
 
@@ -29,6 +38,7 @@ router.get('/install', async (req, res) => {
 
   const client = await DeviceClient.for(ip, config.shelly.user, config.shelly.password);
   const model = await client.getModel();
+  const generation = client.getGeneration();
   let device = await Device.findByProviderId('shelly', ip);
 
   if (!device) {
@@ -38,16 +48,39 @@ router.get('/install', async (req, res) => {
     });
   }
 
+  let role = 'switch';
+
+  if (generation >= 2) {
+    try {
+      const switchConfig = await client.getSwitchConfig();
+
+      if (switchConfig && switchConfig.in_mode === 'detached') {
+        role = 'contact';
+      }
+    } catch (e) {
+      // Some Gen 2+ models may not expose Switch.GetConfig (e.g. dimmers); fall back to switch.
+    }
+  }
+
   device.name = ip;
   device.manufacturer = 'Shelly';
   device.model = model;
   device.meta.endpoint = ip;
-  device.meta.generation = client.getGeneration();
-  
+  device.meta.generation = generation;
+  device.meta.role = role;
+
   await client.setCloudStatus(false);
   await client.setupAuthentication();
-  await client.setOutputOffWebhook(`http://${config.shelly.webhook_host}/shelly/event?secret=${config.shelly.secret}&id=${ip}&action=off`);
-  await client.setOutputOnWebhook(`http://${config.shelly.webhook_host}/shelly/event?secret=${config.shelly.secret}&id=${ip}&action=on`);
+
+  const eventUrl = (action) => `http://${config.shelly.webhook_host}/shelly/event?secret=${config.shelly.secret}&id=${ip}&action=${action}`;
+
+  if (role === 'contact') {
+    await client.setInputOnWebhook(eventUrl('on'));
+    await client.setInputOffWebhook(eventUrl('off'));
+  } else {
+    await client.setOutputOffWebhook(eventUrl('off'));
+    await client.setOutputOnWebhook(eventUrl('on'));
+  }
 
   switch (model) {
     case 'SNPL-00112UK': {  // plug
@@ -56,7 +89,7 @@ router.get('/install', async (req, res) => {
       break;
     }
   }
-  
+
   await client.reboot();
   await device.save();
 

--- a/server/src/routes/shelly.js
+++ b/server/src/routes/shelly.js
@@ -50,15 +50,11 @@ router.get('/install', async (req, res) => {
 
   let role = 'switch';
 
-  if (generation >= 2) {
-    try {
-      const switchConfig = await client.getSwitchConfig();
+  if (generation === 4) {
+    const switchConfig = await client.getSwitchConfig();
 
-      if (switchConfig && switchConfig.in_mode === 'detached') {
-        role = 'contact';
-      }
-    } catch (e) {
-      // Some Gen 2+ models may not expose Switch.GetConfig (e.g. dimmers); fall back to switch.
+    if (switchConfig.in_mode === 'detached') {
+      role = 'contact';
     }
   }
 

--- a/server/src/routes/shelly.js
+++ b/server/src/routes/shelly.js
@@ -15,15 +15,15 @@ router.use((req, res, next) => {
 
 router.get('/event', async (req, res) => {
   const device = await Device.findByProviderIdOrError('shelly', req.query.id);
-  const action = req.query.action;
+  const isOn = req.query.action === 'on';
   const capabilities = device.getCapabilities();
 
   if (capabilities.includes('CONTACT_SENSOR')) {
-    await device.getContactSensorCapability().setIsClosedState(action === 'closed');
+    await device.getContactSensorCapability().setIsClosedState(isOn);
   } else if (capabilities.includes('LIGHT')) {
-    await device.getLightCapability().setIsOnState(action === 'on');
+    await device.getLightCapability().setIsOnState(isOn);
   } else if (capabilities.includes('SWITCH')) {
-    await device.getSwitchCapability().setIsOnState(action === 'on');
+    await device.getSwitchCapability().setIsOnState(isOn);
   }
 
   res.sendStatus(200).end();
@@ -75,8 +75,8 @@ router.get('/install', async (req, res) => {
   const eventUrl = (action) => `http://${config.shelly.webhook_host}/shelly/event?secret=${config.shelly.secret}&id=${ip}&action=${action}`;
 
   if (role === 'contact') {
-    await client.setInputOnWebhook(eventUrl('closed'));
-    await client.setInputOffWebhook(eventUrl('open'));
+    await client.setInputOnWebhook(eventUrl('on'));
+    await client.setInputOffWebhook(eventUrl('off'));
   } else {
     await client.setOutputOffWebhook(eventUrl('off'));
     await client.setOutputOnWebhook(eventUrl('on'));

--- a/server/src/routes/shelly.js
+++ b/server/src/routes/shelly.js
@@ -15,15 +15,15 @@ router.use((req, res, next) => {
 
 router.get('/event', async (req, res) => {
   const device = await Device.findByProviderIdOrError('shelly', req.query.id);
-  const isOn = req.query.action === 'on';
+  const action = req.query.action;
   const capabilities = device.getCapabilities();
 
   if (capabilities.includes('CONTACT_SENSOR')) {
-    await device.getContactSensorCapability().setIsClosedState(isOn);
+    await device.getContactSensorCapability().setIsClosedState(action === 'closed');
   } else if (capabilities.includes('LIGHT')) {
-    await device.getLightCapability().setIsOnState(isOn);
+    await device.getLightCapability().setIsOnState(action === 'on');
   } else if (capabilities.includes('SWITCH')) {
-    await device.getSwitchCapability().setIsOnState(isOn);
+    await device.getSwitchCapability().setIsOnState(action === 'on');
   }
 
   res.sendStatus(200).end();
@@ -75,8 +75,8 @@ router.get('/install', async (req, res) => {
   const eventUrl = (action) => `http://${config.shelly.webhook_host}/shelly/event?secret=${config.shelly.secret}&id=${ip}&action=${action}`;
 
   if (role === 'contact') {
-    await client.setInputOnWebhook(eventUrl('on'));
-    await client.setInputOffWebhook(eventUrl('off'));
+    await client.setInputOnWebhook(eventUrl('closed'));
+    await client.setInputOffWebhook(eventUrl('open'));
   } else {
     await client.setOutputOffWebhook(eventUrl('off'));
     await client.setOutputOnWebhook(eventUrl('on'));

--- a/server/src/services/shelly/client/device.ts
+++ b/server/src/services/shelly/client/device.ts
@@ -8,8 +8,8 @@ export default class DeviceClient {
       case 1:
         return new Gen1DeviceClient(ip, username, password);
       case 2:
-        return new Gen2PlusDeviceClient(ip, username, password, generation);
       case 3:
+      case 4:
         return new Gen2PlusDeviceClient(ip, username, password, generation);
       default:
         throw new Error(`Gen ${generation} is not supported`);

--- a/server/src/services/shelly/client/gen2plus-device.js
+++ b/server/src/services/shelly/client/gen2plus-device.js
@@ -52,6 +52,18 @@ export default class Gen2PlusDeviceClient {
     return await this._request(`/rpc/Webhook.Create?cid=0&enable=true&event="switch.off"&urls=["${encodeURIComponent(endpoint)}"]`);
   }
 
+  async setInputOnWebhook(endpoint) {
+    return await this._request(`/rpc/Webhook.Create?cid=0&enable=true&event="input.toggle_on"&urls=["${encodeURIComponent(endpoint)}"]`);
+  }
+
+  async setInputOffWebhook(endpoint) {
+    return await this._request(`/rpc/Webhook.Create?cid=0&enable=true&event="input.toggle_off"&urls=["${encodeURIComponent(endpoint)}"]`);
+  }
+
+  async getSwitchConfig() {
+    return await this._request('/rpc/Switch.GetConfig?id=0');
+  }
+
   async setBrightness() {
     throw new Error();
   }

--- a/server/src/services/shelly/index.ts
+++ b/server/src/services/shelly/index.ts
@@ -11,6 +11,8 @@ Device.registerProvider('shelly', {
         return ['LIGHT'];
       case 3:
         return ['SWITCH'];
+      case 4:
+        return device.meta.role === 'contact' ? ['CONTACT_SENSOR'] : ['SWITCH'];
       default:
         throw new Error(`Cannot infer capabilities for device ${device.id}`);
     }

--- a/server/src/services/twilio/index.js
+++ b/server/src/services/twilio/index.js
@@ -10,3 +10,10 @@ export function call(user, message) {
     from: config.twilio.number
   });
 }
+
+export function callWithKarenMessage(user, message) {
+  return call(
+    user,
+    `<Response><Say voice="woman">Hi ${user.handle}. This is Karen. ${message}. I repeat. ${message}. Stay safe. Goodbye.</Say></Response>`
+  );
+}


### PR DESCRIPTION
## Summary
- Adds Shelly Plus 1 Mini Gen 4 support (JSON-RPC client passes generation 4 through to the existing Gen 2+ client; install endpoint auto-detects detached input mode via `Switch.GetConfig`).
- Adds a generic, read-only `ContactSensor` capability (`IsClosed` boolean) that the Shelly integration registers when `device.meta.role === 'contact'`. The device API also exposes a `lastTriggered { start, end, durationSeconds }` derived from the same `getIsClosedEvent()` read, and the device card shows a TRIGGERED/OK tile + a "Last triggered for N minutes" tile. The device-details page renders an activity timeline with each activation as a filled segment.
- Adds a `fire-alarm` automation that listens for `CONTACT_SENSOR` activations on a named device and, on the false→true edge, voice-calls every user with a `mobileNumber` (Twilio) and broadcasts an emergency Pushover notification (`priority: 2`) listing who is currently home.
- Fixes a pre-existing bug in `/shelly/event` where `getLightCapability()` was unconditionally invoked for any Shelly device — handler now dispatches based on the device's actual capability set.

## Configuration
After this lands, register the automation in `config.json`:

```json
{ "name": "fire-alarm", "parameters": { "device_name": "Fire Alarm" } }
```

The Shelly itself must be set to **Detached Switch** input mode in the Shelly app before running `/shelly/install?ip=…&secret=…`; the install endpoint reads that config to decide whether to register input or output webhooks.

## Test plan
- [ ] In the Shelly app, set the Shelly Plus 1 Mini Gen 4 input mode to **Detached Switch**.
- [ ] `curl 'http://karen/shelly/install?secret=…&ip=<ip>'` → 201; confirm the device row's `meta` has `role: 'contact'`, `generation: 4`.
- [ ] `curl 'http://<ip>/rpc/Webhook.List'` shows `input.toggle_on` / `input.toggle_off` hooks (no `switch.on/off`).
- [ ] Short the SW terminal to N. Karen logs `GET /shelly/event?…&action=on`.
- [ ] `GET /api/devices` shows the device with `CONTACT_SENSOR` and `isClosed.value === true`.
- [ ] Pushover emergency notification arrives on every user.
- [ ] Twilio call lands on every user with a mobile number.
- [ ] Open the device page: TRIGGERED card + "Last Triggered" tile with duration footer + Activity timeline graph render correctly.
- [ ] Remove the jumper → `isClosed.value` flips to `false`; re-shorting fires Twilio + Pushover again (no cooldown by design).
- [ ] Existing Shelly switch/light devices still respond to webhooks (regression check on the new capability-aware dispatch).

https://claude.ai/code/session_015bTYHGdzQzk7WyqHNaDxAy

---
_Generated by [Claude Code](https://claude.ai/code/session_015bTYHGdzQzk7WyqHNaDxAy)_