### PR TITLE
Fix lambda build after removing RestDeviceResponse.status

### DIFF
--- a/lambdas/smart-home/src/custom-typings/karen-types.d.ts
+++ b/lambdas/smart-home/src/custom-typings/karen-types.d.ts
@@ -1,6 +1,5 @@
 // Import and re-export shared types from server API
 import type {
-  DeviceStatus,
   AlarmMode,
   AlarmStatusResponse as AlarmApiResponse,
   BooleanEventApiResponse,
@@ -11,7 +10,6 @@ import type {
 } from '../../../../server/src/api/types';
 
 export type {
-  DeviceStatus,
   AlarmMode,
   AlarmApiResponse,
   BooleanEventApiResponse,

--- a/lambdas/smart-home/src/devices/light.ts
+++ b/lambdas/smart-home/src/devices/light.ts
@@ -54,6 +54,8 @@ export function createResponseProperties(device: RestDeviceResponse, sampleTime:
     throw new Error('Light capability not found');
   }
 
+  const connectivityCapability = device.capabilities.find(c => c.type === 'CONNECTIVITY');
+
   return [{
     namespace: 'Alexa.PowerController',
     name: 'powerState',
@@ -70,7 +72,7 @@ export function createResponseProperties(device: RestDeviceResponse, sampleTime:
     namespace: 'Alexa.EndpointHealth',
     name: 'connectivity',
     value: {
-      value: device.status === 'OK' ? 'OK' : 'UNREACHABLE'
+      value: connectivityCapability?.isConnected.value === false ? 'UNREACHABLE' : 'OK'
     },
     timeOfSample: sampleTime.toISOString(),
     uncertaintyInMilliseconds

--- a/lambdas/smart-home/src/devices/thermostat.ts
+++ b/lambdas/smart-home/src/devices/thermostat.ts
@@ -8,6 +8,8 @@ export function createResponseProperties(device: RestDeviceResponse, sampleTime:
     throw new Error('Thermostat capability not found');
   }
 
+  const connectivityCapability = device.capabilities.find(x => x.type === 'CONNECTIVITY');
+
   return [{
     namespace: 'Alexa.TemperatureSensor',
     name: 'temperature',
@@ -38,7 +40,7 @@ export function createResponseProperties(device: RestDeviceResponse, sampleTime:
     namespace: 'Alexa.EndpointHealth',
     name: 'connectivity',
     value: {
-      value: device.status === 'OK' ? 'OK' : 'UNREACHABLE'
+      value: connectivityCapability?.isConnected.value === false ? 'UNREACHABLE' : 'OK'
     },
     timeOfSample: sampleTime.toISOString(),
     uncertaintyInMilliseconds

--- a/lambdas/smart-home/src/handlers/discovery.ts
+++ b/lambdas/smart-home/src/handlers/discovery.ts
@@ -131,6 +131,15 @@ function mapLightToEndpoints(device: RestDeviceResponse): SmartHomeEndpoint {
       }
     }, {
       type: 'AlexaInterface',
+      interface: 'Alexa.EndpointHealth',
+      version: '3',
+      properties: {
+        supported: [{ name: 'connectivity' }],
+        proactivelyReported: false,
+        retrievable: true
+      }
+    }, {
+      type: 'AlexaInterface',
       interface: 'Alexa',
       version: '3'
     }]


### PR DESCRIPTION
The smart-home lambda reported Alexa endpoint health from device.status, which no longer exists. Read the new CONNECTIVITY capability instead and report UNREACHABLE only when isConnected is explicitly false.

https://claude.ai/code/session_01AbaAjrvJwTk1bmbZHBnhxA