### PR TITLE
Add recurring charge schedules and idempotent start

### DIFF
--- a/server/src/api/types.ts
+++ b/server/src/api/types.ts
@@ -67,14 +67,7 @@ export type CapabilityApiResponse = {
   isCableConnected: BooleanEventApiResponse;
   chargeLimit: NumericEventApiResponse;
   odometer: NumericEventApiResponse;
-  chargeSchedule: {
-    source: 'config' | 'override';
-    scheduleId: string | null;
-    targetPercentage: number;
-    targetTime: string;
-    calculatedStartTime: string | null;
-  } | null;
-  chargeScheduleOverride: { targetPercentage: number; targetTime: string } | null;
+  chargeSchedule: { targetPercentage: number; targetTime: string; calculatedStartTime: string | null } | null;
 } | {
   type: 'BIN_COLLECTION';
   color: string;
@@ -223,7 +216,7 @@ export interface ThermostatUpdateRequest {
 // /api/device/:id/vehicle endpoint
 export interface VehicleUpdateRequest {
   chargeLimit?: number;
-  chargeScheduleOverride?: { targetPercentage: number; targetTime: string } | null;
+  manualChargeSchedule?: { targetPercentage: number; targetTime: string } | null;
 }
 
 // /api/security endpoint

--- a/server/src/api/types.ts
+++ b/server/src/api/types.ts
@@ -67,7 +67,14 @@ export type CapabilityApiResponse = {
   isCableConnected: BooleanEventApiResponse;
   chargeLimit: NumericEventApiResponse;
   odometer: NumericEventApiResponse;
-  chargeSchedule: { targetPercentage: number; targetTime: string; calculatedStartTime: string | null } | null;
+  chargeSchedule: {
+    source: 'config' | 'override';
+    scheduleId: string | null;
+    targetPercentage: number;
+    targetTime: string;
+    calculatedStartTime: string | null;
+  } | null;
+  chargeScheduleOverride: { targetPercentage: number; targetTime: string } | null;
 } | {
   type: 'BIN_COLLECTION';
   color: string;
@@ -216,7 +223,7 @@ export interface ThermostatUpdateRequest {
 // /api/device/:id/vehicle endpoint
 export interface VehicleUpdateRequest {
   chargeLimit?: number;
-  chargeSchedule?: { targetPercentage: number; targetTime: string } | null;
+  chargeScheduleOverride?: { targetPercentage: number; targetTime: string } | null;
 }
 
 // /api/security endpoint

--- a/server/src/capabilities.json
+++ b/server/src/capabilities.json
@@ -320,6 +320,8 @@
   "properties": []
 }, {
   "name": "ElectricVehicle",
+  "capabilityModelClassName": "ElectricVehicleBase",
+  "capabilityProviderClassName": "ProviderElectricVehicleCapabilityBase",
   "properties": [
     {
       "name": "ChargePercentage",

--- a/server/src/components/modals/charge-schedule-modal.tsx
+++ b/server/src/components/modals/charge-schedule-modal.tsx
@@ -20,7 +20,7 @@ export default function ChargeScheduleModal({ device, capability, closeModal }: 
 
   const handleSubmit = () => {
     updateVehicle({
-      chargeSchedule: {
+      chargeScheduleOverride: {
         targetPercentage,
         targetTime: dayjs(targetTime).toISOString()
       }

--- a/server/src/components/modals/charge-schedule-modal.tsx
+++ b/server/src/components/modals/charge-schedule-modal.tsx
@@ -20,7 +20,7 @@ export default function ChargeScheduleModal({ device, capability, closeModal }: 
 
   const handleSubmit = () => {
     updateVehicle({
-      chargeScheduleOverride: {
+      manualChargeSchedule: {
         targetPercentage,
         targetTime: dayjs(targetTime).toISOString()
       }

--- a/server/src/config.d.ts
+++ b/server/src/config.d.ts
@@ -101,6 +101,13 @@ declare namespace _default {
     const default_charge_limit: number;
     const default_charge_rate_pct_per_hour: number;
     const charge_start_buffer_hours: number;
+    const chargeSchedules: {
+      id: string;
+      targetPercentage: number;
+      targetTimeOfDay: string;
+      anchorDate: string;
+      intervalWeeks: number;
+    }[];
   }
   const bins: {
     overrides: {

--- a/server/src/config.d.ts
+++ b/server/src/config.d.ts
@@ -101,12 +101,12 @@ declare namespace _default {
     const default_charge_limit: number;
     const default_charge_rate_pct_per_hour: number;
     const charge_start_buffer_hours: number;
-    const chargeSchedules: {
+    const charge_schedules: {
       id: string;
-      targetPercentage: number;
-      targetTimeOfDay: string;
-      anchorDate: string;
-      intervalWeeks: number;
+      target_percentage: number;
+      target_time_of_day: string;
+      anchor_date: string;
+      interval_weeks: number;
     }[];
   }
   const bins: {

--- a/server/src/config.d.ts
+++ b/server/src/config.d.ts
@@ -102,7 +102,6 @@ declare namespace _default {
     const default_charge_rate_pct_per_hour: number;
     const charge_start_buffer_hours: number;
     const charge_schedules: {
-      id: string;
       target_percentage: number;
       target_time_of_day: string;
       anchor_date: string;

--- a/server/src/helpers/recurrence.test.ts
+++ b/server/src/helpers/recurrence.test.ts
@@ -1,0 +1,53 @@
+import dayjs from '../dayjs';
+import { getNextOccurrence, isOccurrenceDay } from './recurrence';
+
+describe('getNextOccurrence', () => {
+  it('returns the anchor when the anchor is in the future', () => {
+    const next = getNextOccurrence('2026-06-01', 1, dayjs('2026-05-15'));
+    expect(next.format('YYYY-MM-DD')).toBe('2026-06-01');
+  });
+
+  it('returns today when the anchor is today', () => {
+    const next = getNextOccurrence('2026-05-15', 1, dayjs('2026-05-15T08:00:00'));
+    expect(next.format('YYYY-MM-DD')).toBe('2026-05-15');
+  });
+
+  it('jumps one period forward for weekly when current period has passed', () => {
+    // Anchor on a Wednesday; ask after the following Wednesday.
+    const next = getNextOccurrence('2026-05-06', 1, dayjs('2026-05-07T08:00:00'));
+    expect(next.format('YYYY-MM-DD')).toBe('2026-05-13');
+  });
+
+  it('jumps one period forward for biweekly', () => {
+    // Anchor 2026-05-06 (Wed), biweekly. After 2026-05-07 → next is 2026-05-20.
+    const next = getNextOccurrence('2026-05-06', 2, dayjs('2026-05-07T08:00:00'));
+    expect(next.format('YYYY-MM-DD')).toBe('2026-05-20');
+  });
+
+  it('skips over multiple elapsed periods', () => {
+    // Weekly schedule, ask 5 weeks after anchor.
+    const next = getNextOccurrence('2026-01-07', 1, dayjs('2026-02-12T10:00:00'));
+    // 2026-02-11 is 5 weeks after 2026-01-07; next occurrence after Feb 12 is Feb 18.
+    expect(next.format('YYYY-MM-DD')).toBe('2026-02-18');
+  });
+});
+
+describe('isOccurrenceDay', () => {
+  it('matches the anchor itself', () => {
+    expect(isOccurrenceDay('2026-05-06', 1, '2026-05-06')).toBe(true);
+  });
+
+  it('matches a weekly multiple of the anchor', () => {
+    expect(isOccurrenceDay('2026-05-06', 1, '2026-05-13')).toBe(true);
+    expect(isOccurrenceDay('2026-05-06', 1, '2026-05-20')).toBe(true);
+  });
+
+  it('rejects an in-between day for biweekly', () => {
+    expect(isOccurrenceDay('2026-05-06', 2, '2026-05-13')).toBe(false);
+    expect(isOccurrenceDay('2026-05-06', 2, '2026-05-20')).toBe(true);
+  });
+
+  it('rejects dates before the anchor', () => {
+    expect(isOccurrenceDay('2026-05-06', 1, '2026-04-29')).toBe(false);
+  });
+});

--- a/server/src/helpers/recurrence.ts
+++ b/server/src/helpers/recurrence.ts
@@ -1,0 +1,34 @@
+import dayjs, { Dayjs } from '../dayjs';
+
+export function buildRruleString(anchorDate: string, intervalWeeks: number): string {
+  const dtstart = anchorDate.replace(/-/g, '') + 'T000000';
+  return `DTSTART:${dtstart}\nRRULE:FREQ=WEEKLY;INTERVAL=${intervalWeeks}`;
+}
+
+export function isOccurrenceDay(anchorDate: string, intervalWeeks: number, dateStr: string): boolean {
+  const anchor = dayjs(anchorDate).startOf('day');
+  const date = dayjs(dateStr).startOf('day');
+  const diffDays = date.diff(anchor, 'day');
+  const periodDays = intervalWeeks * 7;
+
+  return diffDays >= 0 && diffDays % periodDays === 0;
+}
+
+export function getNextOccurrence(anchorDate: string, intervalWeeks: number, after: Dayjs): Dayjs {
+  const anchor = dayjs(anchorDate);
+  const diffDays = after.startOf('day').diff(anchor.startOf('day'), 'day');
+  const periodDays = intervalWeeks * 7;
+
+  if (diffDays <= 0) {
+    return anchor;
+  }
+
+  const periodsPassed = Math.floor(diffDays / periodDays);
+  let candidate = anchor.add(periodsPassed * periodDays, 'day');
+
+  if (candidate.isBefore(after, 'day')) {
+    candidate = candidate.add(periodDays, 'day');
+  }
+
+  return candidate;
+}

--- a/server/src/models/capabilities/bin-collection.ts
+++ b/server/src/models/capabilities/bin-collection.ts
@@ -1,6 +1,7 @@
 import { BinCollectionBaseCapability } from './capabilities.gen';
 import config from '../../config';
-import dayjs, { Dayjs } from '../../dayjs';
+import dayjs from '../../dayjs';
+import { buildRruleString, isOccurrenceDay, getNextOccurrence } from '../../helpers/recurrence';
 
 interface BinItemConfig {
   id: string;
@@ -21,39 +22,6 @@ export interface BinScheduleData {
   overrides: Override[];
 }
 
-function buildRruleString(anchorDate: string, intervalWeeks: number): string {
-  const dtstart = anchorDate.replace(/-/g, '') + 'T000000';
-  return `DTSTART:${dtstart}\nRRULE:FREQ=WEEKLY;INTERVAL=${intervalWeeks}`;
-}
-
-function isCollectionDay(anchorDate: string, intervalWeeks: number, dateStr: string): boolean {
-  const anchor = dayjs(anchorDate).startOf('day');
-  const date = dayjs(dateStr).startOf('day');
-  const diffDays = date.diff(anchor, 'day');
-  const periodDays = intervalWeeks * 7;
-
-  return diffDays >= 0 && diffDays % periodDays === 0;
-}
-
-function getNextOccurrence(anchorDate: string, intervalWeeks: number, after: Dayjs): Dayjs {
-  const anchor = dayjs(anchorDate);
-  const diffDays = after.startOf('day').diff(anchor.startOf('day'), 'day');
-  const periodDays = intervalWeeks * 7;
-
-  if (diffDays <= 0) {
-    return anchor;
-  }
-
-  const periodsPassed = Math.floor(diffDays / periodDays);
-  let candidate = anchor.add(periodsPassed * periodDays, 'day');
-
-  if (candidate.isBefore(after, 'day')) {
-    candidate = candidate.add(periodDays, 'day');
-  }
-
-  return candidate;
-}
-
 export class BinCollectionCapability extends BinCollectionBaseCapability {
   #getBinItem(): BinItemConfig {
     const bin = config.bins.items.find(b => b.id === this.device.providerId);
@@ -68,7 +36,7 @@ export class BinCollectionCapability extends BinCollectionBaseCapability {
   #getRelevantOverrides(): Override[] {
     const bin = this.#getBinItem();
     return config.bins.overrides.filter(o =>
-      isCollectionDay(bin.anchorDate, bin.intervalWeeks, o.originalDate)
+      isOccurrenceDay(bin.anchorDate, bin.intervalWeeks, o.originalDate)
     );
   }
 

--- a/server/src/models/capabilities/electric-vehicle.ts
+++ b/server/src/models/capabilities/electric-vehicle.ts
@@ -1,0 +1,17 @@
+import { ElectricVehicleBaseCapability } from './capabilities.gen';
+import { Device } from '..';
+import { NextChargeSchedule, ManualChargeSchedule } from './index';
+
+export class ElectricVehicleCapability extends ElectricVehicleBaseCapability {
+  getNextChargeSchedule(): NextChargeSchedule | null {
+    return Device.getProviderCapabilities(this.device.provider)
+      .provideElectricVehicleCapability!()
+      .getNextChargeSchedule(this.device);
+  }
+
+  setManualChargeSchedule(schedule: ManualChargeSchedule | null): Promise<void> {
+    return Device.getProviderCapabilities(this.device.provider)
+      .provideElectricVehicleCapability!()
+      .setManualChargeSchedule(this.device, schedule);
+  }
+}

--- a/server/src/models/capabilities/index.ts
+++ b/server/src/models/capabilities/index.ts
@@ -1,10 +1,11 @@
 import { Device } from '../';
-import { ProviderThermostatCapabilityBase } from './capabilities.gen';
+import { ProviderThermostatCapabilityBase, ProviderElectricVehicleCapabilityBase } from './capabilities.gen';
 
 export { LightCapability } from './light';
 export { LockCapability } from './lock';
 export { SpeakerCapability } from './speaker';
 export { ThermostatCapability } from './thermostat';
+export { ElectricVehicleCapability } from './electric-vehicle';
 export { BinCollectionCapability } from './bin-collection';
 export * from './capabilities.gen';
 
@@ -16,6 +17,22 @@ export type ScheduledChange = {
 export interface ProviderThermostatCapability extends ProviderThermostatCapabilityBase {
   getNextScheduledChange(device: Device): Promise<ScheduledChange | null>;
   getScheduledTemperatureAtTime(device: Device, timestamp: Date): Promise<number | null>;
+}
+
+export interface NextChargeSchedule {
+  targetPercentage: number;
+  targetTime: string;
+  calculatedStartTime: string | null;
+}
+
+export interface ManualChargeSchedule {
+  targetPercentage: number;
+  targetTime: string;
+}
+
+export interface ProviderElectricVehicleCapability extends ProviderElectricVehicleCapabilityBase {
+  getNextChargeSchedule(device: Device): NextChargeSchedule | null;
+  setManualChargeSchedule(device: Device, schedule: ManualChargeSchedule | null): Promise<void>;
 }
 
 export type ProviderSpeakerCapability = {

--- a/server/src/routes/api/device-helpers.ts
+++ b/server/src/routes/api/device-helpers.ts
@@ -233,12 +233,6 @@ export async function getCapabilityData(device: Device, capability: string): Pro
 
     case 'ELECTRIC_VEHICLE': {
       const ev = device.getElectricVehicleCapability();
-      const override = (device.meta.chargeScheduleOverride ?? null) as ChargeScheduleOverride | null;
-      const active = pickActiveOccurrence(config.smartcar.chargeSchedules ?? [], override, dayjs());
-      const stored = device.meta.chargeSchedule as { targetTime: string; calculatedStartTime: string } | undefined;
-      const calculatedStartTime = active && stored && stored.targetTime === active.targetTime.toISOString()
-        ? stored.calculatedStartTime
-        : null;
 
       return awaitPromises({
         type: 'ELECTRIC_VEHICLE' as const,
@@ -247,14 +241,7 @@ export async function getCapabilityData(device: Device, capability: string): Pro
         isCableConnected: mapBooleanEvent(ev.getIsCableConnectedEvent(), device),
         chargeLimit: mapNumericEvent(ev.getChargeLimitEvent()),
         odometer: mapNumericEvent(ev.getOdometerEvent()),
-        chargeSchedule: active ? {
-          source: active.source,
-          scheduleId: active.scheduleId,
-          targetPercentage: active.targetPercentage,
-          targetTime: active.targetTime.toISOString(),
-          calculatedStartTime,
-        } : null,
-        chargeScheduleOverride: override,
+        chargeSchedule: ev.getNextChargeSchedule(),
       });
     }
 

--- a/server/src/routes/api/device-helpers.ts
+++ b/server/src/routes/api/device-helpers.ts
@@ -1,6 +1,8 @@
 import { Device, NumericEvent, BooleanEvent } from '../../models';
 import { NumericEventApiResponse, BooleanEventApiResponse, EnumEventApiResponse, RestDeviceResponse, CapabilityApiResponse } from '../../api/types';
 import dayjs from '../../dayjs';
+import config from '../../config';
+import { pickActiveOccurrence, ChargeScheduleOverride } from '../../services/vehicle/schedule';
 
 type AwaitedObject<T> = {
   [K in keyof T]: T[K] extends Promise<infer U> ? U : T[K];
@@ -244,6 +246,13 @@ export async function getCapabilityData(device: Device, capability: string): Pro
 
     case 'ELECTRIC_VEHICLE': {
       const ev = device.getElectricVehicleCapability();
+      const override = (device.meta.chargeScheduleOverride ?? null) as ChargeScheduleOverride | null;
+      const active = pickActiveOccurrence(config.smartcar.chargeSchedules ?? [], override, dayjs());
+      const stored = device.meta.chargeSchedule as { targetTime: string; calculatedStartTime: string } | undefined;
+      const calculatedStartTime = active && stored && stored.targetTime === active.targetTime.toISOString()
+        ? stored.calculatedStartTime
+        : null;
+
       return awaitPromises({
         type: 'ELECTRIC_VEHICLE' as const,
         chargePercentage: mapNumericEvent(ev.getChargePercentageEvent()),
@@ -251,10 +260,14 @@ export async function getCapabilityData(device: Device, capability: string): Pro
         isCableConnected: mapBooleanEvent(ev.getIsCableConnectedEvent(), device),
         chargeLimit: mapNumericEvent(ev.getChargeLimitEvent()),
         odometer: mapNumericEvent(ev.getOdometerEvent()),
-        chargeSchedule: Promise.resolve((() => {
-          const s = device.meta.chargeSchedule as { targetPercentage: number; targetTime: string; calculatedStartTime?: string | null } | undefined;
-          return s ? { targetPercentage: s.targetPercentage, targetTime: s.targetTime, calculatedStartTime: s.calculatedStartTime ?? null } : null;
-        })())
+        chargeSchedule: active ? {
+          source: active.source,
+          scheduleId: active.scheduleId,
+          targetPercentage: active.targetPercentage,
+          targetTime: active.targetTime.toISOString(),
+          calculatedStartTime,
+        } : null,
+        chargeScheduleOverride: override,
       });
     }
 

--- a/server/src/routes/api/device/vehicle.ts
+++ b/server/src/routes/api/device/vehicle.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { Device } from '../../../models';
 import { VehicleUpdateRequest, DeviceApiResponse } from '../../../api/types';
 import { mapDeviceToResponse } from '../device-helpers';
+import dayjs from '../../../dayjs';
 
 const router = express.Router({ mergeParams: true });
 
@@ -25,8 +26,18 @@ router.put<Record<string, never>, DeviceApiResponse, VehicleUpdateRequest>('/', 
     await ev.setChargeLimit(body.chargeLimit);
   }
 
-  if ('chargeSchedule' in body) {
-    device.meta.chargeSchedule = body.chargeSchedule;
+  if ('chargeScheduleOverride' in body) {
+    if (body.chargeScheduleOverride !== null) {
+      const targetTime = dayjs(body.chargeScheduleOverride!.targetTime);
+
+      if (!targetTime.isValid() || !targetTime.isAfter(dayjs())) {
+        res.status(400).json({ error: 'chargeScheduleOverride.targetTime must be a valid future timestamp' } as any);
+        return;
+      }
+    }
+
+    device.meta.chargeScheduleOverride = body.chargeScheduleOverride;
+    device.meta.chargeSchedule = undefined;
     await device.save();
   }
 

--- a/server/src/routes/api/device/vehicle.ts
+++ b/server/src/routes/api/device/vehicle.ts
@@ -26,19 +26,17 @@ router.put<Record<string, never>, DeviceApiResponse, VehicleUpdateRequest>('/', 
     await ev.setChargeLimit(body.chargeLimit);
   }
 
-  if ('chargeScheduleOverride' in body) {
-    if (body.chargeScheduleOverride !== null) {
-      const targetTime = dayjs(body.chargeScheduleOverride!.targetTime);
+  if ('manualChargeSchedule' in body) {
+    if (body.manualChargeSchedule !== null) {
+      const targetTime = dayjs(body.manualChargeSchedule!.targetTime);
 
       if (!targetTime.isValid() || !targetTime.isAfter(dayjs())) {
-        res.status(400).json({ error: 'chargeScheduleOverride.targetTime must be a valid future timestamp' } as any);
+        res.status(400).json({ error: 'manualChargeSchedule.targetTime must be a valid future timestamp' } as any);
         return;
       }
     }
 
-    device.meta.chargeScheduleOverride = body.chargeScheduleOverride;
-    device.meta.chargeSchedule = undefined;
-    await device.save();
+    await ev.setManualChargeSchedule(body.manualChargeSchedule ?? null);
   }
 
   const deviceResponse = await mapDeviceToResponse(device);

--- a/server/src/services/vehicle/index.ts
+++ b/server/src/services/vehicle/index.ts
@@ -79,10 +79,16 @@ Device.registerProvider('vehicle', {
 
       getNextChargeSchedule(device: Device): NextChargeSchedule | null {
         const stored = device.meta.chargeSchedule as NextChargeSchedule | undefined;
-        if (stored) return stored;
+
+        if (stored) {
+          return stored;
+        }
 
         const next = pickNextChargeSchedule(config.smartcar.charge_schedules ?? [], dayjs());
-        if (!next) return null;
+
+        if (!next) {
+          return null;
+        }
 
         return {
           targetPercentage: next.targetPercentage,
@@ -97,6 +103,7 @@ Device.registerProvider('vehicle', {
           targetTime: schedule.targetTime,
           calculatedStartTime: null,
         } satisfies NextChargeSchedule : undefined;
+
         await device.save();
       },
     };
@@ -107,19 +114,29 @@ Device.registerProvider('vehicle', {
 
 async function clearNextChargeIfExpired(device: Device, ev: ElectricVehicleCapability, now: Dayjs) {
   const stored = device.meta.chargeSchedule as NextChargeSchedule | undefined;
-  if (!stored || !now.isAfter(dayjs(stored.targetTime))) return;
+
+  if (!stored || !now.isAfter(dayjs(stored.targetTime))) {
+    return;
+  }
 
   logger.info('Charge schedule target time passed, resetting charge limit');
-  await ev.setChargeLimit(config.smartcar.default_charge_limit);
+
   device.meta.chargeSchedule = undefined;
+
+  await ev.setChargeLimit(config.smartcar.default_charge_limit);
   await device.save();
 }
 
 function chooseNextCharge(device: Device, now: Dayjs) {
-  if (device.meta.chargeSchedule) return;
+  if (device.meta.chargeSchedule) {
+    return;
+  }
 
   const next = pickNextChargeSchedule(config.smartcar.charge_schedules ?? [], now);
-  if (!next) return;
+
+  if (!next) {
+    return;
+  }
 
   device.meta.chargeSchedule = {
     targetPercentage: next.targetPercentage,
@@ -130,7 +147,10 @@ function chooseNextCharge(device: Device, now: Dayjs) {
 
 async function recomputeStartTimeForNextCharge(device: Device, ev: ElectricVehicleCapability) {
   const stored = device.meta.chargeSchedule as NextChargeSchedule | undefined;
-  if (!stored) return;
+
+  if (!stored) {
+    return;
+  }
 
   const chargeRate = config.smartcar.default_charge_rate_pct_per_hour;
   const percentageNeeded = stored.targetPercentage - await ev.getChargePercentage();
@@ -142,6 +162,7 @@ async function recomputeStartTimeForNextCharge(device: Device, ev: ElectricVehic
     ...stored,
     calculatedStartTime: startTime.toISOString(),
   } satisfies NextChargeSchedule;
+
   await device.save();
 }
 
@@ -150,11 +171,20 @@ async function recomputeStartTimeForNextCharge(device: Device, ev: ElectricVehic
 // is reset (e.g. the next occurrence rolls in).
 async function notifyUsersOfChargingState(device: Device, ev: ElectricVehicleCapability, now: Dayjs) {
   const stored = device.meta.chargeSchedule as NextChargeSchedule | undefined;
-  if (!stored || !stored.calculatedStartTime) return;
+
+  if (!stored || !stored.calculatedStartTime) {
+    return;
+  }
 
   const startTime = dayjs(stored.calculatedStartTime);
-  if (!now.isSameOrAfter(startTime)) return;
-  if (await ev.getChargeLimit() === stored.targetPercentage) return;
+
+  if (!now.isSameOrAfter(startTime)) {
+    return;
+  }
+
+  if (await ev.getChargeLimit() === stored.targetPercentage) {
+    return;
+  }
 
   const targetTime = dayjs(stored.targetTime);
   logger.info(`Starting charge to reach ${stored.targetPercentage}% by ${targetTime.format('HH:mm')}`);

--- a/server/src/services/vehicle/index.ts
+++ b/server/src/services/vehicle/index.ts
@@ -127,7 +127,7 @@ async function clearNextChargeIfExpired(device: Device, ev: ElectricVehicleCapab
   await device.save();
 }
 
-function chooseNextCharge(device: Device, now: Dayjs) {
+async function chooseNextCharge(device: Device, now: Dayjs) {
   if (device.meta.chargeSchedule) {
     return;
   }
@@ -169,7 +169,7 @@ async function recomputeStartTimeForNextCharge(device: Device, ev: ElectricVehic
 // Gated on the live charge limit so the SmartCar API and the notification
 // fire exactly once per occurrence — re-firing only happens if the limit
 // is reset (e.g. the next occurrence rolls in).
-async function notifyUsersOfChargingState(device: Device, ev: ElectricVehicleCapability, now: Dayjs) {
+async function startChargingAndNotifyUsers(device: Device, ev: ElectricVehicleCapability, now: Dayjs) {
   const stored = device.meta.chargeSchedule as NextChargeSchedule | undefined;
 
   if (!stored || !stored.calculatedStartTime) {
@@ -187,6 +187,7 @@ async function notifyUsersOfChargingState(device: Device, ev: ElectricVehicleCap
   }
 
   const targetTime = dayjs(stored.targetTime);
+
   logger.info(`Starting charge to reach ${stored.targetPercentage}% by ${targetTime.format('HH:mm')}`);
 
   await ev.setChargeLimit(stored.targetPercentage);
@@ -195,13 +196,17 @@ async function notifyUsersOfChargingState(device: Device, ev: ElectricVehicleCap
 
   if (isCableConnected) {
     await ev.setIsCharging(true);
+
+    bus.emit(NOTIFICATION_TO_ADMINS, {
+      message: buildScheduleNotification(stored.targetPercentage, startTime, targetTime, true),
+    });
   } else {
     logger.warn('Charge schedule: cable not connected, cannot start charging');
-  }
 
-  bus.emit(NOTIFICATION_TO_ADMINS, {
-    message: buildScheduleNotification(stored.targetPercentage, startTime, targetTime, isCableConnected),
-  });
+    bus.emit(NOTIFICATION_TO_ADMINS, {
+      message: buildScheduleNotification(stored.targetPercentage, startTime, targetTime, false),
+    });
+  }
 }
 
 // Run charge schedule check every 15 minutes
@@ -211,9 +216,9 @@ nowAndSetInterval(createBackgroundTransaction('vehicle:charge-schedule', async (
   const now = dayjs();
 
   await clearNextChargeIfExpired(device, ev, now);
-  chooseNextCharge(device, now);
+  await chooseNextCharge(device, now);
   await recomputeStartTimeForNextCharge(device, ev);
-  await notifyUsersOfChargingState(device, ev, now);
+  await startChargingAndNotifyUsers(device, ev, now);
 }), 15 * 60 * 1000);
 
 nowAndSetIntervalForTime(createBackgroundTransaction('vehicle:weekly-mileage', async () => {

--- a/server/src/services/vehicle/index.ts
+++ b/server/src/services/vehicle/index.ts
@@ -1,5 +1,5 @@
 import { Device } from '../../models';
-import { NextChargeSchedule, ManualChargeSchedule } from '../../models/capabilities';
+import { ElectricVehicleCapability, NextChargeSchedule, ManualChargeSchedule } from '../../models/capabilities';
 import config from '../../config';
 import nowAndSetInterval from '../../helpers/now-and-set-interval';
 import { createBackgroundTransaction } from '../../helpers/newrelic';
@@ -7,7 +7,7 @@ import * as client from './client';
 import { processSignal } from './signals';
 import { ensureHistoricalMileage, storeWeeklyMileage } from './mileage';
 import { pickNextChargeSchedule, buildScheduleNotification } from './schedule';
-import dayjs from '../../dayjs';
+import dayjs, { Dayjs } from '../../dayjs';
 import logger from '../../logger';
 import nowAndSetIntervalForTime from '../../helpers/now-and-set-interval-for-time';
 import bus, { NOTIFICATION_TO_ADMINS } from '../../bus';
@@ -105,66 +105,85 @@ Device.registerProvider('vehicle', {
   synchronize,
 });
 
-// Run charge schedule check every 15 minutes
-nowAndSetInterval(createBackgroundTransaction('vehicle:charge-schedule', async () => {
-  const device = await Device.findByProviderIdOrError('vehicle', config.smartcar.vehicle_id);
-  const ev = device.getElectricVehicleCapability();
-  const now = dayjs();
-  let stored = device.meta.chargeSchedule as NextChargeSchedule | undefined;
+async function clearNextChargeIfExpired(device: Device, ev: ElectricVehicleCapability, now: Dayjs) {
+  const stored = device.meta.chargeSchedule as NextChargeSchedule | undefined;
+  if (!stored || !now.isAfter(dayjs(stored.targetTime))) return;
 
-  // 1. Roll-over: the stored target has now passed.
-  if (stored && now.isAfter(dayjs(stored.targetTime))) {
-    logger.info('Charge schedule target time passed, resetting charge limit');
-    await ev.setChargeLimit(config.smartcar.default_charge_limit);
-    device.meta.chargeSchedule = undefined;
-    stored = undefined;
-    await device.save();
-  }
+  logger.info('Charge schedule target time passed, resetting charge limit');
+  await ev.setChargeLimit(config.smartcar.default_charge_limit);
+  device.meta.chargeSchedule = undefined;
+  await device.save();
+}
 
-  // 2. Nothing scheduled? Pick the next config occurrence.
-  if (!stored) {
-    const next = pickNextChargeSchedule(config.smartcar.charge_schedules ?? [], now);
-    if (!next) return;
-    stored = {
-      targetPercentage: next.targetPercentage,
-      targetTime: next.targetTime.toISOString(),
-      calculatedStartTime: null,
-    };
-  }
+function chooseNextCharge(device: Device, now: Dayjs) {
+  if (device.meta.chargeSchedule) return;
 
-  // 3. Recompute calculatedStartTime (drifts with current %).
+  const next = pickNextChargeSchedule(config.smartcar.charge_schedules ?? [], now);
+  if (!next) return;
+
+  device.meta.chargeSchedule = {
+    targetPercentage: next.targetPercentage,
+    targetTime: next.targetTime.toISOString(),
+    calculatedStartTime: null,
+  } satisfies NextChargeSchedule;
+}
+
+async function recomputeStartTimeForNextCharge(device: Device, ev: ElectricVehicleCapability) {
+  const stored = device.meta.chargeSchedule as NextChargeSchedule | undefined;
+  if (!stored) return;
+
   const chargeRate = config.smartcar.default_charge_rate_pct_per_hour;
   const percentageNeeded = stored.targetPercentage - await ev.getChargePercentage();
   const hoursNeeded = percentageNeeded / chargeRate;
   const bufferHours = config.smartcar.charge_start_buffer_hours ?? 0;
-  const targetTime = dayjs(stored.targetTime);
-  const startTime = targetTime.subtract(hoursNeeded + bufferHours, 'hour');
+  const startTime = dayjs(stored.targetTime).subtract(hoursNeeded + bufferHours, 'hour');
 
   device.meta.chargeSchedule = {
     ...stored,
     calculatedStartTime: startTime.toISOString(),
   } satisfies NextChargeSchedule;
   await device.save();
+}
 
-  // 4. Fire start actions when past startTime, gated on the live charge limit
-  //    so the SmartCar API and notification fire exactly once per occurrence.
-  if (now.isSameOrAfter(startTime) && await ev.getChargeLimit() !== stored.targetPercentage) {
-    logger.info(`Starting charge to reach ${stored.targetPercentage}% by ${targetTime.format('HH:mm')}`);
+// Gated on the live charge limit so the SmartCar API and the notification
+// fire exactly once per occurrence — re-firing only happens if the limit
+// is reset (e.g. the next occurrence rolls in).
+async function notifyUsersOfChargingState(device: Device, ev: ElectricVehicleCapability, now: Dayjs) {
+  const stored = device.meta.chargeSchedule as NextChargeSchedule | undefined;
+  if (!stored || !stored.calculatedStartTime) return;
 
-    await ev.setChargeLimit(stored.targetPercentage);
+  const startTime = dayjs(stored.calculatedStartTime);
+  if (!now.isSameOrAfter(startTime)) return;
+  if (await ev.getChargeLimit() === stored.targetPercentage) return;
 
-    const isCableConnected = await ev.getIsCableConnected();
+  const targetTime = dayjs(stored.targetTime);
+  logger.info(`Starting charge to reach ${stored.targetPercentage}% by ${targetTime.format('HH:mm')}`);
 
-    if (isCableConnected) {
-      await ev.setIsCharging(true);
-    } else {
-      logger.warn('Charge schedule: cable not connected, cannot start charging');
-    }
+  await ev.setChargeLimit(stored.targetPercentage);
 
-    bus.emit(NOTIFICATION_TO_ADMINS, {
-      message: buildScheduleNotification(stored.targetPercentage, startTime, targetTime, isCableConnected),
-    });
+  const isCableConnected = await ev.getIsCableConnected();
+
+  if (isCableConnected) {
+    await ev.setIsCharging(true);
+  } else {
+    logger.warn('Charge schedule: cable not connected, cannot start charging');
   }
+
+  bus.emit(NOTIFICATION_TO_ADMINS, {
+    message: buildScheduleNotification(stored.targetPercentage, startTime, targetTime, isCableConnected),
+  });
+}
+
+// Run charge schedule check every 15 minutes
+nowAndSetInterval(createBackgroundTransaction('vehicle:charge-schedule', async () => {
+  const device = await Device.findByProviderIdOrError('vehicle', config.smartcar.vehicle_id);
+  const ev = device.getElectricVehicleCapability();
+  const now = dayjs();
+
+  await clearNextChargeIfExpired(device, ev, now);
+  chooseNextCharge(device, now);
+  await recomputeStartTimeForNextCharge(device, ev);
+  await notifyUsersOfChargingState(device, ev, now);
 }), 15 * 60 * 1000);
 
 nowAndSetIntervalForTime(createBackgroundTransaction('vehicle:weekly-mileage', async () => {

--- a/server/src/services/vehicle/index.ts
+++ b/server/src/services/vehicle/index.ts
@@ -6,22 +6,11 @@ import { createBackgroundTransaction } from '../../helpers/newrelic';
 import * as client from './client';
 import { processSignal } from './signals';
 import { ensureHistoricalMileage, storeWeeklyMileage } from './mileage';
-import { pickNextChargeSchedule, buildScheduleNotification, NextChargeOccurrence } from './schedule';
+import { pickNextChargeSchedule, buildScheduleNotification } from './schedule';
 import dayjs from '../../dayjs';
 import logger from '../../logger';
 import nowAndSetIntervalForTime from '../../helpers/now-and-set-interval-for-time';
 import bus, { NOTIFICATION_TO_ADMINS } from '../../bus';
-
-interface StoredChargeSchedule {
-  targetTime: string;
-  calculatedStartTime: string;
-  hasStarted: boolean;
-}
-
-function getNextOccurrenceForDevice(device: Device, now = dayjs()): NextChargeOccurrence | null {
-  const manual = (device.meta.manualChargeSchedule ?? null) as ManualChargeSchedule | null;
-  return pickNextChargeSchedule(config.smartcar.chargeSchedules ?? [], manual, now);
-}
 
 export async function synchronize() {
   let device = await Device.findByProviderId('vehicle', config.smartcar.vehicle_id);
@@ -89,24 +78,25 @@ Device.registerProvider('vehicle', {
       },
 
       getNextChargeSchedule(device: Device): NextChargeSchedule | null {
-        const next = getNextOccurrenceForDevice(device);
-        if (!next) return null;
+        const stored = device.meta.chargeSchedule as NextChargeSchedule | undefined;
+        if (stored) return stored;
 
-        const stored = device.meta.chargeSchedule as StoredChargeSchedule | undefined;
-        const calculatedStartTime = stored && stored.targetTime === next.targetTime.toISOString()
-          ? stored.calculatedStartTime
-          : null;
+        const next = pickNextChargeSchedule(config.smartcar.charge_schedules ?? [], dayjs());
+        if (!next) return null;
 
         return {
           targetPercentage: next.targetPercentage,
           targetTime: next.targetTime.toISOString(),
-          calculatedStartTime,
+          calculatedStartTime: null,
         };
       },
 
       async setManualChargeSchedule(device: Device, schedule: ManualChargeSchedule | null) {
-        device.meta.manualChargeSchedule = schedule;
-        device.meta.chargeSchedule = undefined;
+        device.meta.chargeSchedule = schedule ? {
+          targetPercentage: schedule.targetPercentage,
+          targetTime: schedule.targetTime,
+          calculatedStartTime: null,
+        } satisfies NextChargeSchedule : undefined;
         await device.save();
       },
     };
@@ -120,67 +110,48 @@ nowAndSetInterval(createBackgroundTransaction('vehicle:charge-schedule', async (
   const device = await Device.findByProviderIdOrError('vehicle', config.smartcar.vehicle_id);
   const ev = device.getElectricVehicleCapability();
   const now = dayjs();
-  const stored = device.meta.chargeSchedule as StoredChargeSchedule | undefined;
+  let stored = device.meta.chargeSchedule as NextChargeSchedule | undefined;
 
-  // 1. Roll-over: the occurrence we were tracking has now passed.
-  //    Reset the charge limit and consume the manual schedule if it was the source.
+  // 1. Roll-over: the stored target has now passed.
   if (stored && now.isAfter(dayjs(stored.targetTime))) {
     logger.info('Charge schedule target time passed, resetting charge limit');
     await ev.setChargeLimit(config.smartcar.default_charge_limit);
-
-    const manual = device.meta.manualChargeSchedule as ManualChargeSchedule | null | undefined;
-    if (manual && dayjs(manual.targetTime).isSame(dayjs(stored.targetTime))) {
-      device.meta.manualChargeSchedule = null;
-    }
-
     device.meta.chargeSchedule = undefined;
+    stored = undefined;
     await device.save();
   }
 
-  // 2. Re-derive the next occurrence from config + manual schedule on each tick.
-  const next = getNextOccurrenceForDevice(device, now);
-
-  if (!next) {
-    return;
+  // 2. Nothing scheduled? Pick the next config occurrence.
+  if (!stored) {
+    const next = pickNextChargeSchedule(config.smartcar.charge_schedules ?? [], now);
+    if (!next) return;
+    stored = {
+      targetPercentage: next.targetPercentage,
+      targetTime: next.targetTime.toISOString(),
+      calculatedStartTime: null,
+    };
   }
 
-  const previous = device.meta.chargeSchedule as StoredChargeSchedule | undefined;
-  const isNewOccurrence = !previous || previous.targetTime !== next.targetTime.toISOString();
-
-  if (await ev.getChargePercentage() >= next.targetPercentage) {
-    if (isNewOccurrence) {
-      device.meta.chargeSchedule = {
-        targetTime: next.targetTime.toISOString(),
-        calculatedStartTime: next.targetTime.toISOString(),
-        hasStarted: true,
-      } satisfies StoredChargeSchedule;
-      await device.save();
-    }
-
-    return;
-  }
-
-  // 3. Recompute calculatedStartTime each cycle (drifts with current %).
+  // 3. Recompute calculatedStartTime (drifts with current %).
   const chargeRate = config.smartcar.default_charge_rate_pct_per_hour;
-  const percentageNeeded = next.targetPercentage - await ev.getChargePercentage();
+  const percentageNeeded = stored.targetPercentage - await ev.getChargePercentage();
   const hoursNeeded = percentageNeeded / chargeRate;
   const bufferHours = config.smartcar.charge_start_buffer_hours ?? 0;
-  const startTime = next.targetTime.subtract(hoursNeeded + bufferHours, 'hour');
-
-  const hasStarted = !isNewOccurrence && (previous?.hasStarted ?? false);
+  const targetTime = dayjs(stored.targetTime);
+  const startTime = targetTime.subtract(hoursNeeded + bufferHours, 'hour');
 
   device.meta.chargeSchedule = {
-    targetTime: next.targetTime.toISOString(),
+    ...stored,
     calculatedStartTime: startTime.toISOString(),
-    hasStarted,
-  } satisfies StoredChargeSchedule;
+  } satisfies NextChargeSchedule;
   await device.save();
 
-  // 4. Fire start actions exactly once per occurrence.
-  if (now.isSameOrAfter(startTime) && !hasStarted) {
-    logger.info(`Starting charge to reach ${next.targetPercentage}% by ${next.targetTime.format('HH:mm')}`);
+  // 4. Fire start actions when past startTime, gated on the live charge limit
+  //    so the SmartCar API and notification fire exactly once per occurrence.
+  if (now.isSameOrAfter(startTime) && await ev.getChargeLimit() !== stored.targetPercentage) {
+    logger.info(`Starting charge to reach ${stored.targetPercentage}% by ${targetTime.format('HH:mm')}`);
 
-    await ev.setChargeLimit(next.targetPercentage);
+    await ev.setChargeLimit(stored.targetPercentage);
 
     const isCableConnected = await ev.getIsCableConnected();
 
@@ -191,14 +162,8 @@ nowAndSetInterval(createBackgroundTransaction('vehicle:charge-schedule', async (
     }
 
     bus.emit(NOTIFICATION_TO_ADMINS, {
-      message: buildScheduleNotification(next.targetPercentage, startTime, next.targetTime, isCableConnected),
+      message: buildScheduleNotification(stored.targetPercentage, startTime, targetTime, isCableConnected),
     });
-
-    device.meta.chargeSchedule = {
-      ...(device.meta.chargeSchedule as StoredChargeSchedule),
-      hasStarted: true,
-    } satisfies StoredChargeSchedule;
-    await device.save();
   }
 }), 15 * 60 * 1000);
 

--- a/server/src/services/vehicle/index.ts
+++ b/server/src/services/vehicle/index.ts
@@ -5,10 +5,17 @@ import { createBackgroundTransaction } from '../../helpers/newrelic';
 import * as client from './client';
 import { processSignal } from './signals';
 import { ensureHistoricalMileage, storeWeeklyMileage } from './mileage';
+import { pickActiveOccurrence, buildScheduleNotification, ChargeScheduleOverride } from './schedule';
 import dayjs from '../../dayjs';
 import logger from '../../logger';
 import nowAndSetIntervalForTime from '../../helpers/now-and-set-interval-for-time';
 import bus, { NOTIFICATION_TO_ADMINS } from '../../bus';
+
+interface StoredChargeSchedule {
+  targetTime: string;
+  calculatedStartTime: string;
+  hasStarted: boolean;
+}
 
 export async function synchronize() {
   let device = await Device.findByProviderId('vehicle', config.smartcar.vehicle_id);
@@ -158,59 +165,91 @@ async function estimateChargeRate(device: Device): Promise<number> {
   return totalPercentageGained / (totalChargingMinutes / 60);
 }
 
-// Run charge schedule check and mileage update every 15 minutes
+// Run charge schedule check every 15 minutes
 nowAndSetInterval(createBackgroundTransaction('vehicle:charge-schedule', async () => {
   const device = await Device.findByProviderIdOrError('vehicle', config.smartcar.vehicle_id);
   const ev = device.getElectricVehicleCapability();
-  const schedule = device.meta.chargeSchedule as { targetPercentage: number; targetTime: string; calculatedStartTime?: string | null } | undefined;
-
-  if (!schedule) {
-    return;
-  }
-
-  const targetTime = dayjs(schedule.targetTime);
   const now = dayjs();
+  const stored = device.meta.chargeSchedule as StoredChargeSchedule | undefined;
 
-  // If target time has passed, clear schedule and reset charge limit
-  if (now.isAfter(targetTime)) {
+  // 1. Roll-over: the occurrence we were tracking has now passed.
+  //    Reset the charge limit and consume the override if it was the source.
+  if (stored && now.isAfter(dayjs(stored.targetTime))) {
     logger.info('Charge schedule target time passed, resetting charge limit');
-    device.meta.chargeSchedule = undefined;
-
-    await device.save();
     await ev.setChargeLimit(config.smartcar.default_charge_limit);
 
+    const override = device.meta.chargeScheduleOverride as ChargeScheduleOverride | null | undefined;
+    if (override && dayjs(override.targetTime).isSame(dayjs(stored.targetTime))) {
+      device.meta.chargeScheduleOverride = null;
+    }
+
+    device.meta.chargeSchedule = undefined;
+    await device.save();
+  }
+
+  // 2. Re-derive the active occurrence from config + override on each tick.
+  const override = (device.meta.chargeScheduleOverride ?? null) as ChargeScheduleOverride | null;
+  const active = pickActiveOccurrence(config.smartcar.chargeSchedules ?? [], override, now);
+
+  if (!active) {
     return;
   }
 
-  const currentPercentage = await ev.getChargePercentage();
+  const previous = device.meta.chargeSchedule as StoredChargeSchedule | undefined;
+  const isNewOccurrence = !previous || previous.targetTime !== active.targetTime.toISOString();
 
-  if (currentPercentage >= schedule.targetPercentage) {
+  if (await ev.getChargePercentage() >= active.targetPercentage) {
+    if (isNewOccurrence) {
+      device.meta.chargeSchedule = {
+        targetTime: active.targetTime.toISOString(),
+        calculatedStartTime: active.targetTime.toISOString(),
+        hasStarted: true,
+      } satisfies StoredChargeSchedule;
+      await device.save();
+    }
+
     return;
   }
 
+  // 3. Recompute calculatedStartTime each cycle (drifts with charge rate / current %).
   const chargeRate = await estimateChargeRate(device);
-  const percentageNeeded = schedule.targetPercentage - currentPercentage;
+  const percentageNeeded = active.targetPercentage - await ev.getChargePercentage();
   const hoursNeeded = percentageNeeded / chargeRate;
   const bufferHours = config.smartcar.charge_start_buffer_hours ?? 0;
-  const startTime = targetTime.subtract(hoursNeeded + bufferHours, 'hour');
+  const startTime = active.targetTime.subtract(hoursNeeded + bufferHours, 'hour');
 
-  device.meta.chargeSchedule = { ...schedule, calculatedStartTime: startTime.toISOString() };
+  const hasStarted = !isNewOccurrence && (previous?.hasStarted ?? false);
+
+  device.meta.chargeSchedule = {
+    targetTime: active.targetTime.toISOString(),
+    calculatedStartTime: startTime.toISOString(),
+    hasStarted,
+  } satisfies StoredChargeSchedule;
   await device.save();
 
-  if (now.isSameOrAfter(startTime)) {
-    logger.info(`Starting charge to reach ${schedule.targetPercentage}% by ${targetTime.format('HH:mm')}`);
+  // 4. Fire start actions exactly once per occurrence.
+  if (now.isSameOrAfter(startTime) && !hasStarted) {
+    logger.info(`Starting charge to reach ${active.targetPercentage}% by ${active.targetTime.format('HH:mm')}`);
 
-    await ev.setChargeLimit(schedule.targetPercentage);
+    await ev.setChargeLimit(active.targetPercentage);
 
     const isCableConnected = await ev.getIsCableConnected();
 
     if (isCableConnected) {
       await ev.setIsCharging(true);
-      bus.emit(NOTIFICATION_TO_ADMINS, { message: `Car charging started: targeting ${schedule.targetPercentage}% by ${targetTime.format('HH:mm')}` });
     } else {
       logger.warn('Charge schedule: cable not connected, cannot start charging');
-      bus.emit(NOTIFICATION_TO_ADMINS, { message: `Car needs to be plugged in to allow scheduled charge to ${schedule.targetPercentage}% by ${targetTime.format('HH:mm')}` });
     }
+
+    bus.emit(NOTIFICATION_TO_ADMINS, {
+      message: buildScheduleNotification(active.targetPercentage, startTime, active.targetTime, isCableConnected),
+    });
+
+    device.meta.chargeSchedule = {
+      ...(device.meta.chargeSchedule as StoredChargeSchedule),
+      hasStarted: true,
+    } satisfies StoredChargeSchedule;
+    await device.save();
   }
 }), 15 * 60 * 1000);
 

--- a/server/src/services/vehicle/index.ts
+++ b/server/src/services/vehicle/index.ts
@@ -1,11 +1,12 @@
 import { Device } from '../../models';
+import { NextChargeSchedule, ManualChargeSchedule } from '../../models/capabilities';
 import config from '../../config';
 import nowAndSetInterval from '../../helpers/now-and-set-interval';
 import { createBackgroundTransaction } from '../../helpers/newrelic';
 import * as client from './client';
 import { processSignal } from './signals';
 import { ensureHistoricalMileage, storeWeeklyMileage } from './mileage';
-import { pickActiveOccurrence, buildScheduleNotification, ChargeScheduleOverride } from './schedule';
+import { pickNextChargeSchedule, buildScheduleNotification, NextChargeOccurrence } from './schedule';
 import dayjs from '../../dayjs';
 import logger from '../../logger';
 import nowAndSetIntervalForTime from '../../helpers/now-and-set-interval-for-time';
@@ -15,6 +16,11 @@ interface StoredChargeSchedule {
   targetTime: string;
   calculatedStartTime: string;
   hasStarted: boolean;
+}
+
+function getNextOccurrenceForDevice(device: Device, now = dayjs()): NextChargeOccurrence | null {
+  const manual = (device.meta.manualChargeSchedule ?? null) as ManualChargeSchedule | null;
+  return pickNextChargeSchedule(config.smartcar.chargeSchedules ?? [], manual, now);
 }
 
 export async function synchronize() {
@@ -80,90 +86,34 @@ Device.registerProvider('vehicle', {
         } else {
           await client.stopCharge();
         }
-      }
+      },
+
+      getNextChargeSchedule(device: Device): NextChargeSchedule | null {
+        const next = getNextOccurrenceForDevice(device);
+        if (!next) return null;
+
+        const stored = device.meta.chargeSchedule as StoredChargeSchedule | undefined;
+        const calculatedStartTime = stored && stored.targetTime === next.targetTime.toISOString()
+          ? stored.calculatedStartTime
+          : null;
+
+        return {
+          targetPercentage: next.targetPercentage,
+          targetTime: next.targetTime.toISOString(),
+          calculatedStartTime,
+        };
+      },
+
+      async setManualChargeSchedule(device: Device, schedule: ManualChargeSchedule | null) {
+        device.meta.manualChargeSchedule = schedule;
+        device.meta.chargeSchedule = undefined;
+        await device.save();
+      },
     };
   },
 
   synchronize,
 });
-
-/**
- * Estimate charge rate from recent charging history.
- * Returns percentage per hour.
- *
- * Algorithm:
- * (a) Find when the cable was plugged in (start of current cable-connected session)
- * (b) Within that window, find periods where IsCharging = true
- * (c) For each charging period, calculate the charge % gained
- * (d) Return total % gained / total hours charging
- * Falls back to config.smartcar.default_charge_rate_pct_per_hour if no usable data.
- */
-async function estimateChargeRate(device: Device): Promise<number> {
-  const fallback = config.smartcar.default_charge_rate_pct_per_hour;
-  const ev = device.getElectricVehicleCapability();
-  const until = new Date();
-
-  // (a) Find the start of the current cable-connected session
-  const cableEvent = await ev.getIsCableConnectedEvent();
-
-  if (!cableEvent || !cableEvent.value) {
-    return fallback;
-  }
-
-  const pluggedInAt = cableEvent.start;
-
-  // (b) Find charging periods within the cable-connected window
-  const [chargingHistory, chargeHistory] = await Promise.all([
-    ev.getIsChargingHistory({ since: pluggedInAt, until }),
-    ev.getChargePercentageHistory({ since: pluggedInAt, until }),
-  ]);
-
-  const chargingPeriods = chargingHistory.filter(p => p.value);
-
-  if (chargingPeriods.length === 0) {
-    return fallback;
-  }
-
-  // (c) For each charging period, find the charge % delta
-  let totalPercentageGained = 0;
-  let totalChargingMinutes = 0;
-
-  for (const period of chargingPeriods) {
-    const periodEnd = period.end ?? until;
-    const periodDurationMinutes = dayjs(periodEnd).diff(period.start, 'minute');
-
-    if (periodDurationMinutes <= 0) {
-      continue;
-    }
-
-    // Find charge readings that fall within this charging period
-    const readings = chargeHistory.filter(r => {
-      const readingEnd = r.end ?? until;
-      return r.start <= periodEnd && readingEnd >= period.start;
-    });
-
-    if (readings.length < 2) {
-      continue;
-    }
-
-    const startCharge = readings[0].value;
-    const endCharge = readings[readings.length - 1].value;
-    const delta = endCharge - startCharge;
-
-    if (delta <= 0) {
-      continue;
-    }
-
-    totalPercentageGained += delta;
-    totalChargingMinutes += periodDurationMinutes;
-  }
-
-  if (totalChargingMinutes === 0 || totalPercentageGained <= 0) {
-    return fallback;
-  }
-
-  return totalPercentageGained / (totalChargingMinutes / 60);
-}
 
 // Run charge schedule check every 15 minutes
 nowAndSetInterval(createBackgroundTransaction('vehicle:charge-schedule', async () => {
@@ -173,36 +123,35 @@ nowAndSetInterval(createBackgroundTransaction('vehicle:charge-schedule', async (
   const stored = device.meta.chargeSchedule as StoredChargeSchedule | undefined;
 
   // 1. Roll-over: the occurrence we were tracking has now passed.
-  //    Reset the charge limit and consume the override if it was the source.
+  //    Reset the charge limit and consume the manual schedule if it was the source.
   if (stored && now.isAfter(dayjs(stored.targetTime))) {
     logger.info('Charge schedule target time passed, resetting charge limit');
     await ev.setChargeLimit(config.smartcar.default_charge_limit);
 
-    const override = device.meta.chargeScheduleOverride as ChargeScheduleOverride | null | undefined;
-    if (override && dayjs(override.targetTime).isSame(dayjs(stored.targetTime))) {
-      device.meta.chargeScheduleOverride = null;
+    const manual = device.meta.manualChargeSchedule as ManualChargeSchedule | null | undefined;
+    if (manual && dayjs(manual.targetTime).isSame(dayjs(stored.targetTime))) {
+      device.meta.manualChargeSchedule = null;
     }
 
     device.meta.chargeSchedule = undefined;
     await device.save();
   }
 
-  // 2. Re-derive the active occurrence from config + override on each tick.
-  const override = (device.meta.chargeScheduleOverride ?? null) as ChargeScheduleOverride | null;
-  const active = pickActiveOccurrence(config.smartcar.chargeSchedules ?? [], override, now);
+  // 2. Re-derive the next occurrence from config + manual schedule on each tick.
+  const next = getNextOccurrenceForDevice(device, now);
 
-  if (!active) {
+  if (!next) {
     return;
   }
 
   const previous = device.meta.chargeSchedule as StoredChargeSchedule | undefined;
-  const isNewOccurrence = !previous || previous.targetTime !== active.targetTime.toISOString();
+  const isNewOccurrence = !previous || previous.targetTime !== next.targetTime.toISOString();
 
-  if (await ev.getChargePercentage() >= active.targetPercentage) {
+  if (await ev.getChargePercentage() >= next.targetPercentage) {
     if (isNewOccurrence) {
       device.meta.chargeSchedule = {
-        targetTime: active.targetTime.toISOString(),
-        calculatedStartTime: active.targetTime.toISOString(),
+        targetTime: next.targetTime.toISOString(),
+        calculatedStartTime: next.targetTime.toISOString(),
         hasStarted: true,
       } satisfies StoredChargeSchedule;
       await device.save();
@@ -211,17 +160,17 @@ nowAndSetInterval(createBackgroundTransaction('vehicle:charge-schedule', async (
     return;
   }
 
-  // 3. Recompute calculatedStartTime each cycle (drifts with charge rate / current %).
-  const chargeRate = await estimateChargeRate(device);
-  const percentageNeeded = active.targetPercentage - await ev.getChargePercentage();
+  // 3. Recompute calculatedStartTime each cycle (drifts with current %).
+  const chargeRate = config.smartcar.default_charge_rate_pct_per_hour;
+  const percentageNeeded = next.targetPercentage - await ev.getChargePercentage();
   const hoursNeeded = percentageNeeded / chargeRate;
   const bufferHours = config.smartcar.charge_start_buffer_hours ?? 0;
-  const startTime = active.targetTime.subtract(hoursNeeded + bufferHours, 'hour');
+  const startTime = next.targetTime.subtract(hoursNeeded + bufferHours, 'hour');
 
   const hasStarted = !isNewOccurrence && (previous?.hasStarted ?? false);
 
   device.meta.chargeSchedule = {
-    targetTime: active.targetTime.toISOString(),
+    targetTime: next.targetTime.toISOString(),
     calculatedStartTime: startTime.toISOString(),
     hasStarted,
   } satisfies StoredChargeSchedule;
@@ -229,9 +178,9 @@ nowAndSetInterval(createBackgroundTransaction('vehicle:charge-schedule', async (
 
   // 4. Fire start actions exactly once per occurrence.
   if (now.isSameOrAfter(startTime) && !hasStarted) {
-    logger.info(`Starting charge to reach ${active.targetPercentage}% by ${active.targetTime.format('HH:mm')}`);
+    logger.info(`Starting charge to reach ${next.targetPercentage}% by ${next.targetTime.format('HH:mm')}`);
 
-    await ev.setChargeLimit(active.targetPercentage);
+    await ev.setChargeLimit(next.targetPercentage);
 
     const isCableConnected = await ev.getIsCableConnected();
 
@@ -242,7 +191,7 @@ nowAndSetInterval(createBackgroundTransaction('vehicle:charge-schedule', async (
     }
 
     bus.emit(NOTIFICATION_TO_ADMINS, {
-      message: buildScheduleNotification(active.targetPercentage, startTime, active.targetTime, isCableConnected),
+      message: buildScheduleNotification(next.targetPercentage, startTime, next.targetTime, isCableConnected),
     });
 
     device.meta.chargeSchedule = {

--- a/server/src/services/vehicle/schedule.ts
+++ b/server/src/services/vehicle/schedule.ts
@@ -3,7 +3,6 @@ import { getNextOccurrence } from '../../helpers/recurrence';
 import { humanDate } from '../../helpers/date';
 
 export interface ChargeScheduleConfig {
-  id: string;
   target_percentage: number;
   target_time_of_day: string;
   anchor_date: string;

--- a/server/src/services/vehicle/schedule.ts
+++ b/server/src/services/vehicle/schedule.ts
@@ -1,14 +1,13 @@
 import dayjs, { Dayjs } from '../../dayjs';
 import { getNextOccurrence } from '../../helpers/recurrence';
 import { humanDate } from '../../helpers/date';
-import { ManualChargeSchedule } from '../../models/capabilities';
 
 export interface ChargeScheduleConfig {
   id: string;
-  targetPercentage: number;
-  targetTimeOfDay: string;
-  anchorDate: string;
-  intervalWeeks: number;
+  target_percentage: number;
+  target_time_of_day: string;
+  anchor_date: string;
+  interval_weeks: number;
 }
 
 export interface NextChargeOccurrence {
@@ -18,27 +17,19 @@ export interface NextChargeOccurrence {
 
 export function pickNextChargeSchedule(
   schedules: ChargeScheduleConfig[],
-  manual: ManualChargeSchedule | null,
   now: Dayjs,
 ): NextChargeOccurrence | null {
-  if (manual && dayjs(manual.targetTime).isAfter(now)) {
-    return {
-      targetPercentage: manual.targetPercentage,
-      targetTime: dayjs(manual.targetTime),
-    };
-  }
-
   const candidates = schedules.map(s => {
-    const day = getNextOccurrence(s.anchorDate, s.intervalWeeks, now);
-    const [hh, mm] = s.targetTimeOfDay.split(':').map(Number);
+    const day = getNextOccurrence(s.anchor_date, s.interval_weeks, now);
+    const [hh, mm] = s.target_time_of_day.split(':').map(Number);
     let target = day.hour(hh).minute(mm).second(0).millisecond(0);
 
     if (target.isBefore(now)) {
-      target = target.add(s.intervalWeeks * 7, 'day');
+      target = target.add(s.interval_weeks * 7, 'day');
     }
 
     return {
-      targetPercentage: s.targetPercentage,
+      targetPercentage: s.target_percentage,
       targetTime: target,
     };
   });

--- a/server/src/services/vehicle/schedule.ts
+++ b/server/src/services/vehicle/schedule.ts
@@ -1,6 +1,7 @@
 import dayjs, { Dayjs } from '../../dayjs';
 import { getNextOccurrence } from '../../helpers/recurrence';
 import { humanDate } from '../../helpers/date';
+import { ManualChargeSchedule } from '../../models/capabilities';
 
 export interface ChargeScheduleConfig {
   id: string;
@@ -10,29 +11,20 @@ export interface ChargeScheduleConfig {
   intervalWeeks: number;
 }
 
-export interface ChargeScheduleOverride {
-  targetPercentage: number;
-  targetTime: string;
-}
-
-export interface ActiveOccurrence {
-  source: 'config' | 'override';
-  scheduleId: string | null;
+export interface NextChargeOccurrence {
   targetPercentage: number;
   targetTime: Dayjs;
 }
 
-export function pickActiveOccurrence(
+export function pickNextChargeSchedule(
   schedules: ChargeScheduleConfig[],
-  override: ChargeScheduleOverride | null,
+  manual: ManualChargeSchedule | null,
   now: Dayjs,
-): ActiveOccurrence | null {
-  if (override && dayjs(override.targetTime).isAfter(now)) {
+): NextChargeOccurrence | null {
+  if (manual && dayjs(manual.targetTime).isAfter(now)) {
     return {
-      source: 'override',
-      scheduleId: null,
-      targetPercentage: override.targetPercentage,
-      targetTime: dayjs(override.targetTime),
+      targetPercentage: manual.targetPercentage,
+      targetTime: dayjs(manual.targetTime),
     };
   }
 
@@ -46,8 +38,6 @@ export function pickActiveOccurrence(
     }
 
     return {
-      source: 'config' as const,
-      scheduleId: s.id,
       targetPercentage: s.targetPercentage,
       targetTime: target,
     };

--- a/server/src/services/vehicle/schedule.ts
+++ b/server/src/services/vehicle/schedule.ts
@@ -1,0 +1,77 @@
+import dayjs, { Dayjs } from '../../dayjs';
+import { getNextOccurrence } from '../../helpers/recurrence';
+import { humanDate } from '../../helpers/date';
+
+export interface ChargeScheduleConfig {
+  id: string;
+  targetPercentage: number;
+  targetTimeOfDay: string;
+  anchorDate: string;
+  intervalWeeks: number;
+}
+
+export interface ChargeScheduleOverride {
+  targetPercentage: number;
+  targetTime: string;
+}
+
+export interface ActiveOccurrence {
+  source: 'config' | 'override';
+  scheduleId: string | null;
+  targetPercentage: number;
+  targetTime: Dayjs;
+}
+
+export function pickActiveOccurrence(
+  schedules: ChargeScheduleConfig[],
+  override: ChargeScheduleOverride | null,
+  now: Dayjs,
+): ActiveOccurrence | null {
+  if (override && dayjs(override.targetTime).isAfter(now)) {
+    return {
+      source: 'override',
+      scheduleId: null,
+      targetPercentage: override.targetPercentage,
+      targetTime: dayjs(override.targetTime),
+    };
+  }
+
+  const candidates = schedules.map(s => {
+    const day = getNextOccurrence(s.anchorDate, s.intervalWeeks, now);
+    const [hh, mm] = s.targetTimeOfDay.split(':').map(Number);
+    let target = day.hour(hh).minute(mm).second(0).millisecond(0);
+
+    if (target.isBefore(now)) {
+      target = target.add(s.intervalWeeks * 7, 'day');
+    }
+
+    return {
+      source: 'config' as const,
+      scheduleId: s.id,
+      targetPercentage: s.targetPercentage,
+      targetTime: target,
+    };
+  });
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  candidates.sort((a, b) => a.targetTime.diff(b.targetTime));
+  return candidates[0];
+}
+
+export function buildScheduleNotification(
+  targetPercentage: number,
+  startTime: Dayjs,
+  targetTime: Dayjs,
+  cableConnected: boolean,
+): string {
+  const startStr = `${startTime.format('HH:mm')} ${humanDate(startTime)}`;
+  const targetStr = `${targetTime.format('HH:mm')} ${humanDate(targetTime)}`;
+  const tail = `scheduled charge start at ${startStr} and get to ${targetPercentage}% by ${targetStr}`;
+
+  return cableConnected
+    ? `Car charging started: ${tail}`
+    : `Car needs to be plugged in to allow ${tail}`;
+}

--- a/server/src/services/vehicle/signals.ts
+++ b/server/src/services/vehicle/signals.ts
@@ -1,5 +1,5 @@
 import type { SmartcarSignalAttributes, SmartcarSuccessSignalAttributes } from 'smartcar';
-import { ElectricVehicleCapability } from '../../models/capabilities/capabilities.gen';
+import { ElectricVehicleCapability } from '../../models/capabilities';
 import logger from '../../logger';
 
 const KM_TO_MILES = 0.621371;


### PR DESCRIPTION
## Summary

- **Recurring schedules** — `config.smartcar.chargeSchedules` now defines recurring charge schedules using the same `anchorDate + intervalWeeks` shape as `config.bins`. The recurrence helpers (`getNextOccurrence`, `isOccurrenceDay`, `buildRruleString`) are extracted from `bin-collection.ts` into `helpers/recurrence.ts` so vehicle can reuse them.
- **Override semantics** — `PUT /api/device/:id/vehicle` still accepts a one-shot override (renamed `chargeSchedule` → `chargeScheduleOverride`). When set, the override **is** the next charge schedule; any config occurrences between now and the override's `targetTime` are cancelled. Once consumed, config resumes.
- **Idempotent start** — `device.meta.chargeSchedule` is now minimal (`{ targetTime, calculatedStartTime, hasStarted }`); the active occurrence (source/scheduleId/targetPercentage) is re-derived from config + override on every tick. `hasStarted` gates `setChargeLimit`, `setIsCharging`, and the notification so each fires exactly once per occurrence — fixing the bug where the SmartCar API was hit and the user notified every 15 minutes.
- **Notification copy** — now includes both the calculated start time and the target time using `humanDate`, e.g. _"Car needs to be plugged in to allow scheduled charge start at 10:42 today and get to 100% by 10:00 on Tue 5th"_.

## Test plan

- [x] `npm run codegen && npm run lint && npm run test && npm run build` all pass
- [x] New Jest tests cover `getNextOccurrence` (anchor-in-future, anchor-today, weekly roll, biweekly roll, multiple periods elapsed) and `isOccurrenceDay`
- [ ] End-to-end: add an entry to `config.smartcar.chargeSchedules`, restart, confirm `chargeSchedule.source === 'config'` on the device response
- [ ] PUT an override **sooner** than the next config slot — confirm `chargeSchedule.source === 'override'`
- [ ] PUT an override **later** than the next config slot — confirm `chargeSchedule.source === 'override'` (config slot was cancelled), and that after the override passes, config resumes
- [ ] PUT `chargeScheduleOverride: null` — confirm immediate revert to config
- [ ] Idempotency: tick the task twice past `calculatedStartTime`; confirm `setChargeLimit` invoked once and a single notification fires
- [ ] Roll-over: let an override's `targetTime` pass; confirm `setChargeLimit(default_charge_limit)` is called once, the override is cleared, and `chargeSchedule` re-derives from config (or stays `null` if config empty)


---
_Generated by [Claude Code](https://claude.ai/code/session_01U3MD3Ru3PkaQSijSp2A67y)_