### PR TITLE
Simplify heating automation rules and add temperature delta insight

### DIFF
--- a/server/src/api/types.ts
+++ b/server/src/api/types.ts
@@ -282,7 +282,7 @@ export interface HeatingInsightsApiResponse {
   lines: (HistoryLineApiResponse & { deviceName: string })[];
   modes: HistoryModesApiResponse;
   temperatureDeltas: (HistoryLineApiResponse & { deviceName: string })[];
-  heatPump: { id: number; name: string } | null;
+  heatPump: { id: number; name: string };
 }
 
 export interface DeviceUpdateEvent {

--- a/server/src/api/types.ts
+++ b/server/src/api/types.ts
@@ -281,6 +281,8 @@ export interface TimelineFeedApiResponse {
 export interface HeatingInsightsApiResponse {
   lines: (HistoryLineApiResponse & { deviceName: string })[];
   modes: HistoryModesApiResponse;
+  temperatureDeltas: (HistoryLineApiResponse & { deviceName: string })[];
+  heatPump: { id: number; name: string } | null;
 }
 
 export interface DeviceUpdateEvent {

--- a/server/src/automations/heating.ts
+++ b/server/src/automations/heating.ts
@@ -7,131 +7,87 @@ import { asyncFilterAndMap } from '../helpers/array';
 type HeatingAutomationParameters = {
   heatingSwitchName: string;
   temperatureDeltaSwitchOnThreshold: number;
-  temperatureDeltaSwitchOffThreshold: number;
-  heatPumpDeviceName: string;
-  compressorCooldownPeriodInMinutes: number;
 };
 
-let compressorLockedOutForCooldown = false;
+export default function ({ heatingSwitchName, temperatureDeltaSwitchOnThreshold }: HeatingAutomationParameters) {
+  async function evaluateTurnOn(triggeringDevice: Device) {
+    if (await triggeringDevice.getThermostatCapability().getIsPassive()) {
+      return;
+    }
 
-export default function ({ heatingSwitchName, temperatureDeltaSwitchOffThreshold, temperatureDeltaSwitchOnThreshold, heatPumpDeviceName, compressorCooldownPeriodInMinutes }: HeatingAutomationParameters) {
-  function lockoutCompressor() {
-    compressorLockedOutForCooldown = true;
+    const target = await triggeringDevice.getThermostatCapability().getTargetTemperature();
+    const current = await triggeringDevice.getThermostatCapability().getCurrentTemperature();
+    const delta = target - current;
 
-    setTimeout(async () => {
-      if (compressorLockedOutForCooldown === true) {
-        const heatingDevice = await Device.findByNameOrError(heatingSwitchName);
-        const thermostats = await Device.findByCapability('THERMOSTAT');
-        const thermostatsHeatDemand = await asyncFilterAndMap(
-          thermostats,
-          async t => !await t.getThermostatCapability().getIsPassive(),
-          t => t.getThermostatCapability().getIsOn()
-        );
-        const thermostatsAreRequestingHeat = thermostatsHeatDemand.some(x => x);
+    if (delta <= temperatureDeltaSwitchOnThreshold) {
+      return;
+    }
 
-        compressorLockedOutForCooldown = false;
+    const heatingDevice = await Device.findByNameOrError(heatingSwitchName);
 
-        if (thermostatsAreRequestingHeat) {
-          await heatingDevice.getSwitchCapability().setIsOn(true);
-        }
+    if (await heatingDevice.getSwitchCapability().getIsOn()) {
+      return;
+    }
 
-        bus.emit(NOTIFICATION_TO_ADMINS, {
-          message: `Heat pump lockout ended.${thermostatsAreRequestingHeat ? ' Turning heating on as thermostats are requesting heat' : ''}`
-        });
-      }
-    }, compressorCooldownPeriodInMinutes * 60 * 1000);
+    await heatingDevice.getSwitchCapability().setIsOn(true);
+
+    bus.emit(NOTIFICATION_TO_ADMINS, {
+      message: `Turning heating on, as ${triggeringDevice.name} is ${delta.toFixed(1)}° below target of ${target}°C`
+    });
   }
 
-  /**
-   * @returns < 0 === How many degrees below target temperature. > 0 === How many degrees above target temperature
-   */
-  async function getLargestTemperatureDelta() {
-    const thermostats = await Device.findByCapability('THERMOSTAT');
-    const temperatureDeltas = await asyncFilterAndMap(
+  async function evaluateTurnOff() {
+    const heatingDevice = await Device.findByNameOrError(heatingSwitchName);
+
+    if (!await heatingDevice.getSwitchCapability().getIsOn()) {
+      return;
+    }
+
+    const [thermostats, heatPumps] = await Promise.all([
+      Device.findByCapability('THERMOSTAT'),
+      Device.findByCapability('HEAT_PUMP')
+    ]);
+
+    if (heatPumps.length === 0) {
+      return;
+    }
+
+    const compressorModulation = await heatPumps[0].getHeatPumpCapability().getCompressorModulation();
+
+    if (compressorModulation !== 0) {
+      return;
+    }
+
+    const nonPassivePowers = await asyncFilterAndMap(
       thermostats,
       async t => !await t.getThermostatCapability().getIsPassive(),
-      async t => await t.getThermostatCapability().getCurrentTemperature() - await t.getThermostatCapability().getTargetTemperature()
+      t => t.getThermostatCapability().getPower()
     );
 
-    return Math.min(...temperatureDeltas);
+    if (!nonPassivePowers.every(p => p === 0)) {
+      return;
+    }
+
+    await heatingDevice.getSwitchCapability().setIsOn(false);
+
+    bus.emit(NOTIFICATION_TO_ADMINS, {
+      message: 'Turning heating off, as heat pump has modulated to 0 and no thermostats are requesting heat'
+    });
   }
 
-  DeviceCapabilityEvents.onThermostatPowerChanged(createBackgroundTransaction('automations:heating:thermostat-power-changed', async (event) => {
-    const thermostat = await event.getDevice();
-
-    if (await thermostat.getThermostatCapability().getIsPassive()) {
-      return;
-    }
-
-    const heatingDevice = await Device.findByNameOrError(heatingSwitchName);
-    const heatingIsOn = await heatingDevice.getSwitchCapability().getIsOn();
-    const thermostatIsOn = event.value > 0;
-
-    // On power change, if any heating demand, then turn on.
-    if (thermostatIsOn) {
-      if (!heatingIsOn && !compressorLockedOutForCooldown) {
-        await heatingDevice.getSwitchCapability().setIsOn(true);
-
-        bus.emit(NOTIFICATION_TO_ADMINS, {
-          message: `Turning heating on, as ${thermostat.name} is requesting heat (${event.value}%)`
-        });
-      }
-
-    // On power change to 0, if no thermostats within X degrees, then turn off
-    } else {
-      const maximumTemperatureDelta = await getLargestTemperatureDelta();
-
-      if (maximumTemperatureDelta > temperatureDeltaSwitchOffThreshold && heatingIsOn) {
-        await heatingDevice.getSwitchCapability().setIsOn(false);
-
-        bus.emit(NOTIFICATION_TO_ADMINS, { 
-          message: `Turning heating off, as no thermostats are within ${temperatureDeltaSwitchOffThreshold}° of their target temperature`
-        });
-      }
-    }
+  DeviceCapabilityEvents.onThermostatCurrentTemperatureChanged(createBackgroundTransaction('automations:heating:thermostat-current-temperature-changed', async (event) => {
+    await evaluateTurnOn(await event.getDevice());
   }));
 
-  DeviceCapabilityEvents.onThermostatCurrentTemperatureChanged(createBackgroundTransaction('automations:heating:thermostat-temperature-changed', async (event) => {
-    const thermostat = await event.getDevice();
-
-    if (await thermostat.getThermostatCapability().getIsPassive()) {
-      return;
-    }
-
-    const heatingDevice = await Device.findByNameOrError(heatingSwitchName);
-    const target = await thermostat.getThermostatCapability().getTargetTemperature();
-    const temperatureDelta = target - event.value;
-
-    if (temperatureDelta > temperatureDeltaSwitchOnThreshold && compressorLockedOutForCooldown) {
-      await heatingDevice.getSwitchCapability().setIsOn(true);
-
-      compressorLockedOutForCooldown = false;
-
-      bus.emit(NOTIFICATION_TO_ADMINS, {
-        message: `Ending lockout and turning heating on, as ${thermostat.name} is ${temperatureDelta.toFixed(1)}° below target of ${target}°C`
-      });
-    }
+  DeviceCapabilityEvents.onThermostatTargetTemperatureChanged(createBackgroundTransaction('automations:heating:thermostat-target-temperature-changed', async (event) => {
+    await evaluateTurnOn(await event.getDevice());
   }));
 
-  DeviceCapabilityEvents.onHeatPumpCompressorModulationChanged(createBackgroundTransaction('automations:heating:compressor-modulation-changed', async (event) => {
-    const heatingDevice = await Device.findByNameOrError(heatingSwitchName);
-    const heatingIsOn = await heatingDevice.getSwitchCapability().getIsOn();
+  DeviceCapabilityEvents.onThermostatPowerChanged(createBackgroundTransaction('automations:heating:thermostat-power-changed', async () => {
+    await evaluateTurnOff();
+  }));
 
-    // Either because we have already turned heat demand off from above, or there is not enough heat demand to keep
-    // the heat pump on, so turn it off.
-    if (event.value === 0 && heatingIsOn) {
-      const maximumTemperatureDelta = await getLargestTemperatureDelta();
-
-      // ... but only if all rooms are warm enough, otherwise the above condition will just switch the heating on again.
-      if (maximumTemperatureDelta > temperatureDeltaSwitchOnThreshold) {
-        await heatingDevice.getSwitchCapability().setIsOn(false);
-        
-        lockoutCompressor();
-
-        bus.emit(NOTIFICATION_TO_ADMINS, {
-          message: `Turning heating off, and locking out for max ${compressorCooldownPeriodInMinutes} minutes as heat pump compressor has modulated down to 0`
-        });
-      }
-    }
+  DeviceCapabilityEvents.onHeatPumpCompressorModulationChanged(createBackgroundTransaction('automations:heating:heat-pump-compressor-modulation-changed', async () => {
+    await evaluateTurnOff();
   }));
 }

--- a/server/src/automations/heating.ts
+++ b/server/src/automations/heating.ts
@@ -48,10 +48,6 @@ export default function ({ heatingSwitchName, temperatureDeltaSwitchOnThreshold 
       Device.findByCapability('HEAT_PUMP')
     ]);
 
-    if (heatPumps.length === 0) {
-      throw new Error('Heating automation: expected at least one HEAT_PUMP device, but none were found');
-    }
-
     const compressorModulation = await heatPumps[0].getHeatPumpCapability().getCompressorModulation();
 
     if (compressorModulation !== 0) {

--- a/server/src/automations/heating.ts
+++ b/server/src/automations/heating.ts
@@ -49,7 +49,7 @@ export default function ({ heatingSwitchName, temperatureDeltaSwitchOnThreshold 
     ]);
 
     if (heatPumps.length === 0) {
-      return;
+      throw new Error('Heating automation: expected at least one HEAT_PUMP device, but none were found');
     }
 
     const compressorModulation = await heatPumps[0].getHeatPumpCapability().getCompressorModulation();

--- a/server/src/components/pages/insights-heating.tsx
+++ b/server/src/components/pages/insights-heating.tsx
@@ -52,20 +52,14 @@ function HeatPumpLink() {
     return null;
   }
 
-  const links = forDeviceCapability(data.devices, 'HEAT_PUMP', (device) => (
-    <Anchor key={device.id} component={Link} to={`/device/${device.id}`}>
-      {device.name}
-    </Anchor>
-  ));
-
-  if (links.length === 0) {
-    return null;
-  }
-
   return (
     <Group gap="xs" mt="md">
       <Text size="sm" c="dimmed">Heat pump:</Text>
-      {links}
+      {forDeviceCapability(data.devices, 'HEAT_PUMP', (device) => (
+        <Anchor key={device.id} component={Link} to={`/device/${device.id}`}>
+          {device.name}
+        </Anchor>
+      ))}
     </Group>
   );
 }

--- a/server/src/components/pages/insights-heating.tsx
+++ b/server/src/components/pages/insights-heating.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Anchor, Badge, Box, Table, Title } from '@mantine/core';
+import { Anchor, Badge, Box, Group, Table, Text, Title } from '@mantine/core';
 import useApiCall from '../../hooks/api';
 import { useDevices } from '../../hooks/queries/use-devices';
 import { DateRangeProvider, DateRangeSelector, useDateRange } from '../date-range';
@@ -45,11 +45,42 @@ function ThermostatTable() {
   );
 }
 
+function HeatPumpLink() {
+  const { data, isLoading } = useDevices();
+
+  if (isLoading || !data) {
+    return null;
+  }
+
+  const links = forDeviceCapability(data.devices, 'HEAT_PUMP', (device) => (
+    <Anchor key={device.id} component={Link} to={`/device/${device.id}`}>
+      {device.name}
+    </Anchor>
+  ));
+
+  if (links.length === 0) {
+    return null;
+  }
+
+  return (
+    <Group gap="xs" mt="md">
+      <Text size="sm" c="dimmed">Heat pump:</Text>
+      {links}
+    </Group>
+  );
+}
+
 const yAxisPercentage = {
   yPercentage: {
     position: 'left' as const,
     min: 0,
     max: 100
+  }
+};
+
+const yAxisDelta = {
+  yDelta: {
+    position: 'left' as const
   }
 };
 
@@ -90,6 +121,12 @@ function HeatingDemandGraph() {
         lines={data.lines}
         yAxis={yAxisPercentage}
       />
+
+      <Title order={4} mt="lg">Temperature delta (current − target)</Title>
+      <CapabilityGraph
+        lines={data.temperatureDeltas}
+        yAxis={yAxisDelta}
+      />
     </>
   );
 }
@@ -100,6 +137,7 @@ export default function HeatingInsights() {
       <Title order={2}>Heating</Title>
 
       <ThermostatTable />
+      <HeatPumpLink />
 
       <DateRangeProvider>
         <Box mt="md">

--- a/server/src/helpers/array.ts
+++ b/server/src/helpers/array.ts
@@ -19,3 +19,7 @@ export async function asyncFilterAndMap<T, U>(arr: T[], predicate: (item: T) => 
   const filtered = await asyncFilter(arr, predicate);
   return Promise.all(filtered.map(mapper));
 }
+
+export function asyncMap<T, U>(arr: T[], mapper: (item: T) => Promise<U>): Promise<U[]> {
+  return Promise.all(arr.map(mapper));
+}

--- a/server/src/helpers/promises.ts
+++ b/server/src/helpers/promises.ts
@@ -1,0 +1,11 @@
+type AwaitedObject<T> = {
+  [K in keyof T]: T[K] extends Promise<infer U> ? U : T[K];
+};
+
+export async function awaitPromises<T extends Record<string, unknown>>(obj: T): Promise<AwaitedObject<T>> {
+  const entries = await Promise.all(
+    Object.entries(obj).map(async ([key, value]) => [key, await value])
+  );
+
+  return Object.fromEntries(entries) as AwaitedObject<T>;
+}

--- a/server/src/routes/api/device-helpers.ts
+++ b/server/src/routes/api/device-helpers.ts
@@ -1,18 +1,9 @@
 import { Device, NumericEvent, BooleanEvent } from '../../models';
 import { NumericEventApiResponse, BooleanEventApiResponse, EnumEventApiResponse, RestDeviceResponse, CapabilityApiResponse } from '../../api/types';
 import dayjs from '../../dayjs';
+import { awaitPromises } from '../../helpers/promises';
 
-type AwaitedObject<T> = {
-  [K in keyof T]: T[K] extends Promise<infer U> ? U : T[K];
-};
-
-export async function awaitPromises<T extends Record<string, unknown>>(obj: T): Promise<AwaitedObject<T>> {
-  const entries = await Promise.all(
-    Object.entries(obj).map(async ([key, value]) => [key, await value])
-  );
-
-  return Object.fromEntries(entries) as AwaitedObject<T>;
-}
+export { awaitPromises };
 
 export function mapNumericEvent(eventPromise: Promise<NumericEvent | null>): Promise<NumericEventApiResponse> {
   return eventPromise.then(event => {

--- a/server/src/routes/api/device-helpers.ts
+++ b/server/src/routes/api/device-helpers.ts
@@ -3,8 +3,6 @@ import { NumericEventApiResponse, BooleanEventApiResponse, EnumEventApiResponse,
 import dayjs from '../../dayjs';
 import { awaitPromises } from '../../helpers/promises';
 
-export { awaitPromises };
-
 export function mapNumericEvent(eventPromise: Promise<NumericEvent | null>): Promise<NumericEventApiResponse> {
   return eventPromise.then(event => {
     if (!event) {

--- a/server/src/routes/api/insights/heating.ts
+++ b/server/src/routes/api/insights/heating.ts
@@ -1,7 +1,58 @@
-import { Device } from '../../../models';
+import { Device, NumericEvent } from '../../../models';
 import { Request, Response } from 'express';
-import { HeatingInsightsApiResponse } from '../../../api/types';
+import { HeatingInsightsApiResponse, HistoryDetailsApiResponse, NumericEventApiResponse } from '../../../api/types';
+import { TimeRangeSelector } from '../../../models/capabilities/helpers';
 import { mapNumericHistoryToResponse, mapEnumHistoryToResponse } from '../history-helpers';
+
+function findEventAt(events: NumericEvent[], t: number): NumericEvent | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.start.getTime() <= t && (e.end === null || e.end.getTime() > t)) {
+      return e;
+    }
+  }
+  return null;
+}
+
+function computeTemperatureDelta(
+  currentEvents: NumericEvent[],
+  targetEvents: NumericEvent[],
+  selector: TimeRangeSelector
+): HistoryDetailsApiResponse<NumericEventApiResponse> {
+  const since = selector.since.getTime();
+  const until = selector.until.getTime();
+  const changePoints = new Set<number>();
+
+  for (const e of currentEvents) changePoints.add(Math.max(e.start.getTime(), since));
+  for (const e of targetEvents) changePoints.add(Math.max(e.start.getTime(), since));
+
+  const sorted = [...changePoints].sort((a, b) => a - b);
+  const history: NumericEventApiResponse[] = [];
+
+  for (let k = 0; k < sorted.length; k++) {
+    const segStart = sorted[k];
+    if (segStart >= until) break;
+
+    const segEnd = k + 1 < sorted.length ? Math.min(sorted[k + 1], until) : until;
+    const cur = findEventAt(currentEvents, segStart);
+    const tgt = findEventAt(targetEvents, segStart);
+
+    if (cur && tgt) {
+      history.push({
+        start: new Date(segStart).toISOString(),
+        end: new Date(segEnd).toISOString(),
+        lastReported: new Date(Math.max(cur.lastReported.getTime(), tgt.lastReported.getTime())).toISOString(),
+        value: Number((cur.value - tgt.value).toFixed(2))
+      });
+    }
+  }
+
+  return {
+    history,
+    since: selector.since.toISOString(),
+    until: selector.until.toISOString()
+  };
+}
 
 export default async function (req: Request, res: Response) {
   const selector = {
@@ -16,7 +67,7 @@ export default async function (req: Request, res: Response) {
 
   const heatpump = heatpumps[0].getHeatPumpCapability();
 
-  const [lines, modesData] = await Promise.all([
+  const [lines, modesData, temperatureDeltas] = await Promise.all([
     Promise.all(
       thermostats.map(async (device) => {
         const thermostat = device.getThermostatCapability();
@@ -38,6 +89,24 @@ export default async function (req: Request, res: Response) {
       (hs) => heatpump.getModeHistory(hs),
       selector,
       { 0: 'UNKNOWN', 1: 'STANDBY', 2: 'HEATING', 3: 'DHW', 4: 'DEICING', 5: 'FROST_PROTECTION' }
+    ),
+    Promise.all(
+      thermostats.map(async (device) => {
+        const thermostat = device.getThermostatCapability();
+        const [currentEvents, targetEvents, isPassive] = await Promise.all([
+          thermostat.getCurrentTemperatureHistory(selector),
+          thermostat.getTargetTemperatureHistory(selector),
+          thermostat.getIsPassive()
+        ]);
+
+        return {
+          data: computeTemperatureDelta(currentEvents, targetEvents, selector),
+          label: device.name,
+          deviceName: device.name,
+          yAxisID: 'yDelta',
+          borderDash: isPassive ? [5, 5] : undefined
+        };
+      })
     )
   ]);
 
@@ -51,7 +120,9 @@ export default async function (req: Request, res: Response) {
         { value: 'FROST_PROTECTION', label: 'Frost Protection' },
         { value: 'DHW', label: 'Hot Water' }
       ]
-    }
+    },
+    temperatureDeltas,
+    heatPump: heatpumps[0] ? { id: heatpumps[0].id, name: heatpumps[0].name } : null
   };
 
   res.json(response);

--- a/server/src/routes/api/insights/heating.ts
+++ b/server/src/routes/api/insights/heating.ts
@@ -72,10 +72,10 @@ export default async function (req: Request, res: Response) {
   const { lines, modesData, temperatureDeltas } = await awaitPromises({
     lines: asyncMap(thermostats, async (device) => {
       const thermostat = device.getThermostatCapability();
-      const { data, isPassive } = await awaitPromises({
-        data: mapNumericHistoryToResponse((hs) => thermostat.getPowerHistory(hs), selector),
-        isPassive: thermostat.getIsPassive()
-      });
+      const [data, isPassive] = await Promise.all([
+        mapNumericHistoryToResponse((hs) => thermostat.getPowerHistory(hs), selector),
+        thermostat.getIsPassive()
+      ]);
 
       return {
         data,
@@ -92,11 +92,11 @@ export default async function (req: Request, res: Response) {
     ),
     temperatureDeltas: asyncMap(thermostats, async (device) => {
       const thermostat = device.getThermostatCapability();
-      const { currentEvents, targetEvents, isPassive } = await awaitPromises({
-        currentEvents: thermostat.getCurrentTemperatureHistory(selector),
-        targetEvents: thermostat.getTargetTemperatureHistory(selector),
-        isPassive: thermostat.getIsPassive()
-      });
+      const [currentEvents, targetEvents, isPassive] = await Promise.all([
+        thermostat.getCurrentTemperatureHistory(selector),
+        thermostat.getTargetTemperatureHistory(selector),
+        thermostat.getIsPassive()
+      ]);
 
       return {
         data: computeTemperatureDelta(currentEvents, targetEvents, selector),

--- a/server/src/routes/api/insights/heating.ts
+++ b/server/src/routes/api/insights/heating.ts
@@ -3,6 +3,8 @@ import { Request, Response } from 'express';
 import { HeatingInsightsApiResponse, HistoryDetailsApiResponse, NumericEventApiResponse } from '../../../api/types';
 import { TimeRangeSelector } from '../../../models/capabilities/helpers';
 import { mapNumericHistoryToResponse, mapEnumHistoryToResponse } from '../history-helpers';
+import { awaitPromises } from '../../../helpers/promises';
+import { asyncMap } from '../../../helpers/array';
 
 function findEventAt(events: NumericEvent[], t: number): NumericEvent | null {
   for (let i = events.length - 1; i >= 0; i--) {
@@ -67,48 +69,44 @@ export default async function (req: Request, res: Response) {
 
   const heatpump = heatpumps[0].getHeatPumpCapability();
 
-  const [lines, modesData, temperatureDeltas] = await Promise.all([
-    Promise.all(
-      thermostats.map(async (device) => {
-        const thermostat = device.getThermostatCapability();
-        const [data, isPassive] = await Promise.all([
-          mapNumericHistoryToResponse((hs) => thermostat.getPowerHistory(hs), selector),
-          thermostat.getIsPassive()
-        ]);
+  const { lines, modesData, temperatureDeltas } = await awaitPromises({
+    lines: asyncMap(thermostats, async (device) => {
+      const thermostat = device.getThermostatCapability();
+      const { data, isPassive } = await awaitPromises({
+        data: mapNumericHistoryToResponse((hs) => thermostat.getPowerHistory(hs), selector),
+        isPassive: thermostat.getIsPassive()
+      });
 
-        return {
-          data,
-          label: device.name,
-          deviceName: device.name,
-          yAxisID: 'yPercentage',
-          borderDash: isPassive ? [5, 5] : undefined
-        };
-      })
-    ),
-    mapEnumHistoryToResponse(
+      return {
+        data,
+        label: device.name,
+        deviceName: device.name,
+        yAxisID: 'yPercentage',
+        borderDash: isPassive ? [5, 5] : undefined
+      };
+    }),
+    modesData: mapEnumHistoryToResponse(
       (hs) => heatpump.getModeHistory(hs),
       selector,
       { 0: 'UNKNOWN', 1: 'STANDBY', 2: 'HEATING', 3: 'DHW', 4: 'DEICING', 5: 'FROST_PROTECTION' }
     ),
-    Promise.all(
-      thermostats.map(async (device) => {
-        const thermostat = device.getThermostatCapability();
-        const [currentEvents, targetEvents, isPassive] = await Promise.all([
-          thermostat.getCurrentTemperatureHistory(selector),
-          thermostat.getTargetTemperatureHistory(selector),
-          thermostat.getIsPassive()
-        ]);
+    temperatureDeltas: asyncMap(thermostats, async (device) => {
+      const thermostat = device.getThermostatCapability();
+      const { currentEvents, targetEvents, isPassive } = await awaitPromises({
+        currentEvents: thermostat.getCurrentTemperatureHistory(selector),
+        targetEvents: thermostat.getTargetTemperatureHistory(selector),
+        isPassive: thermostat.getIsPassive()
+      });
 
-        return {
-          data: computeTemperatureDelta(currentEvents, targetEvents, selector),
-          label: device.name,
-          deviceName: device.name,
-          yAxisID: 'yDelta',
-          borderDash: isPassive ? [5, 5] : undefined
-        };
-      })
-    )
-  ]);
+      return {
+        data: computeTemperatureDelta(currentEvents, targetEvents, selector),
+        label: device.name,
+        deviceName: device.name,
+        yAxisID: 'yDelta',
+        borderDash: isPassive ? [5, 5] : undefined
+      };
+    })
+  });
 
   const response: HeatingInsightsApiResponse = {
     lines,

--- a/server/src/routes/api/insights/heating.ts
+++ b/server/src/routes/api/insights/heating.ts
@@ -1,6 +1,6 @@
 import { Device, NumericEvent } from '../../../models';
 import { Request, Response } from 'express';
-import { HeatingInsightsApiResponse, HistoryDetailsApiResponse, NumericEventApiResponse } from '../../../api/types';
+import { HistoryDetailsApiResponse, NumericEventApiResponse } from '../../../api/types';
 import { TimeRangeSelector } from '../../../models/capabilities/helpers';
 import { mapNumericHistoryToResponse, mapEnumHistoryToResponse } from '../history-helpers';
 import { awaitPromises } from '../../../helpers/promises';
@@ -69,7 +69,7 @@ export default async function (req: Request, res: Response) {
 
   const heatpump = heatpumps[0].getHeatPumpCapability();
 
-  const { lines, modesData, temperatureDeltas } = await awaitPromises({
+  res.json(await awaitPromises({
     lines: asyncMap(thermostats, async (device) => {
       const thermostat = device.getThermostatCapability();
       const [data, isPassive] = await Promise.all([
@@ -85,11 +85,19 @@ export default async function (req: Request, res: Response) {
         borderDash: isPassive ? [5, 5] : undefined
       };
     }),
-    modesData: mapEnumHistoryToResponse(
+    modes: mapEnumHistoryToResponse(
       (hs) => heatpump.getModeHistory(hs),
       selector,
       { 0: 'UNKNOWN', 1: 'STANDBY', 2: 'HEATING', 3: 'DHW', 4: 'DEICING', 5: 'FROST_PROTECTION' }
-    ),
+    ).then(data => ({
+      data,
+      details: [
+        { value: 'HEATING', label: 'Heating' },
+        { value: 'DEICING', label: 'Deicing' },
+        { value: 'FROST_PROTECTION', label: 'Frost Protection' },
+        { value: 'DHW', label: 'Hot Water' }
+      ]
+    })),
     temperatureDeltas: asyncMap(thermostats, async (device) => {
       const thermostat = device.getThermostatCapability();
       const [currentEvents, targetEvents, isPassive] = await Promise.all([
@@ -105,23 +113,7 @@ export default async function (req: Request, res: Response) {
         yAxisID: 'yDelta',
         borderDash: isPassive ? [5, 5] : undefined
       };
-    })
-  });
-
-  const response: HeatingInsightsApiResponse = {
-    lines,
-    modes: {
-      data: modesData,
-      details: [
-        { value: 'HEATING', label: 'Heating' },
-        { value: 'DEICING', label: 'Deicing' },
-        { value: 'FROST_PROTECTION', label: 'Frost Protection' },
-        { value: 'DHW', label: 'Hot Water' }
-      ]
-    },
-    temperatureDeltas,
+    }),
     heatPump: { id: heatpumps[0].id, name: heatpumps[0].name }
-  };
-
-  res.json(response);
+  }));
 }

--- a/server/src/routes/api/insights/heating.ts
+++ b/server/src/routes/api/insights/heating.ts
@@ -1,6 +1,6 @@
 import { Device, NumericEvent } from '../../../models';
 import { Request, Response } from 'express';
-import { HistoryDetailsApiResponse, NumericEventApiResponse } from '../../../api/types';
+import { HeatingInsightsApiResponse, HistoryDetailsApiResponse, NumericEventApiResponse } from '../../../api/types';
 import { TimeRangeSelector } from '../../../models/capabilities/helpers';
 import { mapNumericHistoryToResponse, mapEnumHistoryToResponse } from '../history-helpers';
 import { awaitPromises } from '../../../helpers/promises';
@@ -85,19 +85,19 @@ export default async function (req: Request, res: Response) {
         borderDash: isPassive ? [5, 5] : undefined
       };
     }),
-    modes: mapEnumHistoryToResponse(
-      (hs) => heatpump.getModeHistory(hs),
-      selector,
-      { 0: 'UNKNOWN', 1: 'STANDBY', 2: 'HEATING', 3: 'DHW', 4: 'DEICING', 5: 'FROST_PROTECTION' }
-    ).then(data => ({
-      data,
+    modes: awaitPromises({
+      data: mapEnumHistoryToResponse(
+        (hs) => heatpump.getModeHistory(hs),
+        selector,
+        { 0: 'UNKNOWN', 1: 'STANDBY', 2: 'HEATING', 3: 'DHW', 4: 'DEICING', 5: 'FROST_PROTECTION' }
+      ),
       details: [
         { value: 'HEATING', label: 'Heating' },
         { value: 'DEICING', label: 'Deicing' },
         { value: 'FROST_PROTECTION', label: 'Frost Protection' },
         { value: 'DHW', label: 'Hot Water' }
       ]
-    })),
+    }),
     temperatureDeltas: asyncMap(thermostats, async (device) => {
       const thermostat = device.getThermostatCapability();
       const [currentEvents, targetEvents, isPassive] = await Promise.all([
@@ -115,5 +115,5 @@ export default async function (req: Request, res: Response) {
       };
     }),
     heatPump: { id: heatpumps[0].id, name: heatpumps[0].name }
-  }));
+  }) satisfies HeatingInsightsApiResponse);
 }

--- a/server/src/routes/api/insights/heating.ts
+++ b/server/src/routes/api/insights/heating.ts
@@ -122,7 +122,7 @@ export default async function (req: Request, res: Response) {
       ]
     },
     temperatureDeltas,
-    heatPump: heatpumps[0] ? { id: heatpumps[0].id, name: heatpumps[0].name } : null
+    heatPump: { id: heatpumps[0].id, name: heatpumps[0].name }
   };
 
   res.json(response);


### PR DESCRIPTION
## Summary

Replaces the heating automation logic with two simpler rules and surfaces more useful info on the heating insights page.

### Automation (`automations/heating.ts`)

- **Turn off** when the heat pump compressor has modulated to 0 **and** every non-passive thermostat reports `power == 0`. Both `onHeatPumpCompressorModulationChanged` and `onThermostatPowerChanged` trigger a shared `evaluateTurnOff()` so whichever event completes the AND wins.
- **Turn on** when any non-passive thermostat's `currentTemperature` is more than `temperatureDeltaSwitchOnThreshold` degrees below its `targetTemperature`. Listening to both `onThermostatCurrentTemperatureChanged` and `onThermostatTargetTemperatureChanged` so a scheduled target bump also triggers heating.
- Drops the compressor cooldown lockout entirely — short-cycle protection now relies on the heat pump's own modulation behaviour.
- Notifications continue on every transition; the on-notification names the thermostat that triggered it.

### Config migration

The `automations[heating].parameters` block in `config.json` should now contain only:

```json
{
  "heatingSwitchName": "...",
  "temperatureDeltaSwitchOnThreshold": 1.5
}
```

The `temperatureDeltaSwitchOffThreshold`, `heatPumpDeviceName` and `compressorCooldownPeriodInMinutes` keys are no longer used and can be removed.

### Insights page

- New per-thermostat **current − target temperature delta** graph rendered below the existing demand graph. Computed server-side by merging the thermostat's `currentTemperatureHistory` and `targetTemperatureHistory` into a single stepped numeric series.
- Heat pump device shown as a link (to `/device/<id>`) above the date range selector, mirroring the existing thermostat-name links.

## Test plan

- [x] `npm run codegen && npm run lint && npm test` all pass.
- [ ] Open `/insights/heating` and confirm the new delta graph renders one line per thermostat with negative values when below target, plus a "Heat pump:" link that navigates to the device page.
- [ ] On the live stack: with all rooms at or above target, wait for thermostat power to settle to 0 and heat pump modulation to 0 — expect the off notification.
- [ ] Drop one thermostat target so it's more than `temperatureDeltaSwitchOnThreshold`° below current room temperature — expect the on notification naming that thermostat.

https://claude.ai/code/session_01EWrHXDxJqyUG43BNobi5kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWrHXDxJqyUG43BNobi5kD)_