### PR TITLE
Shade switch-on threshold zone on temperature delta graph

### DIFF
--- a/server/src/api/types.ts
+++ b/server/src/api/types.ts
@@ -282,6 +282,7 @@ export interface HeatingInsightsApiResponse {
   lines: (HistoryLineApiResponse & { deviceName: string })[];
   modes: HistoryModesApiResponse;
   temperatureDeltas: (HistoryLineApiResponse & { deviceName: string })[];
+  temperatureDeltaSwitchOnThreshold: number | null;
   heatPump: { id: number; name: string };
 }
 

--- a/server/src/components/capability-graphs/capability-graph.tsx
+++ b/server/src/components/capability-graphs/capability-graph.tsx
@@ -82,8 +82,8 @@ export type CapabilityGraphProps = {
   }
 
   zones?: {
-    min: number;
-    max: number;
+    min?: number;
+    max?: number;
     color: string;
   }[]
 
@@ -299,8 +299,8 @@ export function CapabilityGraph(props: CapabilityGraphProps) {
         type: 'box',
         xMin: min,
         xMax: max,
-        yMin: zone.min,
-        yMax: zone.max,
+        ...(zone.min !== undefined ? { yMin: zone.min } : {}),
+        ...(zone.max !== undefined ? { yMax: zone.max } : {}),
         backgroundColor: zone.color,
         borderWidth: 0
       };

--- a/server/src/components/pages/insights-heating.tsx
+++ b/server/src/components/pages/insights-heating.tsx
@@ -120,6 +120,11 @@ function HeatingDemandGraph() {
       <CapabilityGraph
         lines={data.temperatureDeltas}
         yAxis={yAxisDelta}
+        zones={
+          data.temperatureDeltaSwitchOnThreshold !== null
+            ? [{ max: -data.temperatureDeltaSwitchOnThreshold, color: 'rgba(255, 0, 55, 0.15)' }]
+            : []
+        }
       />
     </>
   );

--- a/server/src/routes/api/insights/heating.ts
+++ b/server/src/routes/api/insights/heating.ts
@@ -5,6 +5,7 @@ import { TimeRangeSelector } from '../../../models/capabilities/helpers';
 import { mapNumericHistoryToResponse, mapEnumHistoryToResponse } from '../history-helpers';
 import { awaitPromises } from '../../../helpers/promises';
 import { asyncMap } from '../../../helpers/array';
+import config from '../../../config';
 
 function findEventAt(events: NumericEvent[], t: number): NumericEvent | null {
   for (let i = events.length - 1; i >= 0; i--) {
@@ -69,6 +70,9 @@ export default async function (req: Request, res: Response) {
 
   const heatpump = heatpumps[0].getHeatPumpCapability();
 
+  const heatingAutomation = config.automations.find((a) => a.name === 'heating');
+  const switchOnThreshold = heatingAutomation?.parameters?.temperatureDeltaSwitchOnThreshold;
+
   res.json(await awaitPromises({
     lines: asyncMap(thermostats, async (device) => {
       const thermostat = device.getThermostatCapability();
@@ -114,6 +118,7 @@ export default async function (req: Request, res: Response) {
         borderDash: isPassive ? [5, 5] : undefined
       };
     }),
-    heatPump: { id: heatpumps[0].id, name: heatpumps[0].name }
+    heatPump: { id: heatpumps[0].id, name: heatpumps[0].name },
+    temperatureDeltaSwitchOnThreshold: typeof switchOnThreshold === 'number' ? switchOnThreshold : null
   }) satisfies HeatingInsightsApiResponse);
 }


### PR DESCRIPTION
## Summary
- The Heating Insights "Temperature delta (current − target)" graph now shades the region where the heating automation would have switched on, using the same `zones` background-colouring pattern as the heat pump system-pressure graph.
- The threshold value is read from `config.automations` (the heating automation's `temperatureDeltaSwitchOnThreshold` parameter) and exposed via the `/api/insights/heating` response so there is no hardcoded duplicate.
- Made `zones[].min` / `zones[].max` optional on `CapabilityGraph` so a band can extend to the chart-area edge (used here to extend from the bottom of the chart up to `−temperatureDeltaSwitchOnThreshold`); the existing system-pressure usage is unaffected.
- The graph plots `current − target` while the automation compares `target − current`, so the page negates the threshold when passing it as a zone bound.

## Test plan
- [ ] Open the Heating Insights page; the temperature delta graph shows a red-tinted band from the bottom of the chart up to `y = −temperatureDeltaSwitchOnThreshold`.
- [ ] Series lines remain readable on top of the band.
- [ ] Remove `temperatureDeltaSwitchOnThreshold` from the heating automation's parameters in `config.json`; the graph renders with no shading and no errors.
- [ ] The heat pump system-pressure graph still renders its red/green bands correctly (regression check on the optional `zones` bounds change).
- [ ] `npm run lint` and `npm test` pass.

https://claude.ai/code/session_016bUjjKGg9cFKgvbhdtcVHi

---
_Generated by [Claude Code](https://claude.ai/code/session_016bUjjKGg9cFKgvbhdtcVHi)_