### PR TITLE
End Tado warmup overlays at next scheduled change

### DIFF
--- a/server/src/automations/heating-warmup.ts
+++ b/server/src/automations/heating-warmup.ts
@@ -120,7 +120,7 @@ export default function ({
         const startTime = await calculateWarmupStartTime(device, nextScheduledChange.temperature, nextScheduledChange.timestamp);
 
         if (dayjs().isAfter(startTime)) {
-          await thermostat.setTargetTemperature(nextScheduledChange.temperature);
+          await thermostat.setTargetTemperatureUntilNextScheduledChange(nextScheduledChange.temperature);
         }
       }
     }
@@ -144,7 +144,7 @@ export default function ({
           earliestWarmup = startTime;
         }
 
-        setTargetTemperatureActors.push(() => thermostat.setTargetTemperature(scheduledTemp));
+        setTargetTemperatureActors.push(() => thermostat.setTargetTemperatureUntilNextScheduledChange(scheduledTemp));
       }
     }
 

--- a/server/src/models/capabilities/index.ts
+++ b/server/src/models/capabilities/index.ts
@@ -16,6 +16,7 @@ export type ScheduledChange = {
 export interface ProviderThermostatCapability extends ProviderThermostatCapabilityBase {
   getNextScheduledChange(device: Device): Promise<ScheduledChange | null>;
   getScheduledTemperatureAtTime(device: Device, timestamp: Date): Promise<number | null>;
+  setTargetTemperatureUntilNextScheduledChange(device: Device, value: number): Promise<void>;
 }
 
 export type ProviderSpeakerCapability = {

--- a/server/src/models/capabilities/thermostat.ts
+++ b/server/src/models/capabilities/thermostat.ts
@@ -3,10 +3,10 @@ import { Device } from '..';
 import { ScheduledChange } from './index';
 
 export class ThermostatCapability extends ThermostatBaseCapability {
-  setTargetTemperature(value: number | null): Promise<void> {
+  setTargetTemperatureUntilNextScheduledChange(value: number): Promise<void> {
     return Device.getProviderCapabilities(this.device.provider)
       .provideThermostatCapability!()
-      .setTargetTemperature(this.device, value as number);
+      .setTargetTemperatureUntilNextScheduledChange(this.device, value);
   }
 
   async getNextScheduledChange(): Promise<ScheduledChange | null> {

--- a/server/src/routes/api/device/thermostat.ts
+++ b/server/src/routes/api/device/thermostat.ts
@@ -22,7 +22,11 @@ router.put<Record<string, never>, DeviceApiResponse | ApiErrorResponse, Thermost
   const body = req.body;
 
   if ('targetTemperature' in body) {
-    await thermostat.setTargetTemperature(body.targetTemperature === 0 ? null : body.targetTemperature);
+    if (body.targetTemperature === 0) {
+      await thermostat.setIsOn(false);
+    } else {
+      await thermostat.setTargetTemperature(body.targetTemperature);
+    }
   }
 
   const deviceResponse = await mapDeviceToResponse(device);

--- a/server/src/services/tado/index.ts
+++ b/server/src/services/tado/index.ts
@@ -83,9 +83,16 @@ Device.registerProvider('tado', {
 
   provideThermostatCapability() {
     return {
-      async setTargetTemperature(device: Device, value: number | null) {
+      async setTargetTemperature(device: Device, value: number) {
         const client = new TadoClient(await getAccessToken(), config.tado.home_id);
-        const response = await client.setHeatingPowerForZone(device.providerId, value === null ? false : value, false);
+        const response = await client.setHeatingPowerForZone(device.providerId, value, false);
+
+        await updateTargetTemperatureFromOverlay(device, response);
+      },
+
+      async setTargetTemperatureUntilNextScheduledChange(device: Device, value: number) {
+        const client = new TadoClient(await getAccessToken(), config.tado.home_id);
+        const response = await client.setHeatingPowerForZone(device.providerId, value, true);
 
         await updateTargetTemperatureFromOverlay(device, response);
       },


### PR DESCRIPTION
## Summary

- The heating warm-up automation was setting Tado target temperatures with a `MANUAL` overlay (no end time), so pre-warmed rooms stayed at the warm-up temperature indefinitely instead of returning to schedule. The original (pre-redesign) behaviour set the overlay with `NEXT_TIME_BLOCK` termination, and that's what's restored here.
- Adds `setTargetTemperatureUntilNextScheduledChange` alongside the existing `getNextScheduledChange` / `getScheduledTemperatureAtTime` extensions on `ProviderThermostatCapability`. Only `automations/heating-warmup.ts` calls it; every other caller of `setTargetTemperature` (occupancy setback, central-heating SETBACK, manual UI override) keeps producing a `MANUAL` overlay as before.
- Drops the `value: number | null` / `as number` lie on `ThermostatCapability.setTargetTemperature`. The single caller that used `null` to mean "off" (`routes/api/device/thermostat.ts`, when `targetTemperature === 0`) now goes through `setIsOn(false)`, which already does the same Tado API call. With the signature back to `(value: number)`, the bespoke override is identical to the codegen'd `ThermostatBaseCapability.setTargetTemperature` and can be removed.

## Test plan

- [x] `npm run codegen && npm run lint && npm run test` clean
- [ ] Trigger `checkAtHomeWarmup` against a Tado zone with an upcoming higher scheduled temperature; confirm the resulting overlay's `termination.typeSkillBasedApp === 'NEXT_TIME_BLOCK'` (Tado app shows "Until next scheduled change")
- [ ] Trigger `checkAwayWarmup` (nobody home, ETA set); confirm same `NEXT_TIME_BLOCK` overlay
- [ ] PUT `/api/heating` with `centralHeating: 'SETBACK'` → overlay still `MANUAL`
- [ ] PUT `/api/device/:id` with non-zero `targetTemperature` → overlay still `MANUAL`
- [ ] PUT `/api/device/:id` with `targetTemperature: 0` → zone heating turns OFF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bk75kxCau1f3xx3LJdqVkR)_