### PR TITLE
Fix Tado overlay error when zone has no next schedule block

### DIFF
--- a/server/src/automations/heating-warmup.ts
+++ b/server/src/automations/heating-warmup.ts
@@ -144,7 +144,13 @@ export default function ({
           earliestWarmup = startTime;
         }
 
-        setTargetTemperatureActors.push(() => thermostat.setTargetTemperatureUntilNextScheduledChange(scheduledTemp));
+        setTargetTemperatureActors.push(async () => {
+          if (await thermostat.getNextScheduledChange() === null) {
+            await thermostat.setIsOn(true);
+          } else {
+            await thermostat.setTargetTemperatureUntilNextScheduledChange(scheduledTemp);
+          }
+        });
       }
     }
 


### PR DESCRIPTION
## Summary

  The heating-warmup automation was crashing on zones that have no next schedule block:

  Error: unsupportedOverlayTerminationType: setting overlay termination type
  NEXT_TIME_BLOCK not supported for zone 4: zone does not have next schedule block
      at TadoClient._request (services/tado/client.js:77)
      at Object.setTargetTemperatureUntilNextScheduledChange (services/tado/index.js:74)
      at checkAwayWarmup (automations/heating-warmup.js:134)

  Some zones run a flat (constant) temperature with no upcoming schedule change. Tado rejects `NEXT_TIME_BLOCK` termination
  on these zones, so `checkAwayWarmup` was unconditionally calling `setTargetTemperatureUntilNextScheduledChange` when it
  should not.

  Fix: check `getNextScheduledChange()` in `checkAwayWarmup` before deciding which action to take. If the zone has a next
  scheduled change, set the warmup temperature until that block. If not, call `setIsOn(true)` instead — this clears any
  manual override and lets the flat schedule run at its configured temperature.

  ## Test plan

  - [ ] Trigger away warmup on a zone without a next schedule block and confirm it no longer throws
  - [ ] Confirm away warmup on a zone with an upcoming schedule block still sets temperature via `NEXT_TIME_BLOCK`