### PR TITLE
Guard SSE device update against empty query cache

### DIFF
--- a/server/src/hooks/use-sse-events.ts
+++ b/server/src/hooks/use-sse-events.ts
@@ -59,7 +59,8 @@ export function useSSEEvents() {
 
     const handleDeviceUpdate = (event: DeviceUpdateEvent) => {
       queryClient.setQueryData(['device', event.device.id], { device: event.device } satisfies DeviceApiResponse);
-      queryClient.setQueryData(['devices'], (old: DevicesApiResponse) => {
+      queryClient.setQueryData(['devices'], (old: DevicesApiResponse | undefined) => {
+        if (!old) return old;
         return {
           ...old,
           devices: old.devices.map((device: RestDeviceResponse) => {


### PR DESCRIPTION
## Summary
- The SSE `device_update` handler crashed with `Cannot read properties of undefined (reading 'devices')` whenever an event arrived before the `['devices']` query had populated (or after it was garbage collected), because the `setQueryData` updater dereferenced `old.devices` unconditionally.
- Added the same `if (!old) return old;` guard already used by the device mutation hooks (`hooks/mutations/use-device-mutations.ts`) and widened the updater's parameter type to `DevicesApiResponse | undefined` to reflect react-query's actual contract.

## Test plan
- [ ] Load the app fresh and confirm no `Failed to parse SSE message` errors in the console when device updates arrive.
- [ ] Trigger a device state change and confirm the device list and individual device caches still update live via SSE.
- [ ] Navigate to a route that does not pre-fetch `['devices']`, trigger an SSE update, and confirm no error is thrown.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuMbfz6GNCL6CMXBjTUrM7)_