### PR TITLE
Fix device details page crash on SSE update

### DIFF
--- a/server/src/hooks/use-sse-events.ts
+++ b/server/src/hooks/use-sse-events.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { DevicesApiResponse, DeviceUpdateEvent, RestDeviceResponse, SSEEvent } from '../api/types';
+import { DeviceApiResponse, DevicesApiResponse, DeviceUpdateEvent, RestDeviceResponse, SSEEvent } from '../api/types';
 
 type SSEStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
 
@@ -58,7 +58,7 @@ export function useSSEEvents() {
     };
 
     const handleDeviceUpdate = (event: DeviceUpdateEvent) => {
-      queryClient.setQueryData(['device', event.device.id], event.device);
+      queryClient.setQueryData(['device', event.device.id], { device: event.device } satisfies DeviceApiResponse);
       queryClient.setQueryData(['devices'], (old: DevicesApiResponse) => {
         return {
           ...old,


### PR DESCRIPTION
## Summary

The device details page would intermittently crash with `TypeError: Cannot read properties of undefined (reading 'lastSeen')` after the page had been open for a while.

## Root cause

`useDevice` (`hooks/queries/use-device.ts`) types its query data as `DeviceApiResponse`, which is `{ device: RestDeviceResponse }` — matching what `/api/device/:id` returns. Mutations and the registry cache writer both respect that shape.

The SSE handler in `hooks/use-sse-events.ts` did not. When a `device_update` event arrived it wrote the raw `RestDeviceResponse` straight into `['device', id]`:

```ts
queryClient.setQueryData(['device', event.device.id], event.device);
```

After that, `useDevice` returned `data` as the bare device, so `data.device` was undefined and `device.tsx:27` crashed on `device.lastSeen`. This was intermittent because it only happened once an SSE update fired while the user was on the device page.

## Fix

Wrap the payload in the same `{ device }` envelope the rest of the cache uses.

## Test plan

- [ ] Load a device details page in the UI
- [ ] Trigger a device state change so an SSE `device_update` fires for that device
- [ ] Confirm the page updates in place instead of crashing into the error boundary

https://claude.ai/code/session_015VEfjBYtZX2pyePD14hRTf

---
_Generated by [Claude Code](https://claude.ai/code/session_015VEfjBYtZX2pyePD14hRTf)_