### PR TITLE
Revert Fibaro button debug logging

### DIFF
--- a/server/src/services/alexa/index.ts
+++ b/server/src/services/alexa/index.ts
@@ -119,18 +119,5 @@ Device.registerProvider('alexa', {
 
 DeviceCapabilityEvents.onButtonPressed(async (event) => {
   const device = await event.getDevice();
-
-  logger.info({
-    deviceId: device.id,
-    deviceName: device.name,
-    provider: device.provider
-  }, 'Alexa onButtonPressed handler fired; notifying Alexa');
-
-  try {
-    await sendSimpleEventSource(device.id);
-    logger.info({ deviceId: device.id }, 'Alexa SimpleEventSource sent for button press');
-  } catch (err) {
-    logger.error({ err, deviceId: device.id }, 'Alexa failed to send SimpleEventSource for button press');
-    throw err;
-  }
+  await sendSimpleEventSource(device.id);
 });

--- a/server/src/services/zwave/index.ts
+++ b/server/src/services/zwave/index.ts
@@ -207,33 +207,12 @@ async function getClient() {
           }
 
           if (data.source === 'node' && data.event === 'value notification') {
-            logger.info({
-              nodeId: data.nodeId,
-              commandClassName: data.args.commandClassName,
-              property: data.args.property,
-              propertyKey: data.args.propertyKey,
-              value: data.args.value
-            }, 'ZWave value notification received');
-
             // Central Scene key attribute values: 0=single press, 1=released, 2=held, 3+=multi-press
             if (data.args.commandClassName === 'Central Scene' && data.args.value !== 1) {
               const device = await Device.findByProviderIdOrError('zwave', data.nodeId);
               const pressedAt = new Date();
 
-              logger.info({
-                nodeId: data.nodeId,
-                deviceId: device.id,
-                deviceName: device.name,
-                pressedAt: pressedAt.toISOString()
-              }, 'ZWave button press detected; setting pressed state');
-
-              try {
-                await device.getButtonCapability().setPressedState(true, pressedAt);
-                logger.info({ deviceId: device.id }, 'ZWave button pressed state set');
-              } catch (err) {
-                logger.error({ err, deviceId: device.id }, 'ZWave failed to set button pressed state');
-                throw err;
-              }
+              await device.getButtonCapability().setPressedState(true, pressedAt);
             }
           }
         });


### PR DESCRIPTION
## Summary
- Reverts the debug logging added in #330 (commit 156a0fe) to the Alexa button-pressed handler and Z-Wave Central Scene handler.
- The underlying intermittent Fibaro button press issue has since been resolved by 895562e (multi-press fix) and a42bc29 (also fire on held), so the temporary instrumentation is no longer needed.
- Preserves the current `Central Scene && value !== 1` filter and the explanatory comment — only the `logger.info`/`logger.error` calls and the surrounding try/catch are removed.

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] Manual: press a Fibaro button and confirm the button-pressed event still flows through to Alexa SimpleEventSource

https://claude.ai/code/session_01YDUyLtsWVaTcE3fTVL5HWZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDUyLtsWVaTcE3fTVL5HWZ)_