### PR TITLE
Fix daily heat pump metrics aggregation

### DIFF
--- a/server/src/codegen/templates/capabilities.ts.hbs
+++ b/server/src/codegen/templates/capabilities.ts.hbs
@@ -35,8 +35,8 @@ export class {{className}} {
     return getBooleanPropertyHistory(this.device, '{{fieldName}}', selection);
   }
 
-  async set{{propertyName}}State(value: boolean, timestamp?: Date): Promise<void> {
-    const event = await setBooleanProperty(this.device, '{{fieldName}}', value, {{#if isMomentary}}true{{else}}false{{/if}}, timestamp);
+  async set{{propertyName}}State(value: boolean, stateTimestamp?: Date, reportedAt?: Date): Promise<void> {
+    const event = await setBooleanProperty(this.device, '{{fieldName}}', value, {{#if isMomentary}}true{{else}}false{{/if}}, stateTimestamp, reportedAt);
 
     if (event !== null) {
       {{#if isMomentary}}
@@ -71,8 +71,8 @@ export class {{className}} {
     return getNumericPropertyHistory(this.device, '{{fieldName}}', selection);
   }
 
-  async set{{propertyName}}State(value: number, timestamp?: Date): Promise<void> {
-    const event = await setNumericProperty(this.device, '{{fieldName}}', value, false, timestamp);
+  async set{{propertyName}}State(value: number, stateTimestamp?: Date, reportedAt?: Date): Promise<void> {
+    const event = await setNumericProperty(this.device, '{{fieldName}}', value, false, stateTimestamp, reportedAt);
 
     if (event !== null) {
       DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}Changed(new NumericEvent(event));

--- a/server/src/models/capabilities/helpers/index.ts
+++ b/server/src/models/capabilities/helpers/index.ts
@@ -18,16 +18,16 @@ export async function getLatestNumericEvent(device: Device, propertyName: string
   return event ? new NumericEvent(event) : null;
 }
 
-export async function setBooleanProperty(device: Device, propertyName: string, propertyValue: boolean, isMomentary: boolean, timestamp: Date = new Date()): Promise<Event | null> {
+export async function setBooleanProperty(device: Device, propertyName: string, propertyValue: boolean, isMomentary: boolean, stateTimestamp: Date = new Date(), reportedAt: Date = stateTimestamp): Promise<Event | null> {
   const lastEvent = await device.getLatestEvent(propertyName);
 
   // Reject historic inserts - use reset script instead
-  if (lastEvent && timestamp < lastEvent.start) {
-    throw new Error(`Cannot insert historic event for ${propertyName}: timestamp ${timestamp.toISOString()} is before latest event ${lastEvent.start.toISOString()}`);
+  if (lastEvent && stateTimestamp < lastEvent.start) {
+    throw new Error(`Cannot insert historic event for ${propertyName}: timestamp ${stateTimestamp.toISOString()} is before latest event ${lastEvent.start.toISOString()}`);
   }
 
   // Same timestamp as latest event
-  if (lastEvent && lastEvent.start.getTime() === timestamp.getTime()) {
+  if (lastEvent && lastEvent.start.getTime() === stateTimestamp.getTime()) {
     const isCurrentlyOn = !lastEvent.end;
 
     if (isCurrentlyOn && propertyValue === false) {
@@ -50,9 +50,9 @@ export async function setBooleanProperty(device: Device, propertyName: string, p
   if (isMomentary) {
     return await Event.create({
       deviceId: device.id,
-      start: timestamp,
-      end: timestamp,
-      lastReported: timestamp,
+      start: stateTimestamp,
+      end: stateTimestamp,
+      lastReported: reportedAt,
       value: Number(propertyValue),
       type: propertyName
     });
@@ -64,8 +64,8 @@ export async function setBooleanProperty(device: Device, propertyName: string, p
       // off -> on (don't touch old, create new)
 
       if (lastEvent && propertyValue === false) {
-        lastEvent.end = timestamp;
-        lastEvent.lastReported = timestamp;
+        lastEvent.end = stateTimestamp;
+        lastEvent.lastReported = reportedAt;
 
         return await lastEvent.save();
       }
@@ -73,14 +73,14 @@ export async function setBooleanProperty(device: Device, propertyName: string, p
       if (propertyValue === true) {
         return await Event.create({
           deviceId: device.id,
-          start: timestamp,
-          lastReported: timestamp,
+          start: stateTimestamp,
+          lastReported: reportedAt,
           value: Number(propertyValue),
           type: propertyName
         });
       }
     } else if (lastEvent) {
-      lastEvent.lastReported = timestamp;
+      lastEvent.lastReported = reportedAt;
 
       await lastEvent.save();
     }
@@ -93,20 +93,20 @@ export async function getNumericProperty(device: Device, propertyName: string, d
   return (await device.getLatestEvent(propertyName))?.value ?? defaultValue;
 }
 
-export async function setNumericProperty(device: Device, propertyName: string, propertyValue: number, isMomentary: boolean, timestamp: Date = new Date()): Promise<Event | null> {
+export async function setNumericProperty(device: Device, propertyName: string, propertyValue: number, isMomentary: boolean, stateTimestamp: Date = new Date(), reportedAt: Date = stateTimestamp): Promise<Event | null> {
   const lastEvent = await device.getLatestEvent(propertyName);
 
   // Reject historic inserts - use reset script instead
-  if (lastEvent && timestamp < lastEvent.start) {
-    throw new Error(`Cannot insert historic event for ${propertyName}: timestamp ${timestamp.toISOString()} is before latest event ${lastEvent.start.toISOString()}`);
+  if (lastEvent && stateTimestamp < lastEvent.start) {
+    throw new Error(`Cannot insert historic event for ${propertyName}: timestamp ${stateTimestamp.toISOString()} is before latest event ${lastEvent.start.toISOString()}`);
   }
 
   // Same timestamp as latest event
-  if (lastEvent && lastEvent.start.getTime() === timestamp.getTime()) {
+  if (lastEvent && lastEvent.start.getTime() === stateTimestamp.getTime()) {
     if (lastEvent.value !== propertyValue) {
       // Allow updating the latest event's value (e.g., 15-min running metrics)
       lastEvent.value = propertyValue;
-      lastEvent.lastReported = timestamp;
+      lastEvent.lastReported = reportedAt;
       return await lastEvent.save();
     }
     return null; // No change needed
@@ -115,9 +115,9 @@ export async function setNumericProperty(device: Device, propertyName: string, p
   if (isMomentary) {
     return await Event.create({
       deviceId: device.id,
-      start: timestamp,
-      end: timestamp,
-      lastReported: timestamp,
+      start: stateTimestamp,
+      end: stateTimestamp,
+      lastReported: reportedAt,
       value: propertyValue,
       type: propertyName
     });
@@ -127,22 +127,22 @@ export async function setNumericProperty(device: Device, propertyName: string, p
 
     if (valueHasChanged) {
       if (lastEvent) {
-        lastEvent.end = timestamp;
-        lastEvent.lastReported = timestamp;
+        lastEvent.end = stateTimestamp;
+        lastEvent.lastReported = reportedAt;
         await lastEvent.save();
       }
 
       return await Event.create({
         deviceId: device.id,
-        start: timestamp,
-        lastReported: timestamp,
+        start: stateTimestamp,
+        lastReported: reportedAt,
         value: propertyValue,
         type: propertyName
       });
     }
 
     // Same value, just update lastReported
-    lastEvent.lastReported = timestamp;
+    lastEvent.lastReported = reportedAt;
     await lastEvent.save();
     return null;
   }

--- a/server/src/services/ebusd/history.ts
+++ b/server/src/services/ebusd/history.ts
@@ -134,26 +134,31 @@ async function storeIntervalMetrics(
   intervalEnd: Date,
   isLastInterval: boolean
 ): Promise<void> {
+  // Clamp so the first interval of the day doesn't precede dayStart
+  const intervalStart = new Date(Math.max(dayStart.getTime(), intervalEnd.getTime() - INTERVAL_MS));
+
+  // DayCumulative*: one event per 15-min window (stateTimestamp = window start, reportedAt = window end)
   await Promise.all([
-    capability.setDayCumulativePowerState(total.power, dayStart),
-    capability.setDayCumulativeYieldState(total.yield, dayStart),
-    capability.setDayHeatingCumulativePowerState(heating.power, dayStart),
-    capability.setDayHeatingCumulativeYieldState(heating.yield, dayStart),
-    capability.setDayDHWCumulativePowerState(dhw.power, dayStart),
-    capability.setDayDHWCumulativeYieldState(dhw.yield, dayStart),
+    capability.setDayCumulativePowerState(total.power, intervalStart, intervalEnd),
+    capability.setDayCumulativeYieldState(total.yield, intervalStart, intervalEnd),
+    capability.setDayHeatingCumulativePowerState(heating.power, intervalStart, intervalEnd),
+    capability.setDayHeatingCumulativeYieldState(heating.yield, intervalStart, intervalEnd),
+    capability.setDayDHWCumulativePowerState(dhw.power, intervalStart, intervalEnd),
+    capability.setDayDHWCumulativeYieldState(dhw.yield, intervalStart, intervalEnd),
   ]);
 
   if (isLastInterval) {
+    // Day* summary: one event per day, updated in place (stateTimestamp = dayStart, reportedAt = intervalEnd)
     await Promise.all([
-      capability.setDayCoPState(total.coP, dayStart),
-      capability.setDayPowerState(total.power, dayStart),
-      capability.setDayYieldState(total.yield, dayStart),
-      capability.setDayHeatingCoPState(heating.coP, dayStart),
-      capability.setDayHeatingPowerState(heating.power, dayStart),
-      capability.setDayHeatingYieldState(heating.yield, dayStart),
-      capability.setDayDHWCoPState(dhw.coP, dayStart),
-      capability.setDayDHWPowerState(dhw.power, dayStart),
-      capability.setDayDHWYieldState(dhw.yield, dayStart),
+      capability.setDayCoPState(total.coP, dayStart, intervalEnd),
+      capability.setDayPowerState(total.power, dayStart, intervalEnd),
+      capability.setDayYieldState(total.yield, dayStart, intervalEnd),
+      capability.setDayHeatingCoPState(heating.coP, dayStart, intervalEnd),
+      capability.setDayHeatingPowerState(heating.power, dayStart, intervalEnd),
+      capability.setDayHeatingYieldState(heating.yield, dayStart, intervalEnd),
+      capability.setDayDHWCoPState(dhw.coP, dayStart, intervalEnd),
+      capability.setDayDHWPowerState(dhw.power, dayStart, intervalEnd),
+      capability.setDayDHWYieldState(dhw.yield, dayStart, intervalEnd),
     ]);
   }
 }

--- a/server/src/services/ebusd/history.ts
+++ b/server/src/services/ebusd/history.ts
@@ -130,29 +130,30 @@ function computeIntervalMetrics(
 async function storeIntervalMetrics(
   capability: HeatPumpCapability,
   { total, heating, dhw }: IntervalMetrics,
+  dayStart: Date,
   intervalEnd: Date,
   isLastInterval: boolean
 ): Promise<void> {
   await Promise.all([
-    capability.setDayCumulativePowerState(total.power, intervalEnd),
-    capability.setDayCumulativeYieldState(total.yield, intervalEnd),
-    capability.setDayHeatingCumulativePowerState(heating.power, intervalEnd),
-    capability.setDayHeatingCumulativeYieldState(heating.yield, intervalEnd),
-    capability.setDayDHWCumulativePowerState(dhw.power, intervalEnd),
-    capability.setDayDHWCumulativeYieldState(dhw.yield, intervalEnd),
+    capability.setDayCumulativePowerState(total.power, dayStart),
+    capability.setDayCumulativeYieldState(total.yield, dayStart),
+    capability.setDayHeatingCumulativePowerState(heating.power, dayStart),
+    capability.setDayHeatingCumulativeYieldState(heating.yield, dayStart),
+    capability.setDayDHWCumulativePowerState(dhw.power, dayStart),
+    capability.setDayDHWCumulativeYieldState(dhw.yield, dayStart),
   ]);
 
   if (isLastInterval) {
     await Promise.all([
-      capability.setDayCoPState(total.coP, intervalEnd),
-      capability.setDayPowerState(total.power, intervalEnd),
-      capability.setDayYieldState(total.yield, intervalEnd),
-      capability.setDayHeatingCoPState(heating.coP, intervalEnd),
-      capability.setDayHeatingPowerState(heating.power, intervalEnd),
-      capability.setDayHeatingYieldState(heating.yield, intervalEnd),
-      capability.setDayDHWCoPState(dhw.coP, intervalEnd),
-      capability.setDayDHWPowerState(dhw.power, intervalEnd),
-      capability.setDayDHWYieldState(dhw.yield, intervalEnd),
+      capability.setDayCoPState(total.coP, dayStart),
+      capability.setDayPowerState(total.power, dayStart),
+      capability.setDayYieldState(total.yield, dayStart),
+      capability.setDayHeatingCoPState(heating.coP, dayStart),
+      capability.setDayHeatingPowerState(heating.power, dayStart),
+      capability.setDayHeatingYieldState(heating.yield, dayStart),
+      capability.setDayDHWCoPState(dhw.coP, dayStart),
+      capability.setDayDHWPowerState(dhw.power, dayStart),
+      capability.setDayDHWYieldState(dhw.yield, dayStart),
     ]);
   }
 }
@@ -172,7 +173,7 @@ export async function calculateDailyHeatPumpMetrics(
   for (let ms = startMs; ms <= dayEnd.getTime(); ms += INTERVAL_MS) {
     const intervalEnd = new Date(ms);
     const metrics = computeIntervalMetrics(powerHistory, yieldHistory, modeHistory, dayStart, intervalEnd);
-    await storeIntervalMetrics(capability, metrics, intervalEnd, ms === dayEnd.getTime());
+    await storeIntervalMetrics(capability, metrics, dayStart, intervalEnd, ms === dayEnd.getTime());
   }
 }
 

--- a/server/src/services/ebusd/history.ts
+++ b/server/src/services/ebusd/history.ts
@@ -131,12 +131,10 @@ async function storeIntervalMetrics(
   capability: HeatPumpCapability,
   { total, heating, dhw }: IntervalMetrics,
   dayStart: Date,
+  intervalStart: Date,
   intervalEnd: Date,
   isLastInterval: boolean
 ): Promise<void> {
-  // Clamp so the first interval of the day doesn't precede dayStart
-  const intervalStart = new Date(Math.max(dayStart.getTime(), intervalEnd.getTime() - INTERVAL_MS));
-
   // DayCumulative*: one event per 15-min window (stateTimestamp = window start, reportedAt = window end)
   await Promise.all([
     capability.setDayCumulativePowerState(total.power, intervalStart, intervalEnd),
@@ -167,18 +165,25 @@ export async function calculateDailyHeatPumpMetrics(
   capability: HeatPumpCapability,
   dayStart: Date,
   dayEnd: Date,
-  startMs: number
+  resumeFrom: Date
 ): Promise<void> {
+  const snappedDayEnd = new Date(Math.floor(dayEnd.getTime() / INTERVAL_MS) * INTERVAL_MS);
+  if (snappedDayEnd.getTime() <= dayStart.getTime()) return;
+
+  const startMs = resumeFrom.getTime() + INTERVAL_MS;
+  if (startMs > snappedDayEnd.getTime()) return;
+
   const [powerHistory, yieldHistory, modeHistory] = await Promise.all([
-    capability.getCurrentPowerHistory({ since: dayStart, until: dayEnd }),
-    capability.getCurrentYieldHistory({ since: dayStart, until: dayEnd }),
-    capability.getModeHistory({ since: dayStart, until: dayEnd }),
+    capability.getCurrentPowerHistory({ since: dayStart, until: snappedDayEnd }),
+    capability.getCurrentYieldHistory({ since: dayStart, until: snappedDayEnd }),
+    capability.getModeHistory({ since: dayStart, until: snappedDayEnd }),
   ]);
 
-  for (let ms = startMs; ms <= dayEnd.getTime(); ms += INTERVAL_MS) {
+  for (let ms = startMs; ms <= snappedDayEnd.getTime(); ms += INTERVAL_MS) {
+    const intervalStart = new Date(ms - INTERVAL_MS);
     const intervalEnd = new Date(ms);
     const metrics = computeIntervalMetrics(powerHistory, yieldHistory, modeHistory, dayStart, intervalEnd);
-    await storeIntervalMetrics(capability, metrics, dayStart, intervalEnd, ms === dayEnd.getTime());
+    await storeIntervalMetrics(capability, metrics, dayStart, intervalStart, intervalEnd, ms === snappedDayEnd.getTime());
   }
 }
 
@@ -219,23 +224,12 @@ export async function storeRunningMetrics(device: Device, capability: HeatPumpCa
 
   for (let day = dayMetricsStart; day.isSameOrBefore(today); day = day.add(1, 'day')) {
     const dayStart = day.toDate();
-    const isToday = day.isSame(today, 'day');
-    const dayEnd = isToday
-      ? new Date(Math.floor(now.getTime() / INTERVAL_MS) * INTERVAL_MS)
-      : day.add(1, 'day').toDate();
-
-    if (dayEnd.getTime() <= dayStart.getTime()) continue;
-
-    const dayHasPartialData = latestTimestamp !== null
-      && latestTimestamp > dayStart
-      && latestTimestamp < dayEnd;
-    const startMs = dayHasPartialData
-      ? latestTimestamp.getTime() + INTERVAL_MS
-      : dayStart.getTime();
-
-    if (startMs > dayEnd.getTime()) continue;
+    const dayEnd = day.isSame(today, 'day') ? now : day.add(1, 'day').toDate();
+    const resumeFrom = (latestTimestamp !== null && latestTimestamp > dayStart && latestTimestamp < dayEnd)
+      ? latestTimestamp
+      : dayStart;
 
     logger.info(`Processing heat pump metrics for ${day.format('YYYY-MM-DD')}`);
-    await calculateDailyHeatPumpMetrics(capability, dayStart, dayEnd, startMs);
+    await calculateDailyHeatPumpMetrics(capability, dayStart, dayEnd, resumeFrom);
   }
 }


### PR DESCRIPTION
## Summary

Three related fixes to the daily heat pump metrics pipeline in `services/ebusd/history.ts`.

### 1. Fix Day* metrics creating one row per 15-min interval instead of one per day

`storeIntervalMetrics` was passing `intervalEnd` (a changing 15-min boundary) as the `start` timestamp for both the Day* summary events and the DayCumulative* events. Since `setNumericProperty` creates a new row whenever the timestamp changes, this produced ~96 rows per day for the Day* group instead of 1.

Fix: pass `dayStart` (midnight) as the `stateTimestamp` for Day* events and `intervalStart` for DayCumulative* events. `setNumericProperty` then finds the same existing row each interval and updates it in place.

### 2. Separate `stateTimestamp` from `reportedAt` in `set*Property` helpers

To support the two different timestamp semantics above, `setNumericProperty` and `setBooleanProperty` (and the codegen template) gained an optional `reportedAt` parameter (defaults to `stateTimestamp`, preserving all existing callers).

- `stateTimestamp` — where in the time-series the event sits (`start`/`end`)
- `reportedAt` — when the value was last observed (`lastReported`)

For Day* summary metrics: `stateTimestamp = dayStart`, `reportedAt = intervalEnd` — one row per day, `lastReported` advances each 15-min tick.  
For DayCumulative* metrics: `stateTimestamp = intervalStart`, `reportedAt = intervalEnd` — one row per 15-min window.

Both groups share the same `lastReported`, so the consistency check and progress tracking in `storeRunningMetrics` continue to work unchanged.

### 3. Refactor interval logic into `calculateDailyHeatPumpMetrics`

`storeRunningMetrics` previously computed `startMs` using `INTERVAL_MS` directly. This responsibility now lives entirely in `calculateDailyHeatPumpMetrics`:

- `storeRunningMetrics` passes `resumeFrom: Date` (`dayStart` for a fresh day, `latestTimestamp` to resume a partially-processed day) — no more `INTERVAL_MS` reference
- `calculateDailyHeatPumpMetrics` snaps `dayEnd` to the nearest interval boundary, derives `startMs = resumeFrom + INTERVAL_MS`, and passes `intervalStart` explicitly to `storeIntervalMetrics`
- `storeIntervalMetrics` accepts `intervalStart` as a parameter — the `Math.max` clamp that was papering over the off-by-one loop start is removed

## Required manual step after deploy

Run `npm run reset-daily-metrics` once to delete the broken per-interval rows. `storeRunningMetrics` will then backfill correctly from `device.createdAt`, producing one event per day for Day* and one per 15-min window for DayCumulative*.

## Test plan

- [ ] Deploy + run `npm run reset-daily-metrics` + restart
- [ ] Check daily metrics history — each day has exactly one entry with `start = 00:00:00Z`
- [ ] Check cumulative energy history — many entries per day at 15-min intervals, values increasing from 0 and resetting each midnight
- [ ] After two consecutive 15-min ticks: Day* entry updates in place (same `start`, updated `value`/`lastReported`); DayCumulative* grows one new row per tick
- [ ] `lastReported` on a Day* event matches the most recent 15-min boundary, not `dayStart`