### PR TITLE
Fix daily metrics consistency: update lastReported on idle intervals and prevent concurrent runs

### DIFF
--- a/server/src/models/capabilities/helpers/index.ts
+++ b/server/src/models/capabilities/helpers/index.ts
@@ -103,8 +103,7 @@ export async function setNumericProperty(device: Device, propertyName: string, p
 
   // Same timestamp as latest event
   if (lastEvent && lastEvent.start.getTime() === stateTimestamp.getTime()) {
-    if (lastEvent.value !== propertyValue) {
-      // Allow updating the latest event's value (e.g., 15-min running metrics)
+    if (lastEvent.value !== propertyValue || lastEvent.lastReported.getTime() !== reportedAt.getTime()) {
       lastEvent.value = propertyValue;
       lastEvent.lastReported = reportedAt;
       return await lastEvent.save();

--- a/server/src/services/ebusd/index.ts
+++ b/server/src/services/ebusd/index.ts
@@ -83,8 +83,12 @@ nowAndSetInterval(createBackgroundTransaction('ebusd:poll', async () => {
 let dailyMetricsRunning = false;
 
 nowAndSetInterval(createBackgroundTransaction('ebusd:daily-metrics', async () => {
-  if (dailyMetricsRunning) return;
+  if (dailyMetricsRunning) {
+    return;
+  }
+
   dailyMetricsRunning = true;
+
   try {
     const device = await Device.findByProviderIdOrError('ebusd', 'heatpump');
     await storeRunningMetrics(device, device.getHeatPumpCapability());

--- a/server/src/services/ebusd/index.ts
+++ b/server/src/services/ebusd/index.ts
@@ -80,7 +80,15 @@ nowAndSetInterval(createBackgroundTransaction('ebusd:poll', async () => {
   }
 }), Math.max(config.ebusd.poll_interval_minutes, 1) * 60 * 1000);
 
+let dailyMetricsRunning = false;
+
 nowAndSetInterval(createBackgroundTransaction('ebusd:daily-metrics', async () => {
-  const device = await Device.findByProviderIdOrError('ebusd', 'heatpump');
-  await storeRunningMetrics(device, device.getHeatPumpCapability());
+  if (dailyMetricsRunning) return;
+  dailyMetricsRunning = true;
+  try {
+    const device = await Device.findByProviderIdOrError('ebusd', 'heatpump');
+    await storeRunningMetrics(device, device.getHeatPumpCapability());
+  } finally {
+    dailyMetricsRunning = false;
+  }
 }), 15 * 60 * 1000);


### PR DESCRIPTION
Two bugs that together caused "inconsistent latest timestamps" after the BST dayStart fix:

1. setNumericProperty did not update lastReported when stateTimestamp matched an existing
   event but the value was unchanged. Day* summary events (fixed stateTimestamp = dayStart)
   would drift behind DayCumulative* on any idle 15-min interval, breaking the consistency
   check on the next run.

2. nowAndSetInterval fires the daily-metrics callback every 15 min regardless of whether the
   previous async call has finished. During a long backfill, concurrent invocations raced on
   the same DB rows, producing the inconsistent state that triggered this incident.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>