### PR TITLE
Expose build version in /version, X-Build-Version header, and UI footer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
       run:
         working-directory: server/src
 
+    outputs:
+      version: ${{ steps.version.outputs.value }}
+
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node
@@ -27,6 +30,12 @@ jobs:
       - run: npm run build
         env:
           NODE_ENV: production
+
+      - name: Compute build version
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        id: version
+        working-directory: .
+        run: echo "value=$(date -u +%Y.%m.%d).$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Docker Hub
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -57,6 +66,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_VERSION=${{ steps.version.outputs.value }}
 
   deploy-application:
     name: Deploy Application
@@ -68,6 +79,34 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           curl -X POST -H "Authorization: Bearer ${{ secrets.DEPLOYMENT_TOKEN }}" ${{ secrets.DEPLOYMENT_WEBHOOK }}
+
+      - name: Verify Deployment
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        env:
+          EXPECTED_VERSION: ${{ needs.ci.outputs.version }}
+          HEALTH_URL: ${{ secrets.DEPLOYMENT_HEALTH_URL }}
+        run: |
+          set -u
+          if [ -z "${HEALTH_URL:-}" ]; then
+            echo "DEPLOYMENT_HEALTH_URL secret is not set; skipping verification."
+            exit 0
+          fi
+
+          DEADLINE=$(( $(date +%s) + 300 ))
+          ATTEMPT=0
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            ACTUAL=$(curl -fsS --max-time 10 "$HEALTH_URL/version" | jq -r '.version' 2>/dev/null || echo "")
+            if [ "$ACTUAL" = "$EXPECTED_VERSION" ]; then
+              echo "Deployment verified after $ATTEMPT attempt(s): /version reports $ACTUAL"
+              exit 0
+            fi
+            echo "Attempt $ATTEMPT: /version reported '${ACTUAL:-<none>}', waiting for '$EXPECTED_VERSION'..."
+            sleep 5
+          done
+
+          echo "Timed out after 5 minutes waiting for $EXPECTED_VERSION at $HEALTH_URL/version"
+          exit 1
 
   deploy-lambda-production:
     name: Deploy Lambda (Production)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,19 +84,15 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:
           EXPECTED_VERSION: ${{ needs.ci.outputs.version }}
-          HEALTH_URL: ${{ secrets.DEPLOYMENT_HEALTH_URL }}
+          DEPLOYMENT_HOST: ${{ secrets.DEPLOYMENT_HOST }}
         run: |
-          set -u
-          if [ -z "${HEALTH_URL:-}" ]; then
-            echo "DEPLOYMENT_HEALTH_URL secret is not set; skipping verification."
-            exit 0
-          fi
+          set -eu
 
           DEADLINE=$(( $(date +%s) + 300 ))
           ATTEMPT=0
           while [ "$(date +%s)" -lt "$DEADLINE" ]; do
             ATTEMPT=$((ATTEMPT + 1))
-            ACTUAL=$(curl -fsS --max-time 10 "$HEALTH_URL/version" | jq -r '.version' 2>/dev/null || echo "")
+            ACTUAL=$(curl -fsS --max-time 10 "$DEPLOYMENT_HOST/version" | jq -r '.version' 2>/dev/null || echo "")
             if [ "$ACTUAL" = "$EXPECTED_VERSION" ]; then
               echo "Deployment verified after $ATTEMPT attempt(s): /version reports $ACTUAL"
               exit 0
@@ -105,7 +101,7 @@ jobs:
             sleep 5
           done
 
-          echo "Timed out after 5 minutes waiting for $EXPECTED_VERSION at $HEALTH_URL/version"
+          echo "Timed out after 5 minutes waiting for $EXPECTED_VERSION at $DEPLOYMENT_HOST/version"
           exit 1
 
   deploy-lambda-production:

--- a/server/src/Dockerfile
+++ b/server/src/Dockerfile
@@ -6,4 +6,6 @@ COPY --chown=node . .
 EXPOSE 8081
 USER node
 ENV NODE_ENV=production
+ARG BUILD_VERSION=dev
+ENV BUILD_VERSION=$BUILD_VERSION
 CMD ["npm", "start"]

--- a/server/src/client.js
+++ b/server/src/client.js
@@ -9,6 +9,7 @@ import { createTheme, MantineProvider } from '@mantine/core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RealtimeProvider } from './components/realtime-provider';
+import { BuildVersionProvider } from './components/build-version-context';
 import AppLayout from './components/app-layout';
 import ErrorBoundary from './components/error-boundary';
 import Home from './components/pages/home';
@@ -68,11 +69,13 @@ window.onload = () => {
   root.render(
     <QueryClientProvider client={queryClient}>
       <MantineProvider theme={theme}>
-        <RealtimeProvider>
-          <ErrorBoundary>
-            <RouterProvider router={router} />
-          </ErrorBoundary>
-        </RealtimeProvider>
+        <BuildVersionProvider>
+          <RealtimeProvider>
+            <ErrorBoundary>
+              <RouterProvider router={router} />
+            </ErrorBoundary>
+          </RealtimeProvider>
+        </BuildVersionProvider>
       </MantineProvider>
       {process.env.NODE_ENV === 'development' && <ReactQueryDevtools />}
     </QueryClientProvider>,

--- a/server/src/components/app-layout.tsx
+++ b/server/src/components/app-layout.tsx
@@ -5,6 +5,7 @@ import { useDisclosure, useMediaQuery } from '@mantine/hooks';
 import Header from './header';
 import HouseStatus from './house-status';
 import NavLinks from './nav-links';
+import Footer from './footer';
 import ErrorBoundary from './error-boundary';
 
 export default function AppLayout() {
@@ -16,6 +17,7 @@ export default function AppLayout() {
   return (
     <AppShell
       header={{ height: 60 }}
+      footer={{ height: 28 }}
       navbar={{
         width: 300,
         breakpoint: 'md',
@@ -38,6 +40,10 @@ export default function AppLayout() {
           <Outlet />
         </ErrorBoundary>
       </AppShell.Main>
+
+      <AppShell.Footer>
+        <Footer />
+      </AppShell.Footer>
     </AppShell>
   );
 }

--- a/server/src/components/app-layout.tsx
+++ b/server/src/components/app-layout.tsx
@@ -17,7 +17,6 @@ export default function AppLayout() {
   return (
     <AppShell
       header={{ height: 60 }}
-      footer={{ height: 28 }}
       navbar={{
         width: 300,
         breakpoint: 'md',
@@ -39,11 +38,8 @@ export default function AppLayout() {
         <ErrorBoundary>
           <Outlet />
         </ErrorBoundary>
-      </AppShell.Main>
-
-      <AppShell.Footer>
         <Footer />
-      </AppShell.Footer>
+      </AppShell.Main>
     </AppShell>
   );
 }

--- a/server/src/components/build-version-context.tsx
+++ b/server/src/components/build-version-context.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const Ctx = createContext<string | null>(null);
+
+let listener: ((v: string) => void) | null = null;
+
+export function recordBuildVersion(version: string) {
+  if (listener) {
+    listener(version);
+  }
+}
+
+export function BuildVersionProvider({ children }: { children: React.ReactNode }) {
+  const [version, setVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    listener = setVersion;
+    return () => {
+      listener = null;
+    };
+  }, []);
+
+  return <Ctx.Provider value={version}>{children}</Ctx.Provider>;
+}
+
+export function useBuildVersion() {
+  return useContext(Ctx);
+}

--- a/server/src/components/footer.module.css
+++ b/server/src/components/footer.module.css
@@ -1,5 +1,6 @@
 .footer {
-  padding: var(--mantine-spacing-md);
+  padding: var(--mantine-spacing-sm);
+  padding-bottom: 0;
   font-size: var(--mantine-font-size-xs);
   color: var(--mantine-color-dimmed);
   text-align: right;

--- a/server/src/components/footer.module.css
+++ b/server/src/components/footer.module.css
@@ -1,0 +1,9 @@
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  height: 100%;
+  padding: 0 var(--mantine-spacing-md);
+  font-size: var(--mantine-font-size-xs);
+  color: var(--mantine-color-dimmed);
+}

--- a/server/src/components/footer.module.css
+++ b/server/src/components/footer.module.css
@@ -1,9 +1,6 @@
 .footer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  height: 100%;
-  padding: 0 var(--mantine-spacing-md);
+  padding: var(--mantine-spacing-md);
   font-size: var(--mantine-font-size-xs);
   color: var(--mantine-color-dimmed);
+  text-align: right;
 }

--- a/server/src/components/footer.tsx
+++ b/server/src/components/footer.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useBuildVersion } from './build-version-context';
+import styles from './footer.module.css';
+
+export default function Footer() {
+  const version = useBuildVersion();
+
+  if (!version) {
+    return null;
+  }
+
+  return <div className={styles.footer}>v{version}</div>;
+}

--- a/server/src/helpers/build-version.ts
+++ b/server/src/helpers/build-version.ts
@@ -1,0 +1,1 @@
+export const BUILD_VERSION = process.env.BUILD_VERSION || 'dev';

--- a/server/src/hooks/fetch-api.ts
+++ b/server/src/hooks/fetch-api.ts
@@ -1,3 +1,5 @@
+import { recordBuildVersion } from '../components/build-version-context';
+
 export class ApiError extends Error {
   constructor(public status: number, message: string) {
     super(message);
@@ -8,6 +10,11 @@ export class ApiError extends Error {
 export async function fetchApi<T>(endpoint: string, params?: Record<string, string>): Promise<T> {
   const qs = typeof params === 'undefined' ? '' : new URLSearchParams(params).toString();
   const res = await fetch(`/api${endpoint}?${qs}`);
+
+  const version = res.headers.get('X-Build-Version');
+  if (version) {
+    recordBuildVersion(version);
+  }
 
   if (!res.ok) {
     if (res.status === 401) {

--- a/server/src/hooks/fetch-api.ts
+++ b/server/src/hooks/fetch-api.ts
@@ -12,6 +12,7 @@ export async function fetchApi<T>(endpoint: string, params?: Record<string, stri
   const res = await fetch(`/api${endpoint}?${qs}`);
 
   const version = res.headers.get('X-Build-Version');
+
   if (version) {
     recordBuildVersion(version);
   }

--- a/server/src/middleware/build-version.ts
+++ b/server/src/middleware/build-version.ts
@@ -1,0 +1,9 @@
+import { RequestHandler } from 'express';
+import { BUILD_VERSION } from '../helpers/build-version';
+
+const buildVersion: RequestHandler = (_req, res, next) => {
+  res.setHeader('X-Build-Version', BUILD_VERSION);
+  next();
+};
+
+export default buildVersion;

--- a/server/src/routes/version.ts
+++ b/server/src/routes/version.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { BUILD_VERSION } from '../helpers/build-version';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json({ version: BUILD_VERSION });
+});
+
+export default router;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -12,7 +12,9 @@ import homeConnectRoutes from './routes/homeconnect';
 import shellyRoutes from './routes/shelly';
 import tadoRoutes from './routes/tado';
 import vehicleRoutes from './routes/vehicle';
+import versionRoutes from './routes/version';
 import auth from './middleware/auth';
+import buildVersion from './middleware/build-version';
 import { Device } from './models';
 import config from './config';
 import cookieParser from 'cookie-parser';
@@ -45,6 +47,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use(express.json());
 app.use(express.text());
 app.use(cookieParser());
+app.use(buildVersion);
 
 app.use('/alexa', alexaRoutes);
 app.use('/api', auth, apiRoutes);
@@ -55,6 +58,7 @@ app.use('/shelly', shellyRoutes);
 app.use('/homeconnect', homeConnectRoutes);
 app.use('/tado', tadoRoutes);
 app.use('/vehicle', vehicleRoutes);
+app.use('/version', versionRoutes);
 app.use('/', express.static(__dirname + '/static'));
 
 app.use((req, res) => res.sendFile(__dirname + '/static/index.html', {


### PR DESCRIPTION
## Summary

Surfaces a `YYYY.MM.DD.<short-sha>` build identifier so it's possible to tell which image is actually running in prod.

- **GHA computes the version** on master pushes and passes it to `docker/build-push-action` as a `BUILD_VERSION` build-arg. The Dockerfile bakes it in via `ARG`/`ENV` (placed at the end of the file so cache invalidation only hits the trivial final layer).
- **Server** reads `process.env.BUILD_VERSION` (defaulting to `'dev'` for local), emits it on every response as `X-Build-Version`, and exposes `GET /version` as a public JSON endpoint.
- **Client** picks the header off the shared `fetchApi` wrapper that every `useQuery` hook already uses — no `window.fetch` monkey-patching, no React-Query internals — and pushes it into a small context. `<Footer />` in `AppLayout` subscribes via `useBuildVersion()`.
- **Deploy validation**: after the deploy webhook fires, the `deploy-application` job polls `<DEPLOYMENT_HOST>/version` for up to 5 minutes and fails the workflow if the deployed version doesn't match the expected one.

### Required secret

Add a `DEPLOYMENT_HOST` repo secret (e.g. `https://karen.example.com`) for the Verify Deployment step. The workflow will fail if it's unset.

### Notes / tradeoffs

- Footer is empty until the first `/api/*` response resolves — sub-second on every authenticated page, and the login screen has no footer by design.
- Mutation hooks in `hooks/mutations/*.ts` and `pages/timeline.js` still call `fetch` directly. The version is populated by `useQuery` calls that fire on page load, so this isn't a regression — but a future cleanup could route mutations through a shared wrapper too.

## Test plan

- [ ] `npm run codegen && npm run lint && npm run test && npm run build` — all pass locally
- [ ] `curl -i http://localhost:8081/version` returns `{"version":"dev"}` with an `X-Build-Version: dev` response header
- [ ] `BUILD_VERSION=2026.05.16.abc1234 npm start` → endpoint, header, and footer all show that string
- [ ] In the browser, log in → footer shows `vdev` after the first API call; no footer visible on `/login`
- [ ] After merging to master and a real deploy: `curl https://<host>/version` returns the new `YYYY.MM.DD.<sha>` and the Verify Deployment job in the workflow turns green