### PR TITLE
Always write Day* summary events each interval to enable safe mid-day resume

### DIFF
--- a/server/src/services/ebusd/history.ts
+++ b/server/src/services/ebusd/history.ts
@@ -134,18 +134,15 @@ async function storeIntervalMetrics(
   intervalStart: Date,
   intervalEnd: Date
 ): Promise<void> {
-  // DayCumulative*: one event per 15-min window (stateTimestamp = window start, reportedAt = window end)
   await Promise.all([
+    // DayCumulative*: one event per 15-min window (stateTimestamp = window start, reportedAt = window end)
     capability.setDayCumulativePowerState(total.power, intervalStart, intervalEnd),
     capability.setDayCumulativeYieldState(total.yield, intervalStart, intervalEnd),
     capability.setDayHeatingCumulativePowerState(heating.power, intervalStart, intervalEnd),
     capability.setDayHeatingCumulativeYieldState(heating.yield, intervalStart, intervalEnd),
     capability.setDayDHWCumulativePowerState(dhw.power, intervalStart, intervalEnd),
     capability.setDayDHWCumulativeYieldState(dhw.yield, intervalStart, intervalEnd),
-  ]);
-
-  // Day* summary: one event per day, updated in place every interval (stateTimestamp = dayStart, reportedAt = intervalEnd)
-  await Promise.all([
+    // Day* summary: one event per day, updated in place every interval (stateTimestamp = dayStart, reportedAt = intervalEnd)
     capability.setDayCoPState(total.coP, dayStart, intervalEnd),
     capability.setDayPowerState(total.power, dayStart, intervalEnd),
     capability.setDayYieldState(total.yield, dayStart, intervalEnd),

--- a/server/src/services/ebusd/history.ts
+++ b/server/src/services/ebusd/history.ts
@@ -132,8 +132,7 @@ async function storeIntervalMetrics(
   { total, heating, dhw }: IntervalMetrics,
   dayStart: Date,
   intervalStart: Date,
-  intervalEnd: Date,
-  isLastInterval: boolean
+  intervalEnd: Date
 ): Promise<void> {
   // DayCumulative*: one event per 15-min window (stateTimestamp = window start, reportedAt = window end)
   await Promise.all([
@@ -145,20 +144,18 @@ async function storeIntervalMetrics(
     capability.setDayDHWCumulativeYieldState(dhw.yield, intervalStart, intervalEnd),
   ]);
 
-  if (isLastInterval) {
-    // Day* summary: one event per day, updated in place (stateTimestamp = dayStart, reportedAt = intervalEnd)
-    await Promise.all([
-      capability.setDayCoPState(total.coP, dayStart, intervalEnd),
-      capability.setDayPowerState(total.power, dayStart, intervalEnd),
-      capability.setDayYieldState(total.yield, dayStart, intervalEnd),
-      capability.setDayHeatingCoPState(heating.coP, dayStart, intervalEnd),
-      capability.setDayHeatingPowerState(heating.power, dayStart, intervalEnd),
-      capability.setDayHeatingYieldState(heating.yield, dayStart, intervalEnd),
-      capability.setDayDHWCoPState(dhw.coP, dayStart, intervalEnd),
-      capability.setDayDHWPowerState(dhw.power, dayStart, intervalEnd),
-      capability.setDayDHWYieldState(dhw.yield, dayStart, intervalEnd),
-    ]);
-  }
+  // Day* summary: one event per day, updated in place every interval (stateTimestamp = dayStart, reportedAt = intervalEnd)
+  await Promise.all([
+    capability.setDayCoPState(total.coP, dayStart, intervalEnd),
+    capability.setDayPowerState(total.power, dayStart, intervalEnd),
+    capability.setDayYieldState(total.yield, dayStart, intervalEnd),
+    capability.setDayHeatingCoPState(heating.coP, dayStart, intervalEnd),
+    capability.setDayHeatingPowerState(heating.power, dayStart, intervalEnd),
+    capability.setDayHeatingYieldState(heating.yield, dayStart, intervalEnd),
+    capability.setDayDHWCoPState(dhw.coP, dayStart, intervalEnd),
+    capability.setDayDHWPowerState(dhw.power, dayStart, intervalEnd),
+    capability.setDayDHWYieldState(dhw.yield, dayStart, intervalEnd),
+  ]);
 }
 
 export async function calculateDailyHeatPumpMetrics(
@@ -183,7 +180,7 @@ export async function calculateDailyHeatPumpMetrics(
     const intervalStart = new Date(ms - INTERVAL_MS);
     const intervalEnd = new Date(ms);
     const metrics = computeIntervalMetrics(powerHistory, yieldHistory, modeHistory, dayStart, intervalEnd);
-    await storeIntervalMetrics(capability, metrics, dayStart, intervalStart, intervalEnd, ms === snappedDayEnd.getTime());
+    await storeIntervalMetrics(capability, metrics, dayStart, intervalStart, intervalEnd);
   }
 }
 


### PR DESCRIPTION
## Summary

If the backfill was interrupted mid-day (e.g. container restart), `DayCumulative*` events would be partially written while `Day*` events (`cop_day`, `power_day`, etc.) remained at the previous day's `lastReported` — because `Day*` were only written on the final interval of each day.

On the next run, `resumeFrom` was derived from `Day*` (pointing to the start of the interrupted day), so the loop would re-attempt already-written `DayCumulative*` intervals and hit the historic-insert guard. This left the two groups with different `lastReported` timestamps, permanently blocking updates via the consistency check.

Fix: write `Day*` summary events on every interval as running totals (updated in place, same `stateTimestamp = dayStart`). All 15 events now share the same `lastReported` after each interval, so interrupted days resume cleanly from where they left off.

## Production recovery

Once deployed, run `npm run reset-daily-metrics` on production and restart the container.

## Test plan

- [ ] Locally: reset-daily-metrics, start dev server, confirm backfill passes through BST transition dates (2025-03-30, 2026-03-30) without errors
- [ ] Confirm all 15 event types have matching lastReported in the DB after backfill completes
- [ ] `npm run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)