### PR TITLE
Fix day boundary calculation at GMT→BST transition

### DIFF
--- a/server/src/services/ebusd/history.ts
+++ b/server/src/services/ebusd/history.ts
@@ -218,7 +218,7 @@ export async function storeRunningMetrics(device: Device, capability: HeatPumpCa
 
   for (let day = dayMetricsStart; day.isSameOrBefore(today); day = day.add(1, 'day').startOf('day')) {
     const dayStart = day.toDate();
-    const dayEnd = day.isSame(today, 'day') ? now : day.add(1, 'day').toDate();
+    const dayEnd = day.isSame(today, 'day') ? now : day.add(1, 'day').startOf('day').toDate();
     const resumeFrom = (latestTimestamp !== null && latestTimestamp > dayStart && latestTimestamp < dayEnd)
       ? latestTimestamp
       : dayStart;


### PR DESCRIPTION
## Summary

- `dayEnd` was computed as `day.add(1, 'day').toDate()`, adding exactly 86,400,000 ms (24 hours)
- On the last GMT day (March 29, 2026), this gives `2026-03-30T00:00:00Z` (UTC midnight) — one hour past when March 30's BST midnight actually starts (`2026-03-29T23:00:00Z`)
- The backfill for March 29 then runs 4 extra intervals into March 30's territory, writing `cumulative_power_day` events at `23:00Z`, `23:15Z`, `23:30Z`, `23:45Z`
- When March 30's processing starts (with `dayStart=23:00Z`), interval 1 tries to insert `cumulative_power_day` at `23:00Z` but finds `lastEvent.start=23:45Z` → historic insert guard throws → backfill aborts permanently
- The loop increment already uses `.startOf('day')` to snap to the correct timezone midnight, so `dayEnd` must do the same

## Test plan

- [x] Reproduced the failure locally (March 29 processing ran to `intervalEnd=2026-03-30T00:00:00Z`, March 30 hit historic insert error)
- [x] Applied fix and confirmed March 27 → 28 → 29 → 30 → 31 → April processes without error
- [x] Full end-to-end backfill from November 2024 running (in progress locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)