### PR TITLE
Use named volume for Claude config in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,7 @@
   "initializeCommand": "touch ${localWorkspaceFolder}/../CLAUDE.local.md",
   "postCreateCommand": "bash /workspace/.devcontainer/post-create.sh",
   "mounts": [
-    "source=${localEnv:HOME}/.claude,target=/root/.claude,type=bind",
-    "source=${localEnv:HOME}/.claude.json,target=/root/.claude.json,type=bind",
+    "source=claude-code-config-${devcontainerId},target=/root/.claude,type=volume",
     "source=${localWorkspaceFolder}/../CLAUDE.local.md,target=/workspace/CLAUDE.local.md,type=bind,readonly",
     "source=${localWorkspaceFolder}/../.env.prod,target=/workspace/.env.prod,type=bind,readonly"
   ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
   "initializeCommand": "touch ${localWorkspaceFolder}/../CLAUDE.local.md",
   "postCreateCommand": "bash /workspace/.devcontainer/post-create.sh",
   "mounts": [
-    "source=claude-code-config-${devcontainerId},target=/root/.claude,type=volume",
+    "source=claude-code-config,target=/root/.claude,type=volume",
+    "source=karen-devcontainer-ssh-${devcontainerId},target=/root/.ssh,type=volume",
     "source=${localWorkspaceFolder}/../CLAUDE.local.md,target=/workspace/CLAUDE.local.md,type=bind,readonly",
     "source=${localWorkspaceFolder}/../.env.prod,target=/workspace/.env.prod,type=bind,readonly"
   ],

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -7,6 +7,17 @@ apt-get update -qq && apt-get install -y -q default-mysql-client
 # Install Claude Code CLI
 npm install -g @anthropic-ai/claude-code
 
+# Restore ~/.claude.json from Claude Code's own backup if it's missing after
+# a container rebuild. ~/.claude is a named volume so the backups directory
+# survives rebuilds even though ~/.claude.json itself does not.
+if [ ! -f /root/.claude.json ]; then
+  latest_backup=$(ls /root/.claude/backups/.claude.json.backup.* 2>/dev/null | sort -V | tail -n1)
+  if [ -n "$latest_backup" ]; then
+    cp "$latest_backup" /root/.claude.json
+    echo "Restored /root/.claude.json from $latest_backup"
+  fi
+fi
+
 # Running `claude` inside the container always skips permission prompts,
 # since the container itself is the security boundary.
 echo "alias claude='claude --dangerously-skip-permissions'" >> ~/.bashrc

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,22 +1,49 @@
 #!/bin/bash
 set -e
 
-# Install MySQL client (includes mysqldump)
-apt-get update -qq && apt-get install -y -q default-mysql-client
+# Install MySQL client (mysqldump) and openssh-client (ssh-keygen, ssh-keyscan).
+apt-get update -qq && apt-get install -y -q default-mysql-client openssh-client
+
+# Provision a karen-only deploy key in the persisted ~/.ssh volume.
+# On first run we generate the key and print the public half so it can
+# be pasted into mattlunn/karen → Settings → Deploy keys. Subsequent
+# rebuilds reuse the existing key from the volume.
+chmod 700 ~/.ssh
+if [ ! -f ~/.ssh/id_ed25519_karen ]; then
+  ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_karen -N '' -C 'karen-devcontainer' -q
+  cat <<EOF
+
+================================================================
+A new SSH key has been generated for this devcontainer.
+
+Add the public key below as a deploy key (with write access) at:
+  https://github.com/mattlunn/karen/settings/keys
+
+$(cat ~/.ssh/id_ed25519_karen.pub)
+================================================================
+
+EOF
+fi
+chmod 600 ~/.ssh/id_ed25519_karen
+
+# Pin this key to github.com only — IdentitiesOnly stops SSH from
+# offering it (or anything else) to other hosts by accident.
+cat > ~/.ssh/config <<'SSHCONFIG'
+Host github.com
+  HostName github.com
+  User git
+  IdentityFile ~/.ssh/id_ed25519_karen
+  IdentitiesOnly yes
+SSHCONFIG
+chmod 600 ~/.ssh/config
+
+# Pre-seed GitHub's host key so non-interactive SSH doesn't prompt.
+ssh-keyscan -t ed25519,rsa github.com >> ~/.ssh/known_hosts 2>/dev/null
+sort -u ~/.ssh/known_hosts -o ~/.ssh/known_hosts
+chmod 644 ~/.ssh/known_hosts
 
 # Install Claude Code CLI
 npm install -g @anthropic-ai/claude-code
-
-# Restore ~/.claude.json from Claude Code's own backup if it's missing after
-# a container rebuild. ~/.claude is a named volume so the backups directory
-# survives rebuilds even though ~/.claude.json itself does not.
-if [ ! -f /root/.claude.json ]; then
-  latest_backup=$(ls /root/.claude/backups/.claude.json.backup.* 2>/dev/null | sort -V | tail -n1)
-  if [ -n "$latest_backup" ]; then
-    cp "$latest_backup" /root/.claude.json
-    echo "Restored /root/.claude.json from $latest_backup"
-  fi
-fi
 
 # Running `claude` inside the container always skips permission prompts,
 # since the container itself is the security boundary.


### PR DESCRIPTION
## Summary

- Bind-mounting `~/.claude.json` as an individual file caused `JSON Parse error: Unexpected EOF` every time `claude` was restarted inside the devcontainer. Docker's single-file bind mount desyncs from the CLI's atomic rewrites of that file (either pointing at a stale inode after a rename, or catching the file mid-truncate).
- Removing the file mount fixed the corruption but lost login state on every rebuild.
- Switched to the [docs-recommended](https://code.claude.com/docs/en/devcontainer#persist-authentication-and-settings-across-rebuilds) per-devcontainer named volume at `/root/.claude`. Auth and session state persist across rebuilds without the file-mount fragility.

Trade-off: in-container Claude state no longer syncs back to the host's `~/.claude` / `~/.claude.json` — the devcontainer Claude session is isolated from any host-side Claude session (this is the documented behaviour).

## Test plan

- [ ] `Dev Containers: Rebuild Container` from VS Code
- [ ] Run `claude` inside the container, sign in once — expect no EOF error
- [ ] Quit `claude` (`Ctrl-D`) and rerun — expect to stay signed in with no parse error
- [ ] Rebuild the container again, run `claude` — expect to still be signed in (named volume survived)
- [ ] `docker volume ls | grep claude-code-config` shows the volume

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVUgzehoXqxN1J7Kyebjdj)_