### PR TITLE
Add string-valued events; migrate HeatPump.Mode as canary

### DIFF
--- a/server/src/bus.ts
+++ b/server/src/bus.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { Stay } from './models';
-import { NumericEvent, BooleanEvent } from './models';
+import { NumericEvent, BooleanEvent, StringEvent } from './models';
 import { DeviceCapabilityEvent } from './models/capabilities';
 
 export const FIRST_USER_HOME = 'FIRST_USER_HOME';
@@ -30,12 +30,13 @@ type NotificationPayload =
 interface KarenEventBus extends EventEmitter {
   emit(event: NotificationEvents, payload: NotificationPayload): boolean;
   emit(event: StayEvents, payload: Stay): boolean;
-  emit(event: DeviceCapabilityEvent, payload: NumericEvent | BooleanEvent): void;
+  emit(event: DeviceCapabilityEvent, payload: NumericEvent | BooleanEvent | StringEvent): void;
 
   on(event: NotificationEvents, cb: (payload: NotificationPayload) => void): this;
   on(event: StayEvents, cb: (payload: Stay) => void): this;
   on(event: DeviceCapabilityEvent, cb: (payload: NumericEvent) => unknown): this;
   on(event: DeviceCapabilityEvent, cb: (payload: BooleanEvent) => unknown): this;
+  on(event: DeviceCapabilityEvent, cb: (payload: StringEvent) => unknown): this;
 }
 
 export default emitter;

--- a/server/src/capabilities.json
+++ b/server/src/capabilities.json
@@ -25,8 +25,9 @@
     {
       "name": "Mode",
       "isWriteable": false,
-      "type": "number",
-      "eventName": "mode"
+      "type": "string",
+      "eventName": "mode",
+      "enum": ["UNKNOWN", "STANDBY", "HEATING", "DHW", "DEICING", "FROST_PROTECTION"]
     },
     {
       "name": "DHWIsOn",

--- a/server/src/codegen/index.ts
+++ b/server/src/codegen/index.ts
@@ -14,10 +14,11 @@ type CapabilityDescriptor = {
 
 type PropertyDescriptor = {
   name: string;
-  type: 'boolean' | 'number';
+  type: 'boolean' | 'number' | 'string';
   isWriteable: boolean;
   eventName: string;
   isMomentary?: boolean;
+  enum?: string[];
 }
 
 const toSnakeCase = (x: string) => x.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`).replace(/^_/, '');
@@ -34,13 +35,18 @@ const capabilities = (JSON.parse(readFileSync(__dirname + '/../capabilities.json
     capabilityName: name,
     capabilityEnumName,
     properties: properties.map(x => {
+      const eventType = x.type === 'boolean' ? 'BooleanEvent' : x.type === 'string' ? 'StringEvent' : 'NumericEvent';
+      const valueType = x.type === 'boolean' ? 'boolean' : x.type === 'string' ? (x.enum ? x.enum.map(e => `'${e}'`).join(' | ') : 'string') : 'number';
+
       return {
         propertyName: x.name,
         propertyEnumName: toPascalUpperCase(x.name),
         isBoolean: x.type === 'boolean',
+        isString: x.type === 'string',
         isMomentary: x.isMomentary ?? false,
         isWriteable: x.isWriteable,
-        eventType: x.type === 'boolean' ? 'BooleanEvent' : 'NumericEvent',
+        eventType,
+        valueType,
         fieldName: x.eventName,
       };
     })

--- a/server/src/codegen/index.ts
+++ b/server/src/codegen/index.ts
@@ -14,15 +14,60 @@ type CapabilityDescriptor = {
 
 type PropertyDescriptor = {
   name: string;
-  type: 'boolean' | 'number' | 'string';
   isWriteable: boolean;
   eventName: string;
   isMomentary?: boolean;
+} & ({
+  type: 'boolean' | 'number';
+} | {
+  type: 'string';
   enum?: string[];
-}
+});
 
 const toSnakeCase = (x: string) => x.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`).replace(/^_/, '');
 const toPascalUpperCase = (x: string) => x.replace(/([A-Z])/g, '_$1').slice(1).toUpperCase();
+
+function describeProperty(capabilityName: string, p: PropertyDescriptor) {
+  let valueType: string;
+  let eventType: string;
+  let typeAlias: string | null = null;
+  let enumValues: string[] | null = null;
+
+  switch (p.type) {
+    case 'boolean':
+      valueType = 'boolean';
+      eventType = 'BooleanEvent';
+      break;
+    case 'number':
+      valueType = 'number';
+      eventType = 'NumericEvent';
+      break;
+    case 'string':
+      eventType = 'StringEvent';
+      if (p.enum) {
+        typeAlias = `${capabilityName}${p.name}`;
+        enumValues = p.enum;
+        valueType = typeAlias;
+      } else {
+        valueType = 'string';
+      }
+      break;
+  }
+
+  return {
+    propertyName: p.name,
+    propertyEnumName: toPascalUpperCase(p.name),
+    isBoolean: p.type === 'boolean',
+    isString: p.type === 'string',
+    isMomentary: p.isMomentary ?? false,
+    isWriteable: p.isWriteable,
+    eventType,
+    valueType,
+    typeAlias,
+    enumValues,
+    fieldName: p.eventName,
+  };
+}
 
 const capabilities = (JSON.parse(readFileSync(__dirname + '/../capabilities.json', 'utf-8')) as CapabilityDescriptor[]).map(({ name, properties, capabilityModelClassName = null, capabilityProviderClassName = null }) => {
   const moduleName = `${toSnakeCase(name)}.gen`;
@@ -34,31 +79,25 @@ const capabilities = (JSON.parse(readFileSync(__dirname + '/../capabilities.json
     providerClassName: capabilityProviderClassName,
     capabilityName: name,
     capabilityEnumName,
-    properties: properties.map(x => {
-      const eventType = x.type === 'boolean' ? 'BooleanEvent' : x.type === 'string' ? 'StringEvent' : 'NumericEvent';
-      const valueType = x.type === 'boolean' ? 'boolean' : x.type === 'string' ? (x.enum ? x.enum.map(e => `'${e}'`).join(' | ') : 'string') : 'number';
-
-      return {
-        propertyName: x.name,
-        propertyEnumName: toPascalUpperCase(x.name),
-        isBoolean: x.type === 'boolean',
-        isString: x.type === 'string',
-        isMomentary: x.isMomentary ?? false,
-        isWriteable: x.isWriteable,
-        eventType,
-        valueType,
-        fieldName: x.eventName,
-      };
-    })
+    properties: properties.map(p => describeProperty(name, p))
   };
 });
+
+const enumAliases = capabilities.flatMap(c =>
+  c.properties
+    .filter(p => p.typeAlias && p.enumValues)
+    .map(p => ({
+      name: p.typeAlias!,
+      values: p.enumValues!.map(v => `'${v}'`).join(' | '),
+    }))
+);
 
 function generateCapabilityModels() {
   const template = Handlebars.compile(readFileSync('./codegen/templates/capabilities.ts.hbs', 'utf-8'));
   const filePath = `../models/capabilities/capabilities.gen.ts`;
   const providers = capabilities.filter(x => x.properties.some(x => x.isWriteable));
 
-  writeFileSync(`${__dirname}/${filePath}`, template({ capabilities, providers }));
+  writeFileSync(`${__dirname}/${filePath}`, template({ capabilities, providers, enumAliases }));
 
   console.log(`Wrote ${filePath}`);
 }

--- a/server/src/codegen/index.ts
+++ b/server/src/codegen/index.ts
@@ -44,6 +44,7 @@ function describeProperty(capabilityName: string, p: PropertyDescriptor) {
       break;
     case 'string':
       eventType = 'StringEvent';
+
       if (p.enum) {
         typeAlias = `${capabilityName}${p.name}`;
         enumValues = p.enum;
@@ -51,6 +52,7 @@ function describeProperty(capabilityName: string, p: PropertyDescriptor) {
       } else {
         valueType = 'string';
       }
+      
       break;
   }
 

--- a/server/src/codegen/templates/capabilities.ts.hbs
+++ b/server/src/codegen/templates/capabilities.ts.hbs
@@ -17,6 +17,10 @@ import {
 
 import bus from '../../bus';
 
+{{#each enumAliases}}
+export type {{name}} = {{{values}}};
+{{/each}}
+
 {{#each capabilities}}
 export class {{className}} {
   protected device: Device;

--- a/server/src/codegen/templates/capabilities.ts.hbs
+++ b/server/src/codegen/templates/capabilities.ts.hbs
@@ -1,13 +1,17 @@
-import { Device, NumericEvent, BooleanEvent } from '..';
+import { Device, NumericEvent, BooleanEvent, StringEvent } from '..';
 import {
   getNumericProperty,
   setNumericProperty,
   getBooleanProperty,
   setBooleanProperty,
+  getStringProperty,
+  setStringProperty,
   getBooleanPropertyHistory,
   getNumericPropertyHistory,
+  getStringPropertyHistory,
   getLatestBooleanEvent,
   getLatestNumericEvent,
+  getLatestStringEvent,
   HistorySelector
 } from './helpers';
 
@@ -59,6 +63,33 @@ export class {{className}} {
   }
   {{/if}}
   {{else}}
+  {{#if isString}}
+  get{{propertyName}}(): Promise<{{{valueType}}}> {
+    return getStringProperty(this.device, '{{fieldName}}') as Promise<{{{valueType}}}>;
+  }
+
+  get{{propertyName}}Event(): Promise<StringEvent | null> {
+    return getLatestStringEvent(this.device, '{{fieldName}}');
+  }
+
+  get{{propertyName}}History(selection: HistorySelector): Promise<StringEvent[]> {
+    return getStringPropertyHistory(this.device, '{{fieldName}}', selection);
+  }
+
+  async set{{propertyName}}State(value: {{{valueType}}}, stateTimestamp?: Date, reportedAt?: Date): Promise<void> {
+    const event = await setStringProperty(this.device, '{{fieldName}}', value, false, stateTimestamp, reportedAt);
+
+    if (event !== null) {
+      DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}Changed(new StringEvent(event));
+    }
+  }
+
+  {{#if isWriteable}}
+  set{{propertyName}}(value: {{{valueType}}}): Promise<void> {
+    return Device.getProviderCapabilities(this.device.provider).provide{{../capabilityName}}Capability!().set{{propertyName}}(this.device, value);
+  }
+  {{/if}}
+  {{else}}
   get{{propertyName}}(): Promise<number> {
     return getNumericProperty(this.device, '{{fieldName}}');
   }
@@ -85,6 +116,7 @@ export class {{className}} {
   }
   {{/if}}
   {{/if}}
+  {{/if}}
 {{/each}}
 }
 
@@ -94,7 +126,7 @@ export class {{className}} {
 export type {{#if providerClassName}}{{providerClassName}}{{else}}Provider{{capabilityName}}Capability{{/if}} = {
   {{#each properties}}
   {{#if isWriteable}}
-  set{{propertyName}}(device: Device, value: {{#if isBoolean}}boolean{{else}}number{{/if}}): Promise<void>
+  set{{propertyName}}(device: Device, value: {{{valueType}}}): Promise<void>
   {{/if}}
   {{/each}}
 }
@@ -124,17 +156,17 @@ export type DeviceCapabilityEvent =
 
 export class DeviceCapabilityEvents {
   private static onPropertyChangedHelper<T>(event: DeviceCapabilityEvent, arg1: ((d: Device) => boolean) | ((e: T) => unknown), arg2?: (e: T) => unknown) {
-    let handler: (e: BooleanEvent | NumericEvent) => unknown;
+    let handler: (e: BooleanEvent | NumericEvent | StringEvent) => unknown;
     let deviceFilter: (d: Device) => boolean;
 
     if (typeof arg2 === 'undefined') {
-      handler = arg1 as (e: BooleanEvent | NumericEvent) => unknown;
+      handler = arg1 as (e: BooleanEvent | NumericEvent | StringEvent) => unknown;
     } else {
       deviceFilter = arg1 as (d: Device) => boolean;
-      handler = arg2 as (e: BooleanEvent | NumericEvent) => unknown;
+      handler = arg2 as (e: BooleanEvent | NumericEvent | StringEvent) => unknown;
     }
 
-    const listener = async (e: BooleanEvent | NumericEvent) => {
+    const listener = async (e: BooleanEvent | NumericEvent | StringEvent) => {
       if (typeof deviceFilter === 'undefined' || deviceFilter(await e.getDevice())) {
         handler(e);
       }
@@ -221,11 +253,11 @@ export class DeviceCapabilityEvents {
   {{/each}}
   {{/each}}
 
-  static onDeviceCapabilityPropertyChanged(handler: (e: BooleanEvent | NumericEvent) => unknown) {
+  static onDeviceCapabilityPropertyChanged(handler: (e: BooleanEvent | NumericEvent | StringEvent) => unknown) {
     bus.on('ON_DEVICE_CAPABILITY_PROPERTY_CHANGED', handler);
   }
 
-  static offDeviceCapabilityPropertyChanged(handler: (e: BooleanEvent | NumericEvent) => unknown) {
+  static offDeviceCapabilityPropertyChanged(handler: (e: BooleanEvent | NumericEvent | StringEvent) => unknown) {
     bus.off('ON_DEVICE_CAPABILITY_PROPERTY_CHANGED', handler);
   }
 }

--- a/server/src/migrations/21-add-string-value-to-events.js
+++ b/server/src/migrations/21-add-string-value-to-events.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: async function(queryInterface, Sequelize) {
+    await queryInterface.addColumn('events', 'stringValue', {
+      type: Sequelize.STRING(255),
+      allowNull: true,
+    });
+  },
+
+  down: async function(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('events', 'stringValue');
+  }
+};

--- a/server/src/migrations/22-migrate-heatpump-mode-to-string.js
+++ b/server/src/migrations/22-migrate-heatpump-mode-to-string.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const MODE_NAMES = {
+  0: 'UNKNOWN',
+  1: 'STANDBY',
+  2: 'HEATING',
+  3: 'DHW',
+  4: 'DEICING',
+  5: 'FROST_PROTECTION'
+};
+
+module.exports = {
+  up: async function(queryInterface, Sequelize) {
+    for (const [numeric, name] of Object.entries(MODE_NAMES)) {
+      await queryInterface.sequelize.query(
+        "UPDATE events SET stringValue = :name, value = NULL WHERE type = 'mode' AND value = :numeric",
+        { replacements: { numeric: Number(numeric), name } }
+      );
+    }
+  },
+
+  down: async function(queryInterface, Sequelize) {
+    for (const [numeric, name] of Object.entries(MODE_NAMES)) {
+      await queryInterface.sequelize.query(
+        "UPDATE events SET value = :numeric, stringValue = NULL WHERE type = 'mode' AND stringValue = :name",
+        { replacements: { numeric: Number(numeric), name } }
+      );
+    }
+  }
+};

--- a/server/src/models/capabilities/helpers/index.test.ts
+++ b/server/src/models/capabilities/helpers/index.test.ts
@@ -1,6 +1,6 @@
 jest.mock('../../../config', () => ({}), { virtual: true });
 
-import { setBooleanProperty, setNumericProperty } from './index';
+import { setBooleanProperty, setNumericProperty, setStringProperty } from './index';
 import { Device, Event } from '../..';
 
 // Mock the models
@@ -11,6 +11,7 @@ jest.mock('../..', () => ({
   },
   BooleanEvent: jest.fn(),
   NumericEvent: jest.fn(),
+  StringEvent: jest.fn(),
   Op: {},
 }));
 
@@ -393,6 +394,138 @@ describe('setBooleanProperty', () => {
       await expect(
         setBooleanProperty(mockDevice as unknown as Device, 'pressed', true, true, historicTimestamp)
       ).rejects.toThrow('Cannot insert historic event');
+    });
+  });
+});
+
+describe('setStringProperty', () => {
+  let mockDevice: { id: number; getLatestEvent: jest.Mock };
+  let mockEvent: { start: Date; stringValue: string; end: Date | null; lastReported: Date; save: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDevice = {
+      id: 1,
+      getLatestEvent: jest.fn(),
+    };
+    mockEvent = {
+      start: new Date('2024-01-15T00:00:00Z'),
+      stringValue: 'HEATING',
+      end: null,
+      lastReported: new Date('2024-01-15T00:00:00Z'),
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  describe('historic insert rejection', () => {
+    it('throws error when timestamp is before latest event start', async () => {
+      mockDevice.getLatestEvent.mockResolvedValue(mockEvent);
+      const historicTimestamp = new Date('2024-01-14T00:00:00Z');
+
+      await expect(
+        setStringProperty(mockDevice as unknown as Device, 'mode', 'DHW', false, historicTimestamp)
+      ).rejects.toThrow('Cannot insert historic event');
+    });
+  });
+
+  describe('fresh inserts', () => {
+    it('creates new event when no existing event', async () => {
+      mockDevice.getLatestEvent.mockResolvedValue(null);
+      const newEvent = { id: 1 };
+      (Event.create as jest.Mock).mockResolvedValue(newEvent);
+
+      const result = await setStringProperty(
+        mockDevice as unknown as Device,
+        'mode',
+        'HEATING',
+        false,
+        new Date('2024-01-15T00:00:00Z')
+      );
+
+      expect(Event.create).toHaveBeenCalledWith(expect.objectContaining({
+        deviceId: 1,
+        type: 'mode',
+        stringValue: 'HEATING',
+      }));
+      expect(result).toBe(newEvent);
+    });
+
+    it('closes old event and creates new one when value changes', async () => {
+      mockDevice.getLatestEvent.mockResolvedValue(mockEvent);
+      const newTimestamp = new Date('2024-01-16T00:00:00Z');
+      const newEvent = { id: 2 };
+      (Event.create as jest.Mock).mockResolvedValue(newEvent);
+
+      const result = await setStringProperty(
+        mockDevice as unknown as Device,
+        'mode',
+        'DHW',
+        false,
+        newTimestamp
+      );
+
+      expect(mockEvent.end).toEqual(newTimestamp);
+      expect(mockEvent.save).toHaveBeenCalled();
+      expect(Event.create).toHaveBeenCalledWith(expect.objectContaining({
+        deviceId: 1,
+        type: 'mode',
+        stringValue: 'DHW',
+      }));
+      expect(result).toBe(newEvent);
+    });
+
+    it('updates lastReported when value unchanged', async () => {
+      mockDevice.getLatestEvent.mockResolvedValue(mockEvent);
+      const newTimestamp = new Date('2024-01-16T00:00:00Z');
+
+      const result = await setStringProperty(
+        mockDevice as unknown as Device,
+        'mode',
+        'HEATING',
+        false,
+        newTimestamp
+      );
+
+      expect(mockEvent.lastReported).toEqual(newTimestamp);
+      expect(mockEvent.save).toHaveBeenCalled();
+      expect(Event.create).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('same timestamp updates', () => {
+    it('updates stringValue in place when timestamp matches latest event', async () => {
+      mockDevice.getLatestEvent.mockResolvedValue(mockEvent);
+      const sameTimestamp = new Date('2024-01-15T00:00:00Z');
+
+      await setStringProperty(
+        mockDevice as unknown as Device,
+        'mode',
+        'DHW',
+        false,
+        sameTimestamp
+      );
+
+      expect(mockEvent.stringValue).toBe('DHW');
+      expect(mockEvent.lastReported).toEqual(sameTimestamp);
+      expect(mockEvent.save).toHaveBeenCalled();
+      expect(Event.create).not.toHaveBeenCalled();
+    });
+
+    it('returns null when value unchanged at same timestamp', async () => {
+      mockDevice.getLatestEvent.mockResolvedValue(mockEvent);
+      const sameTimestamp = new Date('2024-01-15T00:00:00Z');
+
+      const result = await setStringProperty(
+        mockDevice as unknown as Device,
+        'mode',
+        'HEATING',
+        false,
+        sameTimestamp
+      );
+
+      expect(mockEvent.save).not.toHaveBeenCalled();
+      expect(result).toBeNull();
     });
   });
 });

--- a/server/src/models/capabilities/helpers/index.ts
+++ b/server/src/models/capabilities/helpers/index.ts
@@ -1,4 +1,4 @@
-import { BooleanEvent, Device, Event, NumericEvent, Op } from "../..";
+import { BooleanEvent, Device, Event, NumericEvent, StringEvent, Op } from "../..";
 
 export type TimeRangeSelector = { since: Date; until: Date };
 export type ValueFilter =
@@ -26,6 +26,15 @@ export async function getLatestBooleanEvent(device: Device, propertyName: string
 export async function getLatestNumericEvent(device: Device, propertyName: string): Promise<NumericEvent | null> {
   const event = await device.getLatestEvent(propertyName);
   return event ? new NumericEvent(event) : null;
+}
+
+export async function getLatestStringEvent(device: Device, propertyName: string): Promise<StringEvent | null> {
+  const event = await device.getLatestEvent(propertyName);
+  return event ? new StringEvent(event) : null;
+}
+
+export async function getStringProperty(device: Device, propertyName: string, defaultValue = ''): Promise<string> {
+  return (await device.getLatestEvent(propertyName))?.stringValue ?? defaultValue;
 }
 
 export async function setBooleanProperty(device: Device, propertyName: string, propertyValue: boolean, isMomentary: boolean, stateTimestamp: Date = new Date(), reportedAt: Date = stateTimestamp): Promise<Event | null> {
@@ -157,6 +166,59 @@ export async function setNumericProperty(device: Device, propertyName: string, p
   }
 }
 
+export async function setStringProperty(device: Device, propertyName: string, propertyValue: string, isMomentary: boolean, stateTimestamp: Date = new Date(), reportedAt: Date = stateTimestamp): Promise<Event | null> {
+  const lastEvent = await device.getLatestEvent(propertyName);
+
+  // Reject historic inserts - use reset script instead
+  if (lastEvent && stateTimestamp < lastEvent.start) {
+    throw new Error(`Cannot insert historic event for ${propertyName}: timestamp ${stateTimestamp.toISOString()} is before latest event ${lastEvent.start.toISOString()}`);
+  }
+
+  // Same timestamp as latest event
+  if (lastEvent && lastEvent.start.getTime() === stateTimestamp.getTime()) {
+    if (lastEvent.stringValue !== propertyValue || lastEvent.lastReported.getTime() !== reportedAt.getTime()) {
+      lastEvent.stringValue = propertyValue;
+      lastEvent.lastReported = reportedAt;
+      return await lastEvent.save();
+    }
+    return null;
+  }
+
+  if (isMomentary) {
+    return await Event.create({
+      deviceId: device.id,
+      start: stateTimestamp,
+      end: stateTimestamp,
+      lastReported: reportedAt,
+      stringValue: propertyValue,
+      type: propertyName
+    });
+  } else {
+    const valueHasChanged = !lastEvent || propertyValue !== lastEvent.stringValue;
+
+    if (valueHasChanged) {
+      if (lastEvent) {
+        lastEvent.end = stateTimestamp;
+        lastEvent.lastReported = reportedAt;
+        await lastEvent.save();
+      }
+
+      return await Event.create({
+        deviceId: device.id,
+        start: stateTimestamp,
+        lastReported: reportedAt,
+        stringValue: propertyValue,
+        type: propertyName
+      });
+    }
+
+    // Same value, just update lastReported
+    lastEvent.lastReported = reportedAt;
+    await lastEvent.save();
+    return null;
+  }
+}
+
 async function getEventsInRange(device: Device, propertyName: string, selector: HistorySelector): Promise<Event[]> {
   let valueWhere: Record<string, unknown> = {};
 
@@ -215,4 +277,9 @@ export async function getBooleanPropertyHistory(device: Device, propertyName: st
 
 export async function getNumericPropertyHistory(device: Device, propertyName: string, timeRangeSelector: HistorySelector): Promise<NumericEvent[]> {
   return getPropertyHistory(device, propertyName, timeRangeSelector, (event) => new NumericEvent(event));
+}
+
+export async function getStringPropertyHistory(device: Device, propertyName: string, timeRangeSelector: HistorySelector): Promise<StringEvent[]> {
+  const events = await getEventsInRange(device, propertyName, timeRangeSelector);
+  return events.map((event) => new StringEvent(event));
 }

--- a/server/src/models/capabilities/index.ts
+++ b/server/src/models/capabilities/index.ts
@@ -41,11 +41,4 @@ export type ProviderSpeakerCapability = {
   emitSound(device: Device, sound: string | string[], ttlInSeconds?: number): Promise<void>;
 }
 
-export enum HeatPumpMode {
-  UNKNOWN = 0,
-  STANDBY = 1,
-  HEATING = 2,
-  DHW = 3,
-  DEICING = 4,
-  FROST_PROTECTION = 5
-}
+export type HeatPumpMode = 'UNKNOWN' | 'STANDBY' | 'HEATING' | 'DHW' | 'DEICING' | 'FROST_PROTECTION';

--- a/server/src/models/capabilities/index.ts
+++ b/server/src/models/capabilities/index.ts
@@ -40,5 +40,3 @@ export interface ProviderElectricVehicleCapability extends ProviderElectricVehic
 export type ProviderSpeakerCapability = {
   emitSound(device: Device, sound: string | string[], ttlInSeconds?: number): Promise<void>;
 }
-
-export type HeatPumpMode = 'UNKNOWN' | 'STANDBY' | 'HEATING' | 'DHW' | 'DEICING' | 'FROST_PROTECTION';

--- a/server/src/models/event.ts
+++ b/server/src/models/event.ts
@@ -10,6 +10,7 @@ export class Event extends Model<InferAttributes<Event>, InferCreationAttributes
   declare public lastReported: Date;
   declare public type: string;
   declare public value: CreationOptional<number>;
+  declare public stringValue: CreationOptional<string | null>;
   declare public createdAt: CreationOptional<Date>;
   declare public updatedAt: CreationOptional<Date>;
 
@@ -113,6 +114,11 @@ export default function (sequelize: Sequelize) {
       allowNull: true
     },
 
+    stringValue: {
+      type: DataTypes.STRING(255),
+      allowNull: true
+    },
+
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false
@@ -175,6 +181,29 @@ export class NumericEvent {
   constructor(e: Event) {
     this.event = e;
     this.value = e.value;
+    this.start = e.start;
+    this.end = e.end;
+    this.lastReported = e.lastReported;
+    this.updatedAt = e.updatedAt;
+  }
+
+  getDevice() {
+    return this.event.getDevice();
+  }
+}
+
+export class StringEvent {
+  protected event: Event;
+
+  public value: string;
+  public start: Date;
+  public end: Date | null;
+  public lastReported: Date;
+  public updatedAt: Date;
+
+  constructor(e: Event) {
+    this.event = e;
+    this.value = e.stringValue ?? '';
     this.start = e.start;
     this.end = e.end;
     this.lastReported = e.lastReported;

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -27,7 +27,7 @@ const instance = new Sequelize(config.database.name, config.database.user, confi
 export const Token = tokenFactory(instance);
 
 export { Device } from './device';
-export { Event, BooleanEvent, NumericEvent } from './event';
+export { Event, BooleanEvent, NumericEvent, StringEvent } from './event';
 export { Recording } from './recording';
 export { User } from './user';
 export { Stay } from './stay';

--- a/server/src/routes/api/device-helpers.ts
+++ b/server/src/routes/api/device-helpers.ts
@@ -1,4 +1,4 @@
-import { Device, NumericEvent, BooleanEvent } from '../../models';
+import { Device, NumericEvent, BooleanEvent, StringEvent } from '../../models';
 import { NumericEventApiResponse, BooleanEventApiResponse, EnumEventApiResponse, RestDeviceResponse, CapabilityApiResponse } from '../../api/types';
 import dayjs from '../../dayjs';
 import { awaitPromises } from '../../helpers/promises';
@@ -48,16 +48,7 @@ export function mapBooleanEvent(eventPromise: Promise<BooleanEvent | null>, devi
   });
 }
 
-export const HEAT_PUMP_MODES: Record<number, string> = {
-  0: 'UNKNOWN',
-  1: 'STANDBY',
-  2: 'HEATING',
-  3: 'DHW',
-  4: 'DEICING',
-  5: 'FROST_PROTECTION'
-};
-
-export function mapHeatPumpModeEvent(eventPromise: Promise<NumericEvent | null>): Promise<EnumEventApiResponse> {
+export function mapStringEvent(eventPromise: Promise<StringEvent | null>): Promise<EnumEventApiResponse> {
   return eventPromise.then(event => {
     if (!event) {
       throw new Error('Missing an initial event');
@@ -67,7 +58,7 @@ export function mapHeatPumpModeEvent(eventPromise: Promise<NumericEvent | null>)
       start: event.start.toISOString(),
       end: event.end?.toISOString() ?? null,
       lastReported: event.lastReported.toISOString(),
-      value: HEAT_PUMP_MODES[event.value] ?? 'UNKNOWN'
+      value: event.value
     };
   });
 }
@@ -116,7 +107,7 @@ export async function getCapabilityData(device: Device, capability: string): Pro
       const heatPump = device.getHeatPumpCapability();
       return awaitPromises({
         type: 'HEAT_PUMP' as const,
-        mode: mapHeatPumpModeEvent(heatPump.getModeEvent()),
+        mode: mapStringEvent(heatPump.getModeEvent()),
         compressorModulation: mapNumericEvent(heatPump.getCompressorModulationEvent()),
         dhwTemperature: mapNumericEvent(heatPump.getDHWTemperatureEvent()),
         outsideTemperature: mapNumericEvent(heatPump.getOutsideTemperatureEvent()),

--- a/server/src/routes/api/device/history.ts
+++ b/server/src/routes/api/device/history.ts
@@ -8,7 +8,7 @@ import {
   HistoryDetailsApiResponse,
   NumericEventApiResponse
 } from '../../../api/types';
-import { mapBooleanHistoryToResponse, mapNumericHistoryToResponse, mapEnumHistoryToResponse } from '../history-helpers';
+import { mapBooleanHistoryToResponse, mapNumericHistoryToResponse, mapStringHistoryToResponse } from '../history-helpers';
 
 // Types
 
@@ -71,7 +71,7 @@ const historyFetchers = new Map<string, HistoryFetcher>([
         mapNumericHistoryToResponse((hs) => heatPump.getCurrentPowerHistory(hs), selector)
           .then(data => ({ data, label: 'Power' }))
       ]),
-      modes: mapEnumHistoryToResponse((hs) => heatPump.getModeHistory(hs), selector).then(data => ({
+      modes: mapStringHistoryToResponse((hs) => heatPump.getModeHistory(hs), selector).then(data => ({
         data,
         details: [
           { value: 'HEATING', label: 'Heating' },

--- a/server/src/routes/api/device/history.ts
+++ b/server/src/routes/api/device/history.ts
@@ -71,14 +71,7 @@ const historyFetchers = new Map<string, HistoryFetcher>([
         mapNumericHistoryToResponse((hs) => heatPump.getCurrentPowerHistory(hs), selector)
           .then(data => ({ data, label: 'Power' }))
       ]),
-      modes: mapEnumHistoryToResponse((hs) => heatPump.getModeHistory(hs), selector, {
-        0: 'UNKNOWN',
-        1: 'STANDBY',
-        2: 'HEATING',
-        3: 'DHW',
-        4: 'DEICING',
-        5: 'FROST_PROTECTION',
-      }).then(data => ({
+      modes: mapEnumHistoryToResponse((hs) => heatPump.getModeHistory(hs), selector).then(data => ({
         data,
         details: [
           { value: 'HEATING', label: 'Heating' },

--- a/server/src/routes/api/device/timeline.ts
+++ b/server/src/routes/api/device/timeline.ts
@@ -1,4 +1,4 @@
-import { Device, BooleanEvent, NumericEvent } from '../../../models';
+import { Device, BooleanEvent, StringEvent } from '../../../models';
 import { Request, Response, NextFunction } from 'express';
 import dayjs from '../../../dayjs';
 import { TimeRangeSelector, HistorySelector } from '../../../models/capabilities/helpers';
@@ -17,14 +17,13 @@ function mapBooleanHistory(
 }
 
 function mapEnumHistory(
-  fetchHistory: (hs: HistorySelector) => Promise<NumericEvent[]>,
-  historySelector: TimeRangeSelector,
-  map: Record<number, string>
+  fetchHistory: (hs: HistorySelector) => Promise<StringEvent[]>,
+  historySelector: TimeRangeSelector
 ): Promise<{ start: string; value: string }[]> {
   return fetchHistory(historySelector).then(events =>
-    events.map((event: NumericEvent) => ({
+    events.map((event: StringEvent) => ({
       start: event.start.toISOString(),
-      value: map[event.value]
+      value: event.value
     }))
   );
 }
@@ -111,15 +110,7 @@ export default async function (req: Request<{ id: string }>, res: Response, next
         historyPromises.push(
           mapEnumHistory(
             (hs) => heatPump.getModeHistory(hs),
-            historySelector,
-            {
-              0: 'UNKNOWN',
-              1: 'STANDBY',
-              2: 'HEATING',
-              3: 'DHW',
-              4: 'DEICING',
-              5: 'FROST_PROTECTION',
-            }
+            historySelector
           ).then(history => {
             for (const event of history) {
               events.push({ type: 'heatpump-mode', timestamp: event.start, value: event.value });

--- a/server/src/routes/api/device/timeline.ts
+++ b/server/src/routes/api/device/timeline.ts
@@ -16,7 +16,7 @@ function mapBooleanHistory(
   );
 }
 
-function mapEnumHistory(
+function mapStringHistory(
   fetchHistory: (hs: HistorySelector) => Promise<StringEvent[]>,
   historySelector: TimeRangeSelector
 ): Promise<{ start: string; value: string }[]> {
@@ -108,7 +108,7 @@ export default async function (req: Request<{ id: string }>, res: Response, next
       case 'HEAT_PUMP': {
         const heatPump = device.getHeatPumpCapability();
         historyPromises.push(
-          mapEnumHistory(
+          mapStringHistory(
             (hs) => heatPump.getModeHistory(hs),
             historySelector
           ).then(history => {

--- a/server/src/routes/api/events.ts
+++ b/server/src/routes/api/events.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import type { NumericEvent, BooleanEvent } from '../../models';
+import type { NumericEvent, BooleanEvent, StringEvent } from '../../models';
 import { DeviceCapabilityEvents } from '../../models/capabilities';
 import { mapDeviceToResponse } from './device-helpers';
 import logger from '../../logger';
@@ -34,7 +34,7 @@ router.get('/', (req, res) => {
 
   sendMessage(client, { type: 'connected' });
 
-  const handleDeviceCapabilityPropertyChanged = async (e: NumericEvent | BooleanEvent) => {
+  const handleDeviceCapabilityPropertyChanged = async (e: NumericEvent | BooleanEvent | StringEvent) => {
     const message = {
       type: 'device_update' as const,
       device: await mapDeviceToResponse(await e.getDevice())

--- a/server/src/routes/api/history-helpers.ts
+++ b/server/src/routes/api/history-helpers.ts
@@ -39,7 +39,7 @@ export function mapNumericHistoryToResponse(
   }));
 }
 
-export function mapEnumHistoryToResponse(
+export function mapStringHistoryToResponse(
   fetchHistory: (hs: HistorySelector) => Promise<StringEvent[]>,
   historySelector: TimeRangeSelector
 ): Promise<HistoryDetailsApiResponse<EnumEventApiResponse>> {

--- a/server/src/routes/api/history-helpers.ts
+++ b/server/src/routes/api/history-helpers.ts
@@ -1,4 +1,4 @@
-import { BooleanEvent, NumericEvent } from '../../models';
+import { BooleanEvent, NumericEvent, StringEvent } from '../../models';
 import { TimeRangeSelector, HistorySelector } from '../../models/capabilities/helpers';
 import {
   BooleanEventApiResponse,
@@ -40,16 +40,15 @@ export function mapNumericHistoryToResponse(
 }
 
 export function mapEnumHistoryToResponse(
-  fetchHistory: (hs: HistorySelector) => Promise<NumericEvent[]>,
-  historySelector: TimeRangeSelector,
-  map: Record<number, string>
+  fetchHistory: (hs: HistorySelector) => Promise<StringEvent[]>,
+  historySelector: TimeRangeSelector
 ): Promise<HistoryDetailsApiResponse<EnumEventApiResponse>> {
   return fetchHistory(historySelector).then(events => ({
-    history: events.map((event: NumericEvent) => ({
+    history: events.map((event: StringEvent) => ({
       start: event.start.toISOString(),
       end: event.end?.toISOString() ?? null,
       lastReported: event.lastReported.toISOString(),
-      value: map[event.value]
+      value: event.value
     })),
     since: historySelector.since.toISOString(),
     until: historySelector.until.toISOString()

--- a/server/src/routes/api/insights/heating.ts
+++ b/server/src/routes/api/insights/heating.ts
@@ -2,7 +2,7 @@ import { Device, NumericEvent } from '../../../models';
 import { Request, Response } from 'express';
 import { HeatingInsightsApiResponse, HistoryDetailsApiResponse, NumericEventApiResponse } from '../../../api/types';
 import { TimeRangeSelector } from '../../../models/capabilities/helpers';
-import { mapNumericHistoryToResponse, mapEnumHistoryToResponse } from '../history-helpers';
+import { mapNumericHistoryToResponse, mapStringHistoryToResponse } from '../history-helpers';
 import { awaitPromises } from '../../../helpers/promises';
 import { asyncMap } from '../../../helpers/array';
 import config from '../../../config';
@@ -92,7 +92,7 @@ export default async function (req: Request, res: Response) {
       };
     }),
     modes: awaitPromises({
-      data: mapEnumHistoryToResponse(
+      data: mapStringHistoryToResponse(
         (hs) => heatpump.getModeHistory(hs),
         selector
       ),

--- a/server/src/routes/api/insights/heating.ts
+++ b/server/src/routes/api/insights/heating.ts
@@ -94,8 +94,7 @@ export default async function (req: Request, res: Response) {
     modes: awaitPromises({
       data: mapEnumHistoryToResponse(
         (hs) => heatpump.getModeHistory(hs),
-        selector,
-        { 0: 'UNKNOWN', 1: 'STANDBY', 2: 'HEATING', 3: 'DHW', 4: 'DEICING', 5: 'FROST_PROTECTION' }
+        selector
       ),
       details: [
         { value: 'HEATING', label: 'Heating' },

--- a/server/src/services/ebusd/client.ts
+++ b/server/src/services/ebusd/client.ts
@@ -1,15 +1,6 @@
 import { createConnection } from 'net';
 import sleep from '../../helpers/sleep';
 
-export const MODES = {
-  UNKNOWN: 'UNKNOWN',
-  STANDBY: 'STANDBY',
-  HEATING: 'HEATING',
-  DHW: 'DHW',
-  DEICING: 'DEICING',
-  FROST_PROTECTION: 'FROST_PROTECTION'
-} as const;
-
 function toNumber(value: string): number {
   const num = Number(value);
 
@@ -125,17 +116,8 @@ export default class EbusClient {
     return this.#read({ value: 'CurrentConsumedPower', circuit: 'hmu' }, toNumber);
   }
 
-  async getMode(): Promise<typeof MODES[keyof typeof MODES]> {
-    return this.#read({ value: 'Statuscode', circuit: 'hmu' }, (v) => {
-      switch (v.split(':')[0]) {
-        case 'Heating': return MODES.HEATING;
-        case 'Warm Water': return MODES.DHW;
-        case 'Standby': return MODES.STANDBY;
-        case 'Deicing active': return MODES.DEICING;
-        case 'Frost protection': return MODES.FROST_PROTECTION;
-        default: throw new Error(`Unknown status "${v}"`);
-      }
-    });
+  async getMode(): Promise<string> {
+    return this.#read({ value: 'Statuscode', circuit: 'hmu' }, (v) => v.split(':')[0]);
   }
 
   async getDHWIsOn(): Promise<boolean> {

--- a/server/src/services/ebusd/client.ts
+++ b/server/src/services/ebusd/client.ts
@@ -2,13 +2,13 @@ import { createConnection } from 'net';
 import sleep from '../../helpers/sleep';
 
 export const MODES = {
-  UNKNOWN: 0,
-  STANDBY: 1,
-  HEATING: 2,
-  DHW: 3,
-  DEICING: 4,
-  FROST_PROTECTION: 5
-};
+  UNKNOWN: 'UNKNOWN',
+  STANDBY: 'STANDBY',
+  HEATING: 'HEATING',
+  DHW: 'DHW',
+  DEICING: 'DEICING',
+  FROST_PROTECTION: 'FROST_PROTECTION'
+} as const;
 
 function toNumber(value: string): number {
   const num = Number(value);

--- a/server/src/services/ebusd/history.ts
+++ b/server/src/services/ebusd/history.ts
@@ -1,5 +1,5 @@
 import dayjs from '../../dayjs';
-import { NumericEvent } from '../../models/event';
+import { NumericEvent, StringEvent } from '../../models/event';
 import { HeatPumpMode, HeatPumpCapability } from '../../models/capabilities';
 import { filterClampAndSortHistory } from '../../helpers/history';
 import config from '../../config';
@@ -28,7 +28,7 @@ interface IntervalMetrics {
  * Filters out periods shorter than min_mode_duration_minutes (default 10).
  */
 export function getModeWindows(
-  modeHistory: NumericEvent[],
+  modeHistory: StringEvent[],
   modes: HeatPumpMode[]
 ): TimeWindow[] {
   const minDurationMinutes = config.ebusd.min_mode_duration_minutes ?? 10;
@@ -105,7 +105,7 @@ const INTERVAL_MS = 15 * 60 * 1000;
 function computeIntervalMetrics(
   powerHistory: NumericEvent[],
   yieldHistory: NumericEvent[],
-  modeHistory: NumericEvent[],
+  modeHistory: StringEvent[],
   dayStart: Date,
   intervalEnd: Date
 ): IntervalMetrics {
@@ -121,9 +121,9 @@ function computeIntervalMetrics(
   }
 
   return {
-    total:   computeSegment([HeatPumpMode.HEATING, HeatPumpMode.DHW]),
-    heating: computeSegment([HeatPumpMode.HEATING]),
-    dhw:     computeSegment([HeatPumpMode.DHW]),
+    total:   computeSegment(['HEATING', 'DHW']),
+    heating: computeSegment(['HEATING']),
+    dhw:     computeSegment(['DHW']),
   };
 }
 

--- a/server/src/services/ebusd/index.ts
+++ b/server/src/services/ebusd/index.ts
@@ -1,9 +1,18 @@
 import { Device } from '../../models';
+import { HeatPumpMode } from '../../models/capabilities';
 import config from '../../config';
 import nowAndSetInterval from '../../helpers/now-and-set-interval';
 import { createBackgroundTransaction } from '../../helpers/newrelic';
 import EbusClient from './client';
 import { storeRunningMetrics } from './history';
+
+const STATUSCODE_TO_MODE: Record<string, HeatPumpMode> = {
+  'Heating': 'HEATING',
+  'Warm Water': 'DHW',
+  'Standby': 'STANDBY',
+  'Deicing active': 'DEICING',
+  'Frost protection': 'FROST_PROTECTION',
+};
 
 Device.registerProvider('ebusd', {
   getCapabilities(device) {
@@ -66,7 +75,13 @@ nowAndSetInterval(createBackgroundTransaction('ebusd:poll', async () => {
 
     updateState(() => client.getCurrentPower(), (v) => deviceCapability.setCurrentPowerState(roundTo1DecimalPlace(v))),
     updateState(() => client.getCurrentYield(), (v) => deviceCapability.setCurrentYieldState(roundTo1DecimalPlace(v))),
-    updateState(() => client.getMode(), (v) => deviceCapability.setModeState(v)),
+    updateState(() => client.getMode(), (raw) => {
+      const mode = STATUSCODE_TO_MODE[raw];
+      if (!mode) {
+        throw new Error(`Unknown ebusd statuscode "${raw}"`);
+      }
+      return deviceCapability.setModeState(mode);
+    }),
     updateState(() => client.getDHWIsOn(), (v) => deviceCapability.setDHWIsOnState(v))
   ]);
 

--- a/server/src/services/ebusd/index.ts
+++ b/server/src/services/ebusd/index.ts
@@ -77,9 +77,11 @@ nowAndSetInterval(createBackgroundTransaction('ebusd:poll', async () => {
     updateState(() => client.getCurrentYield(), (v) => deviceCapability.setCurrentYieldState(roundTo1DecimalPlace(v))),
     updateState(() => client.getMode(), (raw) => {
       const mode = STATUSCODE_TO_MODE[raw];
+
       if (!mode) {
         throw new Error(`Unknown ebusd statuscode "${raw}"`);
       }
+      
       return deviceCapability.setModeState(mode);
     }),
     updateState(() => client.getDHWIsOn(), (v) => deviceCapability.setDHWIsOnState(v))


### PR DESCRIPTION
## Summary

Adds native string-valued events alongside the existing `BooleanEvent`/`NumericEvent`, with the same lifecycle semantics (no new row on identical value — just bump `lastReported`). Capabilities can declare `"type": "string"` in `capabilities.json`, optionally with an `"enum": [...]` for fixed vocabularies (the codegen'd setter then takes a union literal).

Storage: one new nullable `stringValue VARCHAR(255)` column on the existing polymorphic `events` table — string rows leave `value` null. No new table; same pattern as booleans-in-FLOAT today.

Migrates **HeatPump.Mode** from numeric+lookup to native string as a canary:

- `HEAT_PUMP_MODES` dictionary in `device-helpers.ts` deleted
- `mapHeatPumpModeEvent` → `mapStringEvent` (generic)
- `Record<number, string>` parameter collapsed off `mapEnumHistoryToResponse` and the internal `mapEnumHistory` helper in `device/timeline.ts`
- `HeatPumpMode` TypeScript enum → string union type
- `MODES` in `ebusd/client.ts` → string literals
- Migration `22` rewrites historic mode rows in place

The wire format is unchanged: heat-pump mode already serialised as `EnumEventApiResponse { value: string }` — only storage and internal types change, so no UI change needed.

This PR is sequenced as a prereq for `claude/integrate-sony-bravia-tv-7agH7`, which uses string events for the TV's CurrentSource property and unlocks the future HomeConnect integration where every appliance has its own string-vocab state machine (Dishwasher.ActiveProgram, Oven.OperationState, etc).

## Test plan

- [x] `npm run codegen` regenerates capabilities cleanly
- [x] `npm run lint` — clean
- [x] `npm run test` — 41 passed (35 existing + 6 new `setStringProperty` cases mirroring the existing `setNumericProperty` / `setBooleanProperty` suites)
- [x] `npm run build` — clean
- [ ] Apply migrations against a copy of prod (`npm run migrate`): confirm `stringValue` column added and historic `mode` rows now have `stringValue='HEATING'` etc. with `value=NULL`
- [ ] Boot dev server; heat-pump device API returns `mode: { value: 'HEATING', ... }` exactly as before
- [ ] Trigger a mode change; new event row writes `stringValue` populated, `value` null
- [ ] Heat-pump mode graph overlay (`/insights/heating` + device history view) still renders mode bands correctly

https://claude.ai/code/session_018K6KQj5s7B2Y6LKDLqcdnK

---
_Generated by [Claude Code](https://claude.ai/code/session_018K6KQj5s7B2Y6LKDLqcdnK)_