### PR TITLE
Move Shelly integration onto MQTT

### DIFF
--- a/server/src/components/capabilities/registry.tsx
+++ b/server/src/components/capabilities/registry.tsx
@@ -210,28 +210,100 @@ function createCapability<E extends CapabilityEvent | null>(
 // ============================================================================
 
 export const registry: CapabilityUIRegistry = {
-  LIGHT: {
-    priority: 30,
+  CAMERA: {
+    priority: 10,
+    getCapabilityMetrics: (cap) => [
+      createCapability(cap.snapshotUrl, {
+        icon: faVideo,
+        title: 'Camera',
+        value: 'Active',
+        iconColor: '#04A7F4',
+      }),
+    ],
+  },
+
+  ELECTRIC_VEHICLE: {
+    priority: 15,
     getCapabilityMetrics: (cap, device) => [
-      createCapability(cap.isOn, {
-        icon: faLightbulb,
-        title: 'Status',
-        value: (e) => e.value ? 'On' : 'Off',
-        iconColor: '#ffa24d',
+      createCapability(cap.odometer, {
+        icon: faRoad,
+        title: 'Mileage',
+        value: (e) => `${Math.round(e.value).toLocaleString()} mi`,
+      }),
+      createCapability(cap.chargePercentage, {
+        icon: (e) => {
+          if (e.value === null || e.value <= 25) return faBatteryEmpty;
+          if (e.value > 75) return faBatteryFull;
+          if (e.value > 50) return faBatteryHalf;
+          return faBatteryQuarter;
+        },
+        title: 'Battery',
+        value: (e) => `${e.value.toFixed(0)}%`,
+        iconColor: (e) => {
+          if (e.value > 50) return '#2ecc71';
+          if (e.value > 25) return '#f39c12';
+          return '#e74c3c';
+        },
+        iconHighlighted: !!cap.isCharging.value,
+      }),
+      createCapability(cap.isCableConnected, {
+        icon: faPlug,
+        title: 'Cable',
+        value: (e) => e.value ? 'Connected' : 'Disconnected',
+        iconColor: '#04A7F4',
         iconHighlighted: (e) => e.value,
-        onIconClick: async ({ queryClient }) => {
-          const data = await updateLight(device.id, { isOn: !cap.isOn.value });
-          updateDeviceCache(queryClient, device.id, data);
+      }),
+      createCapability(cap.isCharging, {
+        icon: faBolt,
+        title: 'Charging',
+        value: (e) => e.value ? 'Yes' : 'No',
+        iconColor: '#2ecc71',
+        iconHighlighted: (e) => e.value,
+      }),
+      createCapability(cap.chargeLimit, {
+        icon: faGauge,
+        title: 'Charge Limit',
+        value: (e) => `${e.value.toFixed(0)}%`,
+        onIconClick: ({ openModal, closeModal }) => {
+          openModal(<ChargeLimitModal device={device} capability={cap} closeModal={closeModal} />);
         },
       }),
-      createCapability(cap.brightness, {
-        icon: faCircleHalfStroke,
-        title: 'Brightness',
-        value: <BrightnessControl device={device} capability={cap} />,
+      createCapability(null, {
+        icon: faCalendarCheck,
+        title: 'Schedule',
+        value: cap.chargeSchedule
+          ? `${cap.chargeSchedule.targetPercentage}% by ${dayjs(cap.chargeSchedule.targetTime).format('HH:mm')} ${humanDate(dayjs(cap.chargeSchedule.targetTime))}`
+          : 'No schedule',
+        footer: cap.chargeSchedule
+          ? cap.chargeSchedule.calculatedStartTime
+            ? `starts ${dayjs(cap.chargeSchedule.calculatedStartTime).format('HH:mm')} ${humanDate(dayjs(cap.chargeSchedule.calculatedStartTime))}`
+            : 'start TBC'
+          : undefined,
+        iconColor: cap.chargeSchedule ? '#3498db' : undefined,
+        onIconClick: ({ openModal, closeModal }) => {
+          openModal(
+            <ChargeScheduleModal device={device} capability={cap} closeModal={closeModal} />
+          );
+        },
       }),
     ],
     getGraphs: () => [
-      { id: 'light', title: 'Activity' },
+      {
+        id: 'vehicle-charge',
+        title: 'Charge & Limit',
+        yMin: 0,
+        yMax: 100,
+        overridePreset: 'custom',
+        overrideStart: dayjs().subtract(1, 'week').toISOString(),
+        overrideEnd: dayjs().toISOString(),
+      },
+      {
+        id: 'vehicle-weekly-mileage',
+        title: 'Weekly Mileage',
+        overridePreset: 'custom',
+        overrideStart: dayjs().subtract(6, 'months').startOf('week').toISOString(),
+        overrideEnd: dayjs().toISOString(),
+      },
     ],
   },
 
@@ -278,48 +350,6 @@ export const registry: CapabilityUIRegistry = {
           yPercentage: { position: 'right', min: 0, max: 100 },
         },
       },
-    ],
-  },
-
-  LOCK: {
-    priority: 35,
-    getCapabilityMetrics: (cap, device) => [
-      createCapability(cap.isLocked, {
-        icon: (e) => e.value === false ? faDoorOpen : faDoorClosed,
-        title: 'Lock',
-        value: (e) => e.value ? 'Locked' : 'Unlocked',
-        iconColor: '#04A7F4',
-        iconHighlighted: (e) => !e.value,
-        onIconClick: async ({ queryClient }) => {
-          const data = await updateLock(device.id, { isLocked: !cap.isLocked.value });
-          updateDeviceCache(queryClient, device.id, data);
-        },
-      }),
-    ],
-  },
-
-  CAMERA: {
-    priority: 10,
-    getCapabilityMetrics: (cap) => [
-      createCapability(cap.snapshotUrl, {
-        icon: faVideo,
-        title: 'Camera',
-        value: 'Active',
-        iconColor: '#04A7F4',
-      }),
-    ],
-  },
-
-  SWITCH: {
-    priority: 40,
-    getCapabilityMetrics: (cap) => [
-      createCapability(cap.isOn, {
-        icon: (e) => e.value === true ? faToggleOn : faToggleOff,
-        title: 'Switch',
-        value: (e) => e.value ? 'On' : 'Off',
-        iconColor: '#04A7F4',
-        iconHighlighted: (e) => e.value,
-      }),
     ],
   },
 
@@ -428,98 +458,57 @@ export const registry: CapabilityUIRegistry = {
     ],
   },
 
-  HUMIDITY_SENSOR: {
-    priority: 60,
-    getCapabilityMetrics: (cap) => [
-      createCapability(cap.humidity, {
-        icon: faDroplet,
-        title: 'Humidity',
-        value: (e) => `${e.value}%`,
-        iconColor: '#04A7F4',
-      }),
-    ],
-  },
-
-  TEMPERATURE_SENSOR: {
-    priority: 65,
-    getCapabilityMetrics: (cap) => [
-      createCapability(cap.currentTemperature, {
-        icon: faThermometerQuarter,
-        title: 'Current Temperature',
-        value: (e) => `${e.value.toFixed(1)}°C`,
-        iconColor: '#ff6f22',
-      }),
-    ],
-  },
-
-  MOTION_SENSOR: {
-    priority: 50,
-    getCapabilityMetrics: (cap) => [
-      createCapability(cap.hasMotion, {
-        icon: faPersonWalking,
-        title: 'Motion',
-        value: (e) => e.value ? 'Motion detected' : 'No motion',
-        iconHighlighted: (e) => e.value,
-        iconColor: '#04A7F4',
-      }),
-    ],
-  },
-
-  LIGHT_SENSOR: {
-    priority: 70,
-    getCapabilityMetrics: (cap) => [
-      createCapability(cap.illuminance, {
+  LIGHT: {
+    priority: 30,
+    getCapabilityMetrics: (cap, device) => [
+      createCapability(cap.isOn, {
         icon: faLightbulb,
-        title: 'Illuminance',
-        value: (e) => `${e.value} lx`,
-      }),
-    ],
-  },
-
-  SPEAKER: {
-    priority: 80,
-    getCapabilityMetrics: () => [
-      createCapability(null, {
-        icon: faVolumeHigh,
-        title: 'Speaker',
-        value: 'Connected',
-        since: new Date().toISOString(),
-        lastReported: new Date().toISOString(),
-      }),
-    ],
-  },
-
-  BATTERY_LEVEL_INDICATOR: {
-    priority: 90,
-    getCapabilityMetrics: (cap) => [
-      createCapability(cap.batteryPercentage, {
-        icon: (e) => {
-          if (e.value === null || e.value <= 25) return faBatteryEmpty;
-          if (e.value > 75) return faBatteryFull;
-          if (e.value > 50) return faBatteryHalf;
-          return faBatteryQuarter;
+        title: 'Status',
+        value: (e) => e.value ? 'On' : 'Off',
+        iconColor: '#ffa24d',
+        iconHighlighted: (e) => e.value,
+        onIconClick: async ({ queryClient }) => {
+          const data = await updateLight(device.id, { isOn: !cap.isOn.value });
+          updateDeviceCache(queryClient, device.id, data);
         },
-        title: 'Battery',
-        value: (e) => `${e.value}%`,
-        iconColor: (e) => {
-          if (e.value > 50) return '#2ecc71';
-          if (e.value > 25) return '#f39c12';
-          return '#e74c3c';
+      }),
+      createCapability(cap.brightness, {
+        icon: faCircleHalfStroke,
+        title: 'Brightness',
+        value: <BrightnessControl device={device} capability={cap} />,
+      }),
+    ],
+    getGraphs: () => [
+      { id: 'light', title: 'Activity' },
+    ],
+  },
+
+  LOCK: {
+    priority: 35,
+    getCapabilityMetrics: (cap, device) => [
+      createCapability(cap.isLocked, {
+        icon: (e) => e.value === false ? faDoorOpen : faDoorClosed,
+        title: 'Lock',
+        value: (e) => e.value ? 'Locked' : 'Unlocked',
+        iconColor: '#04A7F4',
+        iconHighlighted: (e) => !e.value,
+        onIconClick: async ({ queryClient }) => {
+          const data = await updateLock(device.id, { isLocked: !cap.isLocked.value });
+          updateDeviceCache(queryClient, device.id, data);
         },
-        isIssue: (e) => e.value <= 25,
       }),
     ],
   },
 
-  BATTERY_LOW_INDICATOR: {
-    priority: 91,
+  SWITCH: {
+    priority: 40,
     getCapabilityMetrics: (cap) => [
-      createCapability(cap.isLow, {
-        icon: (e) => e.value === false ? faBatteryFull : faBatteryEmpty,
-        title: 'Battery',
-        value: (e) => e.value ? 'LOW' : 'OK',
-        iconColor: (e) => e.value ? '#e74c3c' : '#2ecc71',
-        isIssue: (e) => e.value,
+      createCapability(cap.isOn, {
+        icon: (e) => e.value === true ? faToggleOn : faToggleOff,
+        title: 'Switch',
+        value: (e) => e.value ? 'On' : 'Off',
+        iconColor: '#04A7F4',
+        iconHighlighted: (e) => e.value,
       }),
     ],
   },
@@ -549,28 +538,14 @@ export const registry: CapabilityUIRegistry = {
     },
   },
 
-  BUTTON: {
-    priority: 85,
+  MOTION_SENSOR: {
+    priority: 50,
     getCapabilityMetrics: (cap) => [
-      createCapability(cap.lastPressed, {
-        icon: faHandPointer,
-        title: 'Last Pressed',
-        value: (e) => e
-          ? `${humanDate(dayjs(e.start))} at ${dayjs(e.start).format('HH:mm')}`
-          : 'Never',
-        iconColor: '#04A7F4',
-      }),
-      createCapability(null, {
-        icon: faCalendarDay,
-        title: "Today's Presses",
-        value: cap.pressesToday.toString(),
-        iconColor: '#04A7F4',
-        iconHighlighted: cap.pressesToday > 0,
-      }),
-      createCapability(null, {
-        icon: faHashtag,
-        title: 'Total Presses',
-        value: cap.totalPresses.toString(),
+      createCapability(cap.hasMotion, {
+        icon: faPersonWalking,
+        title: 'Motion',
+        value: (e) => e.value ? 'Motion detected' : 'No motion',
+        iconHighlighted: (e) => e.value,
         iconColor: '#04A7F4',
       }),
     ],
@@ -612,15 +587,85 @@ export const registry: CapabilityUIRegistry = {
     ],
   },
 
-  ELECTRIC_VEHICLE: {
-    priority: 15,
-    getCapabilityMetrics: (cap, device) => [
-      createCapability(cap.odometer, {
-        icon: faRoad,
-        title: 'Mileage',
-        value: (e) => `${Math.round(e.value).toLocaleString()} mi`,
+  HUMIDITY_SENSOR: {
+    priority: 60,
+    getCapabilityMetrics: (cap) => [
+      createCapability(cap.humidity, {
+        icon: faDroplet,
+        title: 'Humidity',
+        value: (e) => `${e.value}%`,
+        iconColor: '#04A7F4',
       }),
-      createCapability(cap.chargePercentage, {
+    ],
+  },
+
+  TEMPERATURE_SENSOR: {
+    priority: 65,
+    getCapabilityMetrics: (cap) => [
+      createCapability(cap.currentTemperature, {
+        icon: faThermometerQuarter,
+        title: 'Current Temperature',
+        value: (e) => `${e.value.toFixed(1)}°C`,
+        iconColor: '#ff6f22',
+      }),
+    ],
+  },
+
+  LIGHT_SENSOR: {
+    priority: 70,
+    getCapabilityMetrics: (cap) => [
+      createCapability(cap.illuminance, {
+        icon: faLightbulb,
+        title: 'Illuminance',
+        value: (e) => `${e.value} lx`,
+      }),
+    ],
+  },
+
+  SPEAKER: {
+    priority: 80,
+    getCapabilityMetrics: () => [
+      createCapability(null, {
+        icon: faVolumeHigh,
+        title: 'Speaker',
+        value: 'Connected',
+        since: new Date().toISOString(),
+        lastReported: new Date().toISOString(),
+      }),
+    ],
+  },
+
+  BUTTON: {
+    priority: 85,
+    getCapabilityMetrics: (cap) => [
+      createCapability(cap.lastPressed, {
+        icon: faHandPointer,
+        title: 'Last Pressed',
+        value: (e) => e
+          ? `${humanDate(dayjs(e.start))} at ${dayjs(e.start).format('HH:mm')}`
+          : 'Never',
+        iconColor: '#04A7F4',
+      }),
+      createCapability(null, {
+        icon: faCalendarDay,
+        title: "Today's Presses",
+        value: cap.pressesToday.toString(),
+        iconColor: '#04A7F4',
+        iconHighlighted: cap.pressesToday > 0,
+      }),
+      createCapability(null, {
+        icon: faHashtag,
+        title: 'Total Presses',
+        value: cap.totalPresses.toString(),
+        iconColor: '#04A7F4',
+      }),
+    ],
+  },
+
+  BATTERY_LEVEL_INDICATOR: {
+    priority: 90,
+    getCapabilityMetrics: (cap) => [
+      createCapability(cap.batteryPercentage, {
         icon: (e) => {
           if (e.value === null || e.value <= 25) return faBatteryEmpty;
           if (e.value > 75) return faBatteryFull;
@@ -628,91 +673,32 @@ export const registry: CapabilityUIRegistry = {
           return faBatteryQuarter;
         },
         title: 'Battery',
-        value: (e) => `${e.value.toFixed(0)}%`,
+        value: (e) => `${e.value}%`,
         iconColor: (e) => {
           if (e.value > 50) return '#2ecc71';
           if (e.value > 25) return '#f39c12';
           return '#e74c3c';
         },
-        iconHighlighted: !!cap.isCharging.value,
+        isIssue: (e) => e.value <= 25,
       }),
-      createCapability(cap.isCableConnected, {
-        icon: faPlug,
-        title: 'Cable',
-        value: (e) => e.value ? 'Connected' : 'Disconnected',
-        iconColor: '#04A7F4',
-        iconHighlighted: (e) => e.value,
-      }),
-      createCapability(cap.isCharging, {
-        icon: faBolt,
-        title: 'Charging',
-        value: (e) => e.value ? 'Yes' : 'No',
-        iconColor: '#2ecc71',
-        iconHighlighted: (e) => e.value,
-      }),
-      createCapability(cap.chargeLimit, {
-        icon: faGauge,
-        title: 'Charge Limit',
-        value: (e) => `${e.value.toFixed(0)}%`,
-        onIconClick: ({ openModal, closeModal }) => {
-          openModal(<ChargeLimitModal device={device} capability={cap} closeModal={closeModal} />);
-        },
-      }),
-      createCapability(null, {
-        icon: faCalendarCheck,
-        title: 'Schedule',
-        value: cap.chargeSchedule
-          ? `${cap.chargeSchedule.targetPercentage}% by ${dayjs(cap.chargeSchedule.targetTime).format('HH:mm')} ${humanDate(dayjs(cap.chargeSchedule.targetTime))}`
-          : 'No schedule',
-        footer: cap.chargeSchedule
-          ? cap.chargeSchedule.calculatedStartTime
-            ? `starts ${dayjs(cap.chargeSchedule.calculatedStartTime).format('HH:mm')} ${humanDate(dayjs(cap.chargeSchedule.calculatedStartTime))}`
-            : 'start TBC'
-          : undefined,
-        iconColor: cap.chargeSchedule ? '#3498db' : undefined,
-        onIconClick: ({ openModal, closeModal }) => {
-          openModal(
-            <ChargeScheduleModal device={device} capability={cap} closeModal={closeModal} />
-          );
-        },
-      }),
-    ],
-    getGraphs: () => [
-      {
-        id: 'vehicle-charge',
-        title: 'Charge & Limit',
-        yMin: 0,
-        yMax: 100,
-        overridePreset: 'custom',
-        overrideStart: dayjs().subtract(1, 'week').toISOString(),
-        overrideEnd: dayjs().toISOString(),
-      },
-      {
-        id: 'vehicle-weekly-mileage',
-        title: 'Weekly Mileage',
-        overridePreset: 'custom',
-        overrideStart: dayjs().subtract(6, 'months').startOf('week').toISOString(),
-        overrideEnd: dayjs().toISOString(),
-      },
     ],
   },
 
-  CONNECTIVITY: {
-    priority: 999,
+  BATTERY_LOW_INDICATOR: {
+    priority: 91,
     getCapabilityMetrics: (cap) => [
-      createCapability(cap.isConnected, {
-        icon: faSignal,
-        title: 'Connection',
-        value: (e) => e.value ? 'Online' : 'Offline',
-        iconColor: (e) => e.value ? '#2ecc71' : '#e74c3c',
-        iconHighlighted: (e) => !e.value,
-        isIssue: (e) => !e.value,
+      createCapability(cap.isLow, {
+        icon: (e) => e.value === false ? faBatteryFull : faBatteryEmpty,
+        title: 'Battery',
+        value: (e) => e.value ? 'LOW' : 'OK',
+        iconColor: (e) => e.value ? '#e74c3c' : '#2ecc71',
+        isIssue: (e) => e.value,
       }),
     ],
   },
 
   ENERGY_MONITOR: {
-    priority: 28,
+    priority: 100,
     getCapabilityMetrics: (cap) => [
       createCapability(cap.currentPower, {
         icon: faBolt,
@@ -749,7 +735,7 @@ export const registry: CapabilityUIRegistry = {
   },
 
   ENERGY_COST: {
-    priority: 29,
+    priority: 101,
     getCapabilityMetrics: (cap) => [
       createCapability(cap.unitRate, {
         icon: faSterlingSign,
@@ -764,6 +750,20 @@ export const registry: CapabilityUIRegistry = {
     ],
     getGraphs: () => [
       { id: 'energy-unit-rate', title: 'Unit Rate (p/kWh)', yMin: 0 },
+    ],
+  },
+
+  CONNECTIVITY: {
+    priority: 999,
+    getCapabilityMetrics: (cap) => [
+      createCapability(cap.isConnected, {
+        icon: faSignal,
+        title: 'Connection',
+        value: (e) => e.value ? 'Online' : 'Offline',
+        iconColor: (e) => e.value ? '#2ecc71' : '#e74c3c',
+        iconHighlighted: (e) => !e.value,
+        isIssue: (e) => !e.value,
+      }),
     ],
   },
 };

--- a/server/src/config.d.ts
+++ b/server/src/config.d.ts
@@ -51,10 +51,11 @@ declare namespace _default {
   export namespace shelly {
     const user: string;
     const password: string;
-    const secret: string;
-    const webhook_host: string;
-    const connectivity_poll_seconds: number;
-    const connect_timeout_milliseconds: number;
+    export namespace mqtt {
+      const url: string;
+      const user: string;
+      const password: string;
+    }
   }
   export namespace tplink {
     const sync_interval_seconds: number;

--- a/server/src/models/device.ts
+++ b/server/src/models/device.ts
@@ -235,6 +235,10 @@ export class Device extends Model<InferAttributes<Device>, InferCreationAttribut
 
   static async synchronize() {
     for (const [name, { synchronize }] of Device._providers) {
+      if (!synchronize) {
+        continue;
+      }
+
       logger.info(`Synchronizing ${name}`);
 
       try {
@@ -250,7 +254,7 @@ export class Device extends Model<InferAttributes<Device>, InferCreationAttribut
   static registerProvider(name: string, handlers: ProviderHandler) {
     this._providers.set(name, handlers);
 
-    handlers.synchronize().catch(e => logger.error(e));
+    handlers.synchronize?.().catch(e => logger.error(e));
   }
 
   static getProviderCapabilities(provider: string): ProviderHandler {
@@ -273,7 +277,7 @@ type ProviderHandler = {
   provideElectricVehicleCapability?(): ProviderElectricVehicleCapability;
 
   getCapabilities(device: Device): Capability[];
-  synchronize(): Promise<void>;
+  synchronize?(): Promise<void>;
 };
 
 export default function (sequelize: Sequelize) {

--- a/server/src/models/device.ts
+++ b/server/src/models/device.ts
@@ -235,10 +235,6 @@ export class Device extends Model<InferAttributes<Device>, InferCreationAttribut
 
   static async synchronize() {
     for (const [name, { synchronize }] of Device._providers) {
-      if (!synchronize) {
-        continue;
-      }
-
       logger.info(`Synchronizing ${name}`);
 
       try {
@@ -254,7 +250,7 @@ export class Device extends Model<InferAttributes<Device>, InferCreationAttribut
   static registerProvider(name: string, handlers: ProviderHandler) {
     this._providers.set(name, handlers);
 
-    handlers.synchronize?.().catch(e => logger.error(e));
+    handlers.synchronize().catch(e => logger.error(e));
   }
 
   static getProviderCapabilities(provider: string): ProviderHandler {
@@ -277,7 +273,7 @@ type ProviderHandler = {
   provideElectricVehicleCapability?(): ProviderElectricVehicleCapability;
 
   getCapabilities(device: Device): Capability[];
-  synchronize?(): Promise<void>;
+  synchronize(): Promise<void>;
 };
 
 export default function (sequelize: Sequelize) {

--- a/server/src/package-lock.json
+++ b/server/src/package-lock.json
@@ -33,6 +33,7 @@
         "express": "^5.0.0",
         "handlebars": "^4.7.8",
         "iso8601-duration": "^2.0.0",
+        "mqtt": "^5.15.1",
         "mysql2": "^3.22.0",
         "newrelic": "^13.20.0",
         "pino": "^10.3.1",
@@ -2895,6 +2896,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -6474,6 +6484,15 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
+      "integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -6518,7 +6537,6 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -7243,6 +7261,18 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -8046,6 +8076,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/broker-factory": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.14.tgz",
+      "integrity": "sha512-L45k5HMbPIrMid0nTOZ/UPXG/c0aRuQKVrSDFIb1zOkvfiyHgYmIjc3cSiN1KwQIvRDOtKE0tfb3I9EZ3CmpQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.49"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -8536,6 +8578,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/commist": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
+      "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
+      "license": "MIT"
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -9935,6 +9983,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -10122,6 +10179,19 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-unique-numbers": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.27.tgz",
+      "integrity": "sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -10922,7 +10992,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/hermes-estree": {
@@ -11386,6 +11455,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -12982,6 +13060,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-sdsl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13723,6 +13811,147 @@
         "node": "*"
       }
     },
+    "node_modules/mqtt": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.15.1.tgz",
+      "integrity": "sha512-V1WnkGuJh3ec9QXzy5Iylw8OOBK+Xu1WhxcQ9mMpLThG+/JZIMV1PgLNRgIiqXhZnvnVLsuyxHl5A/3bHHbcAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.21",
+        "@types/ws": "^8.18.1",
+        "commist": "^3.2.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.4.1",
+        "help-me": "^5.0.0",
+        "lru-cache": "^10.4.3",
+        "minimist": "^1.2.8",
+        "mqtt-packet": "^9.0.2",
+        "number-allocator": "^1.0.14",
+        "readable-stream": "^4.7.0",
+        "rfdc": "^1.4.1",
+        "socks": "^2.8.6",
+        "split2": "^4.2.0",
+        "worker-timers": "^8.0.23",
+        "ws": "^8.18.3"
+      },
+      "bin": {
+        "mqtt": "build/bin/mqtt.js",
+        "mqtt_pub": "build/bin/pub.js",
+        "mqtt_sub": "build/bin/sub.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/mqtt-packet": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.2.tgz",
+      "integrity": "sha512-MvIY0B8/qjq7bKxdN1eD+nrljoeaai+qjLJgfRn3TiMuz0pamsIWY2bFODPZMSNmabsLANXsLl4EMoWvlaTZWA==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^6.0.8",
+        "debug": "^4.3.4",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/mqtt-packet/node_modules/bl": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
+      "integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/mqtt-packet/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/mqtt-packet/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/mqtt/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/mqtt/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/mqtt/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -14140,6 +14369,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/number-allocator": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.14.tgz",
+      "integrity": "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "js-sdsl": "4.3.0"
       }
     },
     "node_modules/object-assign": {
@@ -15203,6 +15442,21 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/process-warning": {
       "version": "5.0.0",
@@ -16564,6 +16818,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/smartcar": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/smartcar/-/smartcar-10.4.0.tgz",
@@ -16575,6 +16839,20 @@
       "engines": {
         "node": ">=18.20.0",
         "npm": ">=8.3.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/sonic-boom": {
@@ -18547,6 +18825,53 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "license": "MIT"
+    },
+    "node_modules/worker-factory": {
+      "version": "7.0.49",
+      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.49.tgz",
+      "integrity": "sha512-lW7tpgy6aUv2dFsQhv1yv+XFzdkCf/leoKRTGMPVK5/die6RrUjqgJHJf556qO+ZfytNG6wPXc17E8zzsOLUDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/worker-timers": {
+      "version": "8.0.31",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-8.0.31.tgz",
+      "integrity": "sha512-ngkq5S6JuZyztom8tDgBzorLo9byhBMko/sXfgiUD945AuzKGg1GCgDMCC3NaYkicLpGKXutONM36wEX8UbBCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1",
+        "worker-timers-broker": "^8.0.16",
+        "worker-timers-worker": "^9.0.14"
+      }
+    },
+    "node_modules/worker-timers-broker": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-8.0.16.tgz",
+      "integrity": "sha512-JyP3AvUGyPGbBGW7XiUewm2+0pN/aYo1QpVf5kdXAfkDZcN3p7NbWrG6XnyDEpDIvfHk/+LCnOW/NsuiU9riYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "broker-factory": "^3.1.14",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-timers-worker": "^9.0.14"
+      }
+    },
+    "node_modules/worker-timers-worker": {
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-9.0.14.tgz",
+      "integrity": "sha512-/qF06C60sXmSLfUl7WglvrDIbspmPOM8UrG63Dnn4bi2x4/DfqHS/+dxF5B+MdHnYO5tVuZYLHdAodrKdabTIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.49"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "9.0.2",

--- a/server/src/package.json
+++ b/server/src/package.json
@@ -28,6 +28,7 @@
     "express": "^5.0.0",
     "handlebars": "^4.7.8",
     "iso8601-duration": "^2.0.0",
+    "mqtt": "^5.15.1",
     "mysql2": "^3.22.0",
     "newrelic": "^13.20.0",
     "pino": "^10.3.1",

--- a/server/src/routes/shelly.js
+++ b/server/src/routes/shelly.js
@@ -28,13 +28,10 @@ router.get('/install', async (req, res) => {
   }
 
   if (!device) {
-    device = Device.build({
-      provider: 'shelly',
-      providerId: mqttId,
-    });
-  } else {
-    device.providerId = mqttId;
+    device = Device.build({ provider: 'shelly' });
   }
+
+  device.providerId = mqttId;
 
   let role = 'switch';
 
@@ -51,6 +48,7 @@ router.get('/install', async (req, res) => {
   device.model = model;
   device.meta.generation = generation;
   device.meta.role = role;
+
   delete device.meta.endpoint;
 
   await client.setCloudStatus(false);

--- a/server/src/routes/shelly.js
+++ b/server/src/routes/shelly.js
@@ -5,10 +5,6 @@ import DeviceClient from '../services/shelly/client/device';
 
 const router = express.Router();
 
-function hostPortFromUrl(url) {
-  return url.replace(/^[a-z]+:\/\//, '');
-}
-
 router.get('/install', async (req, res) => {
   const ip = req.query.ip;
 
@@ -24,14 +20,8 @@ router.get('/install', async (req, res) => {
   let device = await Device.findByProviderId('shelly', mqttId);
 
   if (!device) {
-    device = await Device.findByProviderId('shelly', ip);
+    device = Device.build({ provider: 'shelly', providerId: mqttId });
   }
-
-  if (!device) {
-    device = Device.build({ provider: 'shelly' });
-  }
-
-  device.providerId = mqttId;
 
   let role = 'switch';
 
@@ -55,7 +45,7 @@ router.get('/install', async (req, res) => {
   await client.setupAuthentication();
 
   await client.enableMqtt({
-    url: hostPortFromUrl(config.shelly.mqtt.url),
+    url: config.shelly.mqtt.url,
     user: config.shelly.mqtt.user,
     password: config.shelly.mqtt.password,
   });

--- a/server/src/routes/shelly.js
+++ b/server/src/routes/shelly.js
@@ -5,29 +5,9 @@ import DeviceClient from '../services/shelly/client/device';
 
 const router = express.Router();
 
-router.use((req, res, next) => {
-  if (req.query.secret !== config.shelly.secret) {
-    return res.sendStatus(401).end();
-  } else {
-    next();
-  }
-});
-
-router.get('/event', async (req, res) => {
-  const device = await Device.findByProviderIdOrError('shelly', req.query.id);
-  const isOn = req.query.action === 'on';
-  const capabilities = device.getCapabilities();
-
-  if (capabilities.includes('CONTACT_SENSOR')) {
-    await device.getContactSensorCapability().setIsClosedState(isOn);
-  } else if (capabilities.includes('LIGHT')) {
-    await device.getLightCapability().setIsOnState(isOn);
-  } else if (capabilities.includes('SWITCH')) {
-    await device.getSwitchCapability().setIsOnState(isOn);
-  }
-
-  res.sendStatus(200).end();
-});
+function hostPortFromUrl(url) {
+  return url.replace(/^[a-z]+:\/\//, '');
+}
 
 router.get('/install', async (req, res) => {
   const ip = req.query.ip;
@@ -39,13 +19,21 @@ router.get('/install', async (req, res) => {
   const client = await DeviceClient.for(ip, config.shelly.user, config.shelly.password);
   const model = await client.getModel();
   const generation = client.getGeneration();
-  let device = await Device.findByProviderId('shelly', ip);
+  const mqttId = await client.getMqttId();
+
+  let device = await Device.findByProviderId('shelly', mqttId);
+
+  if (!device) {
+    device = await Device.findByProviderId('shelly', ip);
+  }
 
   if (!device) {
     device = Device.build({
       provider: 'shelly',
-      providerId: ip,
+      providerId: mqttId,
     });
+  } else {
+    device.providerId = mqttId;
   }
 
   let role = 'switch';
@@ -61,22 +49,18 @@ router.get('/install', async (req, res) => {
   device.name = ip;
   device.manufacturer = 'Shelly';
   device.model = model;
-  device.meta.endpoint = ip;
   device.meta.generation = generation;
   device.meta.role = role;
+  delete device.meta.endpoint;
 
   await client.setCloudStatus(false);
   await client.setupAuthentication();
 
-  const eventUrl = (action) => `http://${config.shelly.webhook_host}/shelly/event?secret=${config.shelly.secret}&id=${ip}&action=${action}`;
-
-  if (role === 'contact') {
-    await client.setInputOnWebhook(eventUrl('on'));
-    await client.setInputOffWebhook(eventUrl('off'));
-  } else {
-    await client.setOutputOffWebhook(eventUrl('off'));
-    await client.setOutputOnWebhook(eventUrl('on'));
-  }
+  await client.enableMqtt({
+    url: hostPortFromUrl(config.shelly.mqtt.url),
+    user: config.shelly.mqtt.user,
+    password: config.shelly.mqtt.password,
+  });
 
   switch (model) {
     case 'SNPL-00112UK': {  // plug

--- a/server/src/services/shelly/client/gen1-device.js
+++ b/server/src/services/shelly/client/gen1-device.js
@@ -1,5 +1,4 @@
 import { stringify } from 'querystring';
-import logger from '../../../logger';
 
 export default class Gen1DeviceClient {
   constructor(ip, username, password) {
@@ -9,11 +8,7 @@ export default class Gen1DeviceClient {
   }
 
   async _request(path, args = {}) {
-    // Endpoint to define actions (webhooks) requires the "urls[]" query string parameter
-    // to literally be "urls[]", not "urls%5B%5D". By default, stringify encodes the [].
-    const res = await fetch(`http://${this._ip}${path}?${stringify(args, '&', '=', {
-      encodeURIComponent: String
-    })}`, {
+    const res = await fetch(`http://${this._ip}${path}?${stringify(args)}`, {
       headers: {
         Authorization: 'Basic ' + Buffer.from(`${this._username}:${this._password}`).toString('base64')
       }
@@ -29,7 +24,7 @@ export default class Gen1DeviceClient {
   }
 
   async setCloudStatus(enabled) {
-    return await this._request('/settings/cloud', { 
+    return await this._request('/settings/cloud', {
       enabled: enabled ? '1' : '0'
     });
   }
@@ -42,43 +37,25 @@ export default class Gen1DeviceClient {
     }
   }
 
-  async setIsOn(isOn) {
-    return await this._request('/light/0', {
-      turn: isOn ? 'on' : 'off'
-    });
-  }
-
-  async setBrightness(brightness) {
-    return await this._request('/light/0', {
-      brightness,
-      turn: brightness > 0 ? 'on' : 'off'
-    });
-  }
-
   async setupAuthentication() {
-    return await this._request('/settings/login', { 
+    return await this._request('/settings/login', {
       username: this._username,
       password: this._password,
       enabled: '1'
     });
   }
 
-  async setOutputOnWebhook(endpoint) {
-    return await this._request('/settings/actions/', {
-      index: 0,
-      enabled: true,
-      name: 'out_on_url',
-      'urls[]': encodeURIComponent(endpoint)
+  async enableMqtt({ url, user, password }) {
+    return await this._request('/settings', {
+      mqtt_enable: 'true',
+      mqtt_server: url,
+      mqtt_user: user,
+      mqtt_pass: password,
     });
   }
 
-  async setOutputOffWebhook(endpoint) {
-    return await this._request('/settings/actions/', {
-      index: 0,
-      enabled: true,
-      name: 'out_off_url',
-      'urls[]': encodeURIComponent(endpoint)
-    });
+  async getMqttId() {
+    return (await this._request('/settings')).device.hostname;
   }
 
   async getDeviceName() {

--- a/server/src/services/shelly/client/gen2plus-device.js
+++ b/server/src/services/shelly/client/gen2plus-device.js
@@ -16,7 +16,7 @@ export default class Gen2PlusDeviceClient {
 
     if (body === '') {
       return Promise.resolve();
-    } else { 
+    } else {
       return JSON.parse(body);
     }
   }
@@ -30,42 +30,27 @@ export default class Gen2PlusDeviceClient {
   }
 
   async setupAuthentication() {
-    /*
-    const deviceId = (await this._request('/rpc/Shelly.GetDeviceInfo')).id;
-    const hash = createHash('sha256').update(`${this._username}:${this.deviceId}:${this._password}`).digest('hex');
-
-    return await this._request(`/rpc/Shelly.SetAuth?user="${this._username}"&realm="${deviceId}"&ha1="${hash}"`);
-    */
-
     return Promise.resolve();
   }
 
-  async setIsOn(isOn) {
-    return await this._request(`/rpc/Switch.Set?id=0&on=${isOn ? 'true' : 'false'}`);
+  async enableMqtt({ url, user, password }) {
+    const config = {
+      enable: true,
+      server: url,
+      user,
+      pass: password,
+      topic_prefix: 'shellies'
+    };
+
+    return await this._request(`/rpc/Mqtt.SetConfig?config=${encodeURIComponent(JSON.stringify(config))}`);
   }
 
-  async setOutputOnWebhook(endpoint) {
-    return await this._request(`/rpc/Webhook.Create?cid=0&enable=true&event="switch.on"&urls=["${encodeURIComponent(endpoint)}"]`);
-  }
-
-  async setOutputOffWebhook(endpoint) {
-    return await this._request(`/rpc/Webhook.Create?cid=0&enable=true&event="switch.off"&urls=["${encodeURIComponent(endpoint)}"]`);
-  }
-
-  async setInputOnWebhook(endpoint) {
-    return await this._request(`/rpc/Webhook.Create?cid=0&enable=true&event="input.toggle_on"&urls=["${encodeURIComponent(endpoint)}"]`);
-  }
-
-  async setInputOffWebhook(endpoint) {
-    return await this._request(`/rpc/Webhook.Create?cid=0&enable=true&event="input.toggle_off"&urls=["${encodeURIComponent(endpoint)}"]`);
+  async getMqttId() {
+    return (await this._request('/rpc/Shelly.GetDeviceInfo')).id;
   }
 
   async getSwitchConfig() {
     return await this._request('/rpc/Switch.GetConfig?id=0');
-  }
-
-  async setBrightness() {
-    throw new Error();
   }
 
   async getDeviceName() {

--- a/server/src/services/shelly/index.ts
+++ b/server/src/services/shelly/index.ts
@@ -56,4 +56,6 @@ Device.registerProvider('shelly', {
       },
     };
   },
+
+  async synchronize() {},
 });

--- a/server/src/services/shelly/index.ts
+++ b/server/src/services/shelly/index.ts
@@ -1,16 +1,22 @@
 import { Device } from '../../models';
-import DeviceClient from './client/device';
-import config from '../../config';
-import logger from '../../logger';
-import nowAndSetInterval from '../../helpers/now-and-set-interval';
-import sleep from '../../helpers/sleep';
+import { Capability } from '../../models/capabilities/capabilities.gen';
+import { publishCommand } from './mqtt';
+
+const TOPIC_PREFIX = 'shellies';
 
 Device.registerProvider('shelly', {
   getCapabilities(device) {
     switch (device.meta.generation) {
       case 1:
-      case 2:
-        return ['LIGHT', 'CONNECTIVITY'];
+      case 2: {
+        const caps: Capability[] = ['LIGHT', 'CONNECTIVITY'];
+
+        if (device.model === 'SHDM-2') {
+          caps.push('ENERGY_MONITOR');
+        }
+
+        return caps;
+      }
       case 3:
         return ['SWITCH', 'CONNECTIVITY'];
       case 4:
@@ -25,79 +31,29 @@ Device.registerProvider('shelly', {
   provideLightCapability() {
     return {
       setBrightness(device: Device, brightness: number) {
-        const shellyDevice = DeviceClient.forGeneration(device.meta.generation as number, device.meta.endpoint as string, config.shelly.user, config.shelly.password);
-
-        return shellyDevice.setBrightness(brightness);
+        return publishCommand(
+          `${TOPIC_PREFIX}/${device.providerId}/light/0/set`,
+          JSON.stringify({ turn: brightness > 0 ? 'on' : 'off', brightness })
+        );
       },
 
       setIsOn(device: Device, isOn: boolean) {
-        const shellyDevice = DeviceClient.forGeneration(device.meta.generation as number, device.meta.endpoint as string, config.shelly.user, config.shelly.password);
-
-        return shellyDevice.setIsOn(isOn);
+        return publishCommand(
+          `${TOPIC_PREFIX}/${device.providerId}/light/0/command`,
+          isOn ? 'on' : 'off'
+        );
       },
     };
   },
 
   provideSwitchCapability() {
     return {
-      async setIsOn(device: Device, isOn: boolean) {
-        const shellyDevice = DeviceClient.forGeneration(device.meta.generation as number, device.meta.endpoint as string, config.shelly.user, config.shelly.password);
-
-        return await shellyDevice.setIsOn(isOn);
+      setIsOn(device: Device, isOn: boolean) {
+        return publishCommand(
+          `${TOPIC_PREFIX}/${device.providerId}/command/switch:0`,
+          isOn ? 'on' : 'off'
+        );
       },
     };
   },
-
-  async synchronize() {
-    const devices = await Device.findByProvider('shelly');
-
-    for (const device of devices) {
-      try {
-        const shellyDevice = DeviceClient.forGeneration(device.meta.generation as number, device.meta.endpoint as string, config.shelly.user, config.shelly.password);
-        const newName = await shellyDevice.getDeviceName();
-
-        if (newName !== null) {
-          device.name = newName;
-        }
-
-        // TODO: Eventually move this to "on create" (right now we also have to correct existing devices)
-        if (device.getCapabilities().includes('LIGHT')) {
-          const brightnessEvent = await device.getLightCapability().getBrightnessEvent();
-
-          if (brightnessEvent === null) {
-            await device.getLightCapability().setBrightnessState(100, device.createdAt);
-
-            logger.info(`Initialized brightness for Shelly light device ${device.id}`);
-          }
-        }
-
-        device.manufacturer = 'Shelly';
-        device.model = await shellyDevice.getModel() || 'Unknown';
-
-        await device.save();
-      } catch (e) {
-        logger.error(e, `Failed to synchronize Shelly device ${device.id} (${device.name})`);
-      }
-    }
-  }
 });
-
-async function probeShellyDevice(device: Device): Promise<boolean> {
-  const shellyDevice = DeviceClient.forGeneration(device.meta.generation as number, device.meta.endpoint as string, config.shelly.user, config.shelly.password);
-
-  const result = await Promise.race([
-    shellyDevice.getDeviceName().then(() => true).catch(() => false),
-    sleep(Math.max(config.shelly.connect_timeout_milliseconds, 5000)).then(() => false)
-  ]);
-
-  return result;
-}
-
-nowAndSetInterval(async () => {
-  const devices = await Device.findByProvider('shelly');
-
-  await Promise.all(devices.map(async device => {
-    const isConnected = await probeShellyDevice(device);
-    await device.getConnectivityCapability().setIsConnectedState(isConnected);
-  }));
-}, Math.max(config.shelly.connectivity_poll_seconds, 30) * 1000);

--- a/server/src/services/shelly/mqtt.ts
+++ b/server/src/services/shelly/mqtt.ts
@@ -21,6 +21,7 @@ function getClient(): MqttClient {
       client!.subscribe([
         `${TOPIC_PREFIX}/+/online`,
         `${TOPIC_PREFIX}/+/light/0/status`,
+        `${TOPIC_PREFIX}/+/light/0/power`,
         `${TOPIC_PREFIX}/+/status/switch:0`,
         `${TOPIC_PREFIX}/+/status/input:0`,
       ], (err) => {
@@ -69,8 +70,12 @@ async function handleMessage(topic: string, payload: string): Promise<void> {
       await device.getLightCapability().setBrightnessState(data.brightness);
     }
 
+    return;
+  }
+
+  if (subtopic === 'light/0/power') {
     if (capabilities.includes('ENERGY_MONITOR')) {
-      await device.getEnergyMonitorCapability().setCurrentPowerState(data.power);
+      await device.getEnergyMonitorCapability().setCurrentPowerState(parseFloat(payload));
     }
 
     return;
@@ -81,10 +86,6 @@ async function handleMessage(topic: string, payload: string): Promise<void> {
 
     if (capabilities.includes('SWITCH')) {
       await device.getSwitchCapability().setIsOnState(data.output);
-    }
-
-    if (capabilities.includes('ENERGY_MONITOR')) {
-      await device.getEnergyMonitorCapability().setCurrentPowerState(data.apower);
     }
 
     return;

--- a/server/src/services/shelly/mqtt.ts
+++ b/server/src/services/shelly/mqtt.ts
@@ -1,0 +1,127 @@
+import { connect, MqttClient } from 'mqtt';
+import { Device } from '../../models';
+import config from '../../config';
+import logger from '../../logger';
+
+const TOPIC_PREFIX = 'shellies';
+
+let client: MqttClient | null = null;
+
+function getClient(): MqttClient {
+  if (client === null) {
+    client = connect(config.shelly.mqtt.url, {
+      username: config.shelly.mqtt.user,
+      password: config.shelly.mqtt.password,
+      reconnectPeriod: 5000,
+    });
+
+    client.on('connect', () => {
+      logger.info('Shelly MQTT connected');
+
+      client!.subscribe([
+        `${TOPIC_PREFIX}/+/online`,
+        `${TOPIC_PREFIX}/+/light/0/status`,
+        `${TOPIC_PREFIX}/+/relay/0/status`,
+        `${TOPIC_PREFIX}/+/status/switch:0`,
+        `${TOPIC_PREFIX}/+/status/input:0`,
+      ], (err) => {
+        if (err) {
+          logger.error(err, 'Shelly MQTT subscribe failed');
+        }
+      });
+    });
+
+    client.on('error', (err) => {
+      logger.error(err, 'Shelly MQTT error');
+    });
+
+    client.on('message', (topic, payload) => {
+      handleMessage(topic, payload.toString()).catch((err) => {
+        logger.error(err, `Shelly MQTT failed to handle ${topic}`);
+      });
+    });
+  }
+
+  return client;
+}
+
+async function handleMessage(topic: string, payload: string): Promise<void> {
+  const segments = topic.split('/');
+
+  if (segments.length < 3 || segments[0] !== TOPIC_PREFIX) {
+    return;
+  }
+
+  const mqttId = segments[1];
+  const device = await Device.findByProviderId('shelly', mqttId);
+
+  if (device === null) {
+    return;
+  }
+
+  const subtopic = segments.slice(2).join('/');
+  const capabilities = device.getCapabilities();
+
+  if (subtopic === 'online') {
+    await device.getConnectivityCapability().setIsConnectedState(payload === 'true');
+    return;
+  }
+
+  if (subtopic === 'light/0/status' || subtopic === 'relay/0/status') {
+    const data = JSON.parse(payload);
+
+    if (capabilities.includes('LIGHT')) {
+      if (typeof data.ison === 'boolean') {
+        await device.getLightCapability().setIsOnState(data.ison);
+      }
+
+      if (typeof data.brightness === 'number') {
+        await device.getLightCapability().setBrightnessState(data.brightness);
+      }
+    }
+
+    if (capabilities.includes('ENERGY_MONITOR') && typeof data.power === 'number') {
+      await device.getEnergyMonitorCapability().setCurrentPowerState(data.power);
+    }
+
+    return;
+  }
+
+  if (subtopic === 'status/switch:0') {
+    const data = JSON.parse(payload);
+
+    if (capabilities.includes('SWITCH') && typeof data.output === 'boolean') {
+      await device.getSwitchCapability().setIsOnState(data.output);
+    }
+
+    if (capabilities.includes('ENERGY_MONITOR') && typeof data.apower === 'number') {
+      await device.getEnergyMonitorCapability().setCurrentPowerState(data.apower);
+    }
+
+    return;
+  }
+
+  if (subtopic === 'status/input:0' && capabilities.includes('CONTACT_SENSOR')) {
+    const data = JSON.parse(payload);
+
+    if (typeof data.state === 'boolean') {
+      await device.getContactSensorCapability().setIsClosedState(data.state);
+    }
+
+    return;
+  }
+}
+
+export function publishCommand(topic: string, payload: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    getClient().publish(topic, payload, { qos: 1 }, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+getClient();

--- a/server/src/services/shelly/mqtt.ts
+++ b/server/src/services/shelly/mqtt.ts
@@ -21,7 +21,6 @@ function getClient(): MqttClient {
       client!.subscribe([
         `${TOPIC_PREFIX}/+/online`,
         `${TOPIC_PREFIX}/+/light/0/status`,
-        `${TOPIC_PREFIX}/+/relay/0/status`,
         `${TOPIC_PREFIX}/+/status/switch:0`,
         `${TOPIC_PREFIX}/+/status/input:0`,
       ], (err) => {
@@ -47,11 +46,6 @@ function getClient(): MqttClient {
 
 async function handleMessage(topic: string, payload: string): Promise<void> {
   const segments = topic.split('/');
-
-  if (segments.length < 3 || segments[0] !== TOPIC_PREFIX) {
-    return;
-  }
-
   const mqttId = segments[1];
   const device = await Device.findByProviderId('shelly', mqttId);
 
@@ -67,20 +61,15 @@ async function handleMessage(topic: string, payload: string): Promise<void> {
     return;
   }
 
-  if (subtopic === 'light/0/status' || subtopic === 'relay/0/status') {
+  if (subtopic === 'light/0/status') {
     const data = JSON.parse(payload);
 
     if (capabilities.includes('LIGHT')) {
-      if (typeof data.ison === 'boolean') {
-        await device.getLightCapability().setIsOnState(data.ison);
-      }
-
-      if (typeof data.brightness === 'number') {
-        await device.getLightCapability().setBrightnessState(data.brightness);
-      }
+      await device.getLightCapability().setIsOnState(data.ison);
+      await device.getLightCapability().setBrightnessState(data.brightness);
     }
 
-    if (capabilities.includes('ENERGY_MONITOR') && typeof data.power === 'number') {
+    if (capabilities.includes('ENERGY_MONITOR')) {
       await device.getEnergyMonitorCapability().setCurrentPowerState(data.power);
     }
 
@@ -90,11 +79,11 @@ async function handleMessage(topic: string, payload: string): Promise<void> {
   if (subtopic === 'status/switch:0') {
     const data = JSON.parse(payload);
 
-    if (capabilities.includes('SWITCH') && typeof data.output === 'boolean') {
+    if (capabilities.includes('SWITCH')) {
       await device.getSwitchCapability().setIsOnState(data.output);
     }
 
-    if (capabilities.includes('ENERGY_MONITOR') && typeof data.apower === 'number') {
+    if (capabilities.includes('ENERGY_MONITOR')) {
       await device.getEnergyMonitorCapability().setCurrentPowerState(data.apower);
     }
 
@@ -104,9 +93,7 @@ async function handleMessage(topic: string, payload: string): Promise<void> {
   if (subtopic === 'status/input:0' && capabilities.includes('CONTACT_SENSOR')) {
     const data = JSON.parse(payload);
 
-    if (typeof data.state === 'boolean') {
-      await device.getContactSensorCapability().setIsClosedState(data.state);
-    }
+    await device.getContactSensorCapability().setIsClosedState(data.state);
 
     return;
   }

--- a/server/src/services/shelly/mqtt.ts
+++ b/server/src/services/shelly/mqtt.ts
@@ -9,7 +9,7 @@ let client: MqttClient | null = null;
 
 function getClient(): MqttClient {
   if (client === null) {
-    client = connect(config.shelly.mqtt.url, {
+    client = connect(`mqtt://${config.shelly.mqtt.url}`, {
       username: config.shelly.mqtt.user,
       password: config.shelly.mqtt.password,
       reconnectPeriod: 5000,


### PR DESCRIPTION
Based on `claude/add-energy-monitoring-PZ2YN`. Merges after that branch lands.

## Summary

- Replace the Shelly HTTP webhook + connectivity-poll flow with a single MQTT broker connection. On/off, brightness, power, contact, and connectivity (via LWT) all arrive as MQTT messages; outbound commands publish to the device's command topic.
- Delete `GET /shelly/event` and the 30s connectivity poller.
- Gate `ENERGY_MONITOR` on `device.model === 'SHDM-2'` (Dimmer 2). Live Watts come from the dimmer status topic and feed the daily aggregator via the existing `setCurrentPowerState`.
- `device.providerId` is now the MQTT id (e.g. `shellydimmer2-A4CF12AB1234`), matching the topic segment exactly. The IP is no longer persisted - karen only talks HTTP to the device during `/shelly/install`. `meta.endpoint` is removed.
- `synchronize` is now optional on `ProviderHandler`; the Shelly provider drops it (name/model are set at install and don't change without a re-install).

## Config changes

`config.json` (out of repo) needs a new block under `shelly`:

```json
"shelly": {
  "user": "...",
  "password": "...",
  "mqtt": {
    "url": "mqtt://broker:1883",
    "user": "...",
    "password": "..."
  }
}
```

Remove `secret`, `webhook_host`, `connectivity_poll_seconds`, `connect_timeout_milliseconds`.

## Migration

Each existing Shelly needs a one-time `GET /shelly/install?ip=<ip>` re-run. The install:
- discovers the MQTT id (`shellydimmer2-...` / `shellyplus1-...`),
- writes it to `providerId`,
- pushes MQTT config to the device (Gen 1 via `/settings`, Gen 2+ via `Mqtt.SetConfig` with `topic_prefix: "shellies"`),
- reboots.

Until re-run a device is uncontrollable (HTTP control paths are gone).

## Out of scope

Gen 4 BLU contact sensors (BLE -> gateway). The existing `meta.role === 'contact'` flow is a native Gen 4 Plus in detached-input mode and is covered by the standard Gen 2+ MQTT topics.

## Test plan

- [ ] `nvm use && npm install && npm run codegen && npm run lint && npm test && npm run build`
- [ ] Re-run `/shelly/install?ip=<ip>` for a Dimmer 2. Confirm `providerId` flipped from IP to `shellydimmer2-...` in the DB and `meta.endpoint` is gone.
- [ ] `mosquitto_sub -v -t 'shellies/#'` shows `light/0/status` JSON with `power` and `online` flipping to `true` on boot.
- [ ] UI toggle publishes to `shellies/<id>/light/0/command`.
- [ ] Pull device power; `online` -> `false` and connectivity card flips offline.
- [ ] Dimmer 2 card shows live Watts; brightness/on-off via the physical switch propagates to karen in real time.
- [ ] Re-install a non-Dimmer-2 Shelly; capabilities stay `['SWITCH', 'CONNECTIVITY']`, no Energy Monitor card.
- [ ] Wait at least 15 min; `services/energy/index.ts` writes `DayEnergy` (and `DayCost`) events for the Dimmer 2 and it appears on `/insights/energy`.
- [ ] `curl /shelly/event` returns 404.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeWnZaka4MmzR73WKYtTe3)_