### PR TITLE
Fix Gen2+ Shelly MQTT topic prefix and status notifications

### DIFF
--- a/server/src/routes/shelly.js
+++ b/server/src/routes/shelly.js
@@ -45,6 +45,7 @@ router.get('/install', async (req, res) => {
   await client.setupAuthentication();
 
   await client.enableMqtt({
+    id: mqttId,
     url: config.shelly.mqtt.url,
     user: config.shelly.mqtt.user,
     password: config.shelly.mqtt.password,

--- a/server/src/services/shelly/client/gen2plus-device.js
+++ b/server/src/services/shelly/client/gen2plus-device.js
@@ -33,13 +33,14 @@ export default class Gen2PlusDeviceClient {
     return Promise.resolve();
   }
 
-  async enableMqtt({ url, user, password }) {
+  async enableMqtt({ url, user, password, id }) {
     const config = {
       enable: true,
       server: url,
       user,
       pass: password,
-      topic_prefix: 'shellies'
+      topic_prefix: `shellies/${id}`,
+      status_ntf: true
     };
 
     return await this._request(`/rpc/Mqtt.SetConfig?config=${encodeURIComponent(JSON.stringify(config))}`);


### PR DESCRIPTION
## Summary

Gen2+/Gen3/Gen4 Shelly devices weren't sending MQTT events through to karen, while Gen1 Dimmer 2s worked fine. Two bugs in the install flow (`enableMqtt` in `gen2plus-device.js`):

- **`topic_prefix` was `"shellies"`** — Gen2+ devices then published to `shellies/online`, `shellies/status/switch:0`, etc. with **no device-id segment**. The MQTT subscriber (`services/shelly/mqtt.ts`) subscribes to `shellies/+/...`, where the `+` wildcard *requires* that segment — so no Gen2+ messages ever matched, and every Gen2+ device collided into a single shared namespace. Now set to `shellies/<id>`, matching the Gen1 scheme and the subscription pattern.
- **`status_ntf` was unset** (defaults to `false`) — this is the "Generic status update over MQTT" device setting. Without it, the device only publishes RPC-framed messages to `events/rpc` (which karen does not consume) and never the `status/<component>` topics karen's handler parses. Now explicitly set to `true`.

The install route passes the MQTT id through to `enableMqtt` so it can build the per-device prefix.

## Migration note

Existing Gen2+ devices were installed with the broken config. Each needs a one-time re-run of `GET /shelly/install?ip=<ip>` for the corrected `topic_prefix` / `status_ntf` to take effect (the device reboots as part of install).

## Test plan

- [x] `npm run lint` and `npm test` pass
- [ ] Re-run `/shelly/install` for a Gen3/Gen4 device; confirm in MQTT Explorer it now publishes under `shellies/<id>/...` (with the id segment) and emits `shellies/<id>/status/switch:0`
- [ ] Confirm the device's `online` LWT and switch state propagate to its karen card
- [ ] Confirm toggling the card publishes to `shellies/<id>/command/switch:0` and the device responds

https://claude.ai/code/session_01GeWnZaka4MmzR73WKYtTe3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeWnZaka4MmzR73WKYtTe3)_