### PR TITLE
Convert heat pump power to watts for the energy monitor

### DIFF
--- a/server/src/components/capabilities/registry.tsx
+++ b/server/src/components/capabilities/registry.tsx
@@ -408,7 +408,7 @@ export const registry: CapabilityUIRegistry = {
       { id: 'heatpump-power', title: 'Power' },
       { id: 'heatpump-compressor-power', title: 'Compressor Power', yMin: 0 },
       { id: 'heatpump-compressor-modulation', title: 'Compressor Modulation', yMin: 0, yMax: 100 },
-      { id: 'heatpump-cumulative-energy', title: 'Cumulative Energy (Wh)', yMin: 0 },
+      { id: 'heatpump-cumulative-energy', title: 'Cumulative Energy (kWh)', yMin: 0 },
       { id: 'heatpump-outside-temp', title: 'Outside Temperature', yMin: -10 },
       { id: 'heatpump-dhw-temp', title: 'DHW Temperature' },
       { id: 'heatpump-flow-temp', title: 'Flow/ Return Temperatures' },

--- a/server/src/routes/api/device/history.ts
+++ b/server/src/routes/api/device/history.ts
@@ -118,17 +118,17 @@ const historyFetchers = new Map<string, HistoryFetcher>([
     return {
       lines: await Promise.all([
         mapNumericHistoryToResponse((hs) => heatPump.getDayCumulativePowerHistory(hs), selector)
-          .then(data => ({ data, label: 'Total Power (Wh)' })),
+          .then(data => ({ data, label: 'Total Power (kWh)' })),
         mapNumericHistoryToResponse((hs) => heatPump.getDayHeatingCumulativePowerHistory(hs), selector)
-          .then(data => ({ data, label: 'Heating Power (Wh)' })),
+          .then(data => ({ data, label: 'Heating Power (kWh)' })),
         mapNumericHistoryToResponse((hs) => heatPump.getDayDHWCumulativePowerHistory(hs), selector)
-          .then(data => ({ data, label: 'DHW Power (Wh)' })),
+          .then(data => ({ data, label: 'DHW Power (kWh)' })),
         mapNumericHistoryToResponse((hs) => heatPump.getDayCumulativeYieldHistory(hs), selector)
-          .then(data => ({ data, label: 'Total Yield (Wh)' })),
+          .then(data => ({ data, label: 'Total Yield (kWh)' })),
         mapNumericHistoryToResponse((hs) => heatPump.getDayHeatingCumulativeYieldHistory(hs), selector)
-          .then(data => ({ data, label: 'Heating Yield (Wh)' })),
+          .then(data => ({ data, label: 'Heating Yield (kWh)' })),
         mapNumericHistoryToResponse((hs) => heatPump.getDayDHWCumulativeYieldHistory(hs), selector)
-          .then(data => ({ data, label: 'DHW Yield (Wh)' })),
+          .then(data => ({ data, label: 'DHW Yield (kWh)' })),
       ])
     };
   }],
@@ -198,9 +198,9 @@ const historyFetchers = new Map<string, HistoryFetcher>([
         .then(data => ({ data, label: 'CoP', yAxisID: 'yCoP' })),
       lines: Promise.all([
         mapNumericHistoryToResponse((hs) => heatPump.getDayPowerHistory(hs), selector)
-          .then(data => ({ data, label: 'Power (Wh)', yAxisID: 'yEnergy' })),
+          .then(data => ({ data, label: 'Power (kWh)', yAxisID: 'yEnergy' })),
         mapNumericHistoryToResponse((hs) => heatPump.getDayYieldHistory(hs), selector)
-          .then(data => ({ data, label: 'Yield (Wh)', yAxisID: 'yEnergy' }))
+          .then(data => ({ data, label: 'Yield (kWh)', yAxisID: 'yEnergy' }))
       ])
     });
   }],
@@ -214,9 +214,9 @@ const historyFetchers = new Map<string, HistoryFetcher>([
         .then(data => ({ data, label: 'Heating CoP', yAxisID: 'yCoP' })),
       lines: Promise.all([
         mapNumericHistoryToResponse((hs) => heatPump.getDayHeatingPowerHistory(hs), selector)
-          .then(data => ({ data, label: 'Heating Power (Wh)', yAxisID: 'yEnergy' })),
+          .then(data => ({ data, label: 'Heating Power (kWh)', yAxisID: 'yEnergy' })),
         mapNumericHistoryToResponse((hs) => heatPump.getDayHeatingYieldHistory(hs), selector)
-          .then(data => ({ data, label: 'Heating Yield (Wh)', yAxisID: 'yEnergy' }))
+          .then(data => ({ data, label: 'Heating Yield (kWh)', yAxisID: 'yEnergy' }))
       ])
     });
   }],
@@ -230,9 +230,9 @@ const historyFetchers = new Map<string, HistoryFetcher>([
         .then(data => ({ data, label: 'DHW CoP', yAxisID: 'yCoP' })),
       lines: Promise.all([
         mapNumericHistoryToResponse((hs) => heatPump.getDayDHWPowerHistory(hs), selector)
-          .then(data => ({ data, label: 'DHW Power (Wh)', yAxisID: 'yEnergy' })),
+          .then(data => ({ data, label: 'DHW Power (kWh)', yAxisID: 'yEnergy' })),
         mapNumericHistoryToResponse((hs) => heatPump.getDayDHWYieldHistory(hs), selector)
-          .then(data => ({ data, label: 'DHW Yield (Wh)', yAxisID: 'yEnergy' }))
+          .then(data => ({ data, label: 'DHW Yield (kWh)', yAxisID: 'yEnergy' }))
       ])
     });
   }],

--- a/server/src/services/ebusd/client.ts
+++ b/server/src/services/ebusd/client.ts
@@ -109,13 +109,11 @@ export default class EbusClient {
   }
 
   async getCurrentYield(): Promise<number> {
-    // ebusd reports power in kW; Karen works in W throughout.
-    return this.#read({ value: 'CurrentYieldPower', circuit: 'hmu' }, (raw) => toNumber(raw) * 1000);
+    return this.#read({ value: 'CurrentYieldPower', circuit: 'hmu' }, toNumber);
   }
 
   async getCurrentPower(): Promise<number> {
-    // ebusd reports power in kW; Karen works in W throughout.
-    return this.#read({ value: 'CurrentConsumedPower', circuit: 'hmu' }, (raw) => toNumber(raw) * 1000);
+    return this.#read({ value: 'CurrentConsumedPower', circuit: 'hmu' }, toNumber);
   }
 
   async getMode(): Promise<string> {

--- a/server/src/services/ebusd/client.ts
+++ b/server/src/services/ebusd/client.ts
@@ -109,11 +109,13 @@ export default class EbusClient {
   }
 
   async getCurrentYield(): Promise<number> {
-    return this.#read({ value: 'CurrentYieldPower', circuit: 'hmu' }, toNumber);
+    // ebusd reports power in kW; Karen works in W throughout.
+    return this.#read({ value: 'CurrentYieldPower', circuit: 'hmu' }, (raw) => toNumber(raw) * 1000);
   }
 
   async getCurrentPower(): Promise<number> {
-    return this.#read({ value: 'CurrentConsumedPower', circuit: 'hmu' }, toNumber);
+    // ebusd reports power in kW; Karen works in W throughout.
+    return this.#read({ value: 'CurrentConsumedPower', circuit: 'hmu' }, (raw) => toNumber(raw) * 1000);
   }
 
   async getMode(): Promise<string> {

--- a/server/src/services/ebusd/index.ts
+++ b/server/src/services/ebusd/index.ts
@@ -76,7 +76,8 @@ nowAndSetInterval(createBackgroundTransaction('ebusd:poll', async () => {
 
     updateState(() => client.getCurrentPower(), (v) => Promise.all([
       heatPumpCapability.setCurrentPowerState(roundTo1DecimalPlace(v)),
-      energyMonitorCapability.setCurrentPowerState(roundTo1DecimalPlace(v))
+      // ebusd reports power in kW; the energy monitor works in W, like every other device.
+      energyMonitorCapability.setCurrentPowerState(v * 1000)
     ])),
     updateState(() => client.getCurrentYield(), (v) => heatPumpCapability.setCurrentYieldState(roundTo1DecimalPlace(v))),
     updateState(() => client.getMode(), (raw) => {


### PR DESCRIPTION
## Summary

The eBUSd integration reads `CurrentConsumedPower` from the Vaillant heat pump in **kilowatts**. The `ENERGY_MONITOR` capability — like Shelly, Z-Wave and the vehicle integration — works in **watts**. As a result the heat pump showed `1.4` in the Energy monitor where a lightbulb correctly shows `14W`: the value was 1000x too small.

## Changes

**1. Convert the reading to watts for the energy monitor** (`services/ebusd/index.ts`)

Convert to watts (`v * 1000`) only when feeding `energyMonitorCapability.setCurrentPowerState`.

The `HeatPump` capability deliberately keeps its kW reading:

- Its daily aggregates go through `calculateWattHours`, producing kWh, and the device card formats `dayPower`/`dayYield` as `kWh` — already correct.
- CoP is `(power + yield) / power`, a unit-agnostic ratio.
- Converting `current_power` there would inflate the card's "Today's Power"/"Today's Yield" by 1000x.

So only the energy monitor's view of the reading needs the conversion.

**2. Relabel heat pump energy graphs as kWh** (`routes/api/device/history.ts`, `components/capabilities/registry.tsx`)

The heat pump day/cumulative power & yield aggregates are in kWh (kW integrated over hours), but the history graphs labelled them `(Wh)`. The device card already formats them as `kWh`; the graph labels now match.

## Notes

Historical `energy_current_power` / `energy_day_energy` / `energy_day_cost` rows for the heat pump device are still in the old units; corrected separately via a one-off SQL `UPDATE`, not a migration.

## Test plan

- [ ] After a poll cycle, the heat pump shows realistic wattage (~1400W) in the Energy monitor
- [ ] Heat pump card "Today's Power" / "Today's Yield" / CoP unchanged and still sensible
- [ ] Heat pump daily-metrics / cumulative-energy graphs display the kWh label
- [ ] Daily energy / cost for the heat pump in the Energy monitor read in the expected magnitude going forward

https://claude.ai/code/session_01RY1otyUjpnhS4kpLxqQacX