### PR TITLE
Round Shelly wattage to 1 decimal place

### DIFF
--- a/server/src/services/shelly/mqtt.ts
+++ b/server/src/services/shelly/mqtt.ts
@@ -75,7 +75,7 @@ async function handleMessage(topic: string, payload: string): Promise<void> {
 
   if (subtopic === 'light/0/power') {
     if (capabilities.includes('ENERGY_MONITOR')) {
-      await device.getEnergyMonitorCapability().setCurrentPowerState(parseFloat(payload));
+      await device.getEnergyMonitorCapability().setCurrentPowerState(Math.round(parseFloat(payload) * 10) / 10);
     }
 
     return;


### PR DESCRIPTION
## Summary
- Shelly energy monitors report power on the `light/0/power` MQTT topic to 2 decimal places. Tiny sub-watt fluctuations each produce a distinct value, and since `setNumericProperty` only skips creating a new event row when the value is unchanged, this generates excessive event churn ("noise").
- This rounds the incoming power reading to 1 decimal place at ingestion (`services/shelly/mqtt.ts`), so small fluctuations collapse to the same value and stop creating new rows.

## Test plan
- [ ] Confirm a Shelly `SHDM-2` (ENERGY_MONITOR) still records power changes, now at 1 dp.
- [ ] Verify the energy graph for a Shelly device shows fewer redundant data points.

https://claude.ai/code/session_0137U2xkosX3rY9gdhw9fRm2

---
_Generated by [Claude Code](https://claude.ai/code/session_0137U2xkosX3rY9gdhw9fRm2)_