### PR TITLE
Persist Claude Code login across devcontainer rebuilds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,9 @@
   "forwardPorts": [8081],
   "initializeCommand": "touch ${localWorkspaceFolder}/../CLAUDE.local.md",
   "postCreateCommand": "bash /workspace/.devcontainer/post-create.sh",
+  "containerEnv": {
+    "CLAUDE_CONFIG_DIR": "/root/.claude"
+  },
   "mounts": [
     "source=claude-code-config,target=/root/.claude,type=volume",
     "source=karen-devcontainer-ssh-${devcontainerId},target=/root/.ssh,type=volume",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,10 +7,9 @@
   "initializeCommand": "touch ${localWorkspaceFolder}/../CLAUDE.local.md",
   "postCreateCommand": "bash /workspace/.devcontainer/post-create.sh",
   "containerEnv": {
-    "CLAUDE_CONFIG_DIR": "/root/.claude"
+    "CLAUDE_CONFIG_DIR": "/root/.config/claude"
   },
   "mounts": [
-    "source=claude-code-config,target=/root/.claude,type=volume",
     "source=karen-devcontainer-ssh-${devcontainerId},target=/root/.ssh,type=volume",
     "source=karen-devcontainer-config-${devcontainerId},target=/root/.config,type=volume",
     "source=${localWorkspaceFolder}/../CLAUDE.local.md,target=/workspace/CLAUDE.local.md,type=bind",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -50,6 +50,10 @@ chmod 644 ~/.ssh/known_hosts
 # Install Claude Code CLI
 npm install -g @anthropic-ai/claude-code
 
+# CLAUDE_CONFIG_DIR lives in a subdir of the persisted ~/.config volume;
+# create it so Claude Code's login state survives rebuilds.
+mkdir -p "$CLAUDE_CONFIG_DIR"
+
 # Running `claude` inside the container always skips permission prompts,
 # since the container itself is the security boundary.
 echo "alias claude='claude --dangerously-skip-permissions'" >> ~/.bashrc


### PR DESCRIPTION
## Summary

Stops Claude Code from prompting for login every time the devcontainer is rebuilt.

The auth token (`.credentials.json`) was already persisting via a volume, but Claude Code also stores account/onboarding state in `~/.claude.json` — a file in the **home directory root**, outside `~/.claude/`. That file was lost on every rebuild, which re-triggered the login/onboarding flow despite the token surviving.

The fix sets `CLAUDE_CONFIG_DIR` so Claude Code keeps **all** its state (`.credentials.json` and `.claude.json`) in one directory. That directory is a subfolder of the existing `karen-devcontainer-config` volume already mounted at `/root/.config`, so the standalone `claude-code-config` volume is no longer needed and has been dropped — one mount instead of two.

## Changes

- `.devcontainer/devcontainer.json`: add `containerEnv.CLAUDE_CONFIG_DIR=/root/.config/claude`; remove the standalone `claude-code-config` mount
- `.devcontainer/post-create.sh`: `mkdir -p "$CLAUDE_CONFIG_DIR"` so the subdir exists in the fresh volume before Claude Code first runs

## Notes

- Claude config is now scoped per `devcontainerId` (consistent with the SSH key and `.config` volume), rather than the previous globally-shared volume.
- One final re-login is expected after this lands — the config is created fresh in its new location, then persists from there.
- The old `claude-code-config` Docker volume is now orphaned and can be removed with `docker volume rm claude-code-config`.

## Test plan

- [ ] Rebuild the devcontainer, log in to Claude Code once
- [ ] Rebuild again and confirm no login/onboarding prompt appears

https://claude.ai/code/session_01UggyztbfN9ME4MSdq41k5B