### PR TITLE
Fix energy day totals stuck at 0 by passing now as reportedAt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,7 @@ Device.registerProvider('providerName', {
 - Store using the start of the period as the timestamp (e.g., Monday 00:00 for weekly data)
 - Use the same timestamp to update existing events rather than creating duplicates
 - Fill historical gaps by querying the last stored period and calculating forward
+- **Always pass `reportedAt = now` (current time) as the third argument to the setter, distinct from `stateTimestamp` (period start).** If `reportedAt` defaults to `stateTimestamp`, the "same value" branch in `setNumericProperty` writes `lastReported = period_start` instead of the current time. The resume calculation (`dayjs(latestEvent.lastReported).startOf('day')`) then resolves back to that same period and the catch-up loop replays it on every run indefinitely — instead of jumping to today where the new value can differ and trigger a proper new event. The heat pump service demonstrates the correct pattern: `capability.setDayPowerState(value, dayStart, intervalEnd)`.
 
 **Event-Driven Updates**: Device changes emit events via `DeviceCapabilityEvents`, which trigger SSE (Server-Sent Events) for real-time UI updates.
 

--- a/server/src/services/energy/index.ts
+++ b/server/src/services/energy/index.ts
@@ -61,13 +61,13 @@ async function storeDailyEnergyForDevice(
     const clampedPower = filterClampAndSortHistory(powerHistory, dayStart, dayEnd, false);
     const kWh = Math.round(calculateWattHours(clampedPower) / 10) / 100;
 
-    await energyMonitor.setDayEnergyState(kWh, dayStart);
+    await energyMonitor.setDayEnergyState(kWh, dayStart, now);
 
     const rateHistory = await energyCost.getUnitRateHistory({ since: dayStart, until: dayEnd });
     const cost = calculateDayCost(powerHistory, rateHistory, dayStart, dayEnd);
 
     if (cost !== null) {
-      await energyMonitor.setDayCostState(cost, dayStart);
+      await energyMonitor.setDayCostState(cost, dayStart, now);
     }
   }
 }


### PR DESCRIPTION
setDayEnergyState/setDayCostState were defaulting reportedAt to
dayStart (midnight), so the "same value" branch in setNumericProperty
kept setting lastReported to the stuck day's midnight rather than the
current time. On every subsequent run, startDay resolved back to that
same midnight and the loop replayed from April 1 BST indefinitely.

Passing now as reportedAt mirrors the heat pump service pattern
(intervalEnd), so lastReported always reflects when the service last
ran. The next run then resolves startDay to today, processes today's
non-zero kWh, and creates a fresh event.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>