### PR TITLE
Refactor Shelly capabilities by model and record plug energy usage

### DIFF
--- a/server/src/routes/shelly.js
+++ b/server/src/routes/shelly.js
@@ -14,7 +14,6 @@ router.get('/install', async (req, res) => {
 
   const client = await DeviceClient.for(ip, config.shelly.user, config.shelly.password);
   const model = await client.getModel();
-  const generation = client.getGeneration();
   const mqttId = await client.getMqttId();
 
   let device = await Device.findByProviderId('shelly', mqttId);
@@ -23,21 +22,9 @@ router.get('/install', async (req, res) => {
     device = Device.build({ provider: 'shelly', providerId: mqttId });
   }
 
-  let role = 'switch';
-
-  if (generation === 4) {
-    const switchConfig = await client.getSwitchConfig();
-
-    if (switchConfig.in_mode === 'detached') {
-      role = 'contact';
-    }
-  }
-
   device.name = ip;
   device.manufacturer = 'Shelly';
   device.model = model;
-  device.meta.generation = generation;
-  device.meta.role = role;
 
   delete device.meta.endpoint;
 

--- a/server/src/services/shelly/index.ts
+++ b/server/src/services/shelly/index.ts
@@ -1,30 +1,25 @@
 import { Device } from '../../models';
-import { Capability } from '../../models/capabilities/capabilities.gen';
 import { publishCommand } from './mqtt';
 
 const TOPIC_PREFIX = 'shellies';
 
 Device.registerProvider('shelly', {
   getCapabilities(device) {
-    switch (device.meta.generation) {
-      case 1:
-      case 2: {
-        const caps: Capability[] = ['LIGHT', 'CONNECTIVITY'];
+    switch (device.model) {
+      case 'SHDM-2':       // Shelly Dimmer 2
+        return ['LIGHT', 'ENERGY_MONITOR', 'CONNECTIVITY'];
 
-        if (device.model === 'SHDM-2') {
-          caps.push('ENERGY_MONITOR');
-        }
+      case 'SNPL-00112UK': // Shelly Plus Plug UK
+        return ['SWITCH', 'ENERGY_MONITOR', 'CONNECTIVITY'];
 
-        return caps;
-      }
-      case 3:
+      case 'S3SW-001X8EU': // Shelly Plus 1 Mini (Heating)
         return ['SWITCH', 'CONNECTIVITY'];
-      case 4:
-        return device.meta.role === 'contact'
-          ? ['CONTACT_SENSOR', 'CONNECTIVITY']
-          : ['SWITCH', 'CONNECTIVITY'];
+
+      case 'S4SW-001X8EU': // Shelly 1 Mini Gen4 (Fire Alarm)
+        return ['CONTACT_SENSOR', 'CONNECTIVITY'];
+
       default:
-        throw new Error(`Cannot infer capabilities for device ${device.id}`);
+        throw new Error(`Cannot infer capabilities for device ${device.id} (${device.model})`);
     }
   },
 

--- a/server/src/services/shelly/mqtt.ts
+++ b/server/src/services/shelly/mqtt.ts
@@ -88,6 +88,10 @@ async function handleMessage(topic: string, payload: string): Promise<void> {
       await device.getSwitchCapability().setIsOnState(data.output);
     }
 
+    if (capabilities.includes('ENERGY_MONITOR')) {
+      await device.getEnergyMonitorCapability().setCurrentPowerState(Math.round(data.apower * 10) / 10);
+    }
+
     return;
   }
 


### PR DESCRIPTION
## Summary

- Replaces generation/role-based capability inference in `getCapabilities()` with a direct `switch` on `device.model`, making each Shelly model's capabilities explicit and easier to grok
- Removes `meta.generation` and `meta.role` from the install route — they were only ever used for capability inference and are no longer read anywhere
- Fixes energy monitoring for the Shelly Plus Plug UK (`SNPL-00112UK`) by reading `apower` from `status/switch:0` MQTT messages, which were previously only used for switch state

## Test plan

- [ ] Verify lint passes (`npm run lint`)
- [ ] Confirm `energy_current_power` events appear in the `events` table for device 238 after the plug sends an MQTT status message
- [ ] Confirm existing dimmer devices (SHDM-2) still report power correctly via `light/0/power`
- [ ] Confirm fire alarm (S4SW-001X8EU) and heating (S3SW-001X8EU) capabilities are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)