### PR TITLE
Integrate Oven, Microwave & Dishwasher via Home Connect API

### DIFF
--- a/server/src/api/types.ts
+++ b/server/src/api/types.ts
@@ -94,6 +94,22 @@ export type CapabilityApiResponse = {
   unitRate: NumericStateApiResponse;
   standingCharge: NumericStateApiResponse;
 } | {
+  type: 'OVEN';
+  runningProgram: EnumStateApiResponse;
+  setpointTemperature: NumericStateApiResponse;
+  currentTemperature: NumericStateApiResponse;
+} | {
+  type: 'MICROWAVE';
+  runningProgram: EnumStateApiResponse;
+  estimatedCompletionTime: NumericStateApiResponse;
+} | {
+  type: 'DISHWASHER';
+  runningProgram: EnumStateApiResponse;
+  estimatedCompletionTime: NumericStateApiResponse;
+  lastSelfCareRun: EnumStateApiResponse | null;
+  isSaltLow: BooleanStateApiResponse;
+  isRinseAidLow: BooleanStateApiResponse;
+} | {
   type: null;
 };
 

--- a/server/src/capabilities.json
+++ b/server/src/capabilities.json
@@ -437,22 +437,67 @@
 }, {
   "name": "Oven",
   "properties": [
-    { "name": "ProgramName",         "isWriteable": false, "type": "string", "eventName": "program_name" },
-    { "name": "SetpointTemperature", "isWriteable": false, "type": "number", "eventName": "setpoint_temperature" },
-    { "name": "CurrentTemperature",  "isWriteable": false, "type": "number", "eventName": "current_temperature" }
+    {
+      "name": "ProgramName",
+      "isWriteable": false,
+      "type": "string",
+      "eventName": "program_name"
+    },
+    {
+      "name": "SetpointTemperature",
+      "isWriteable": true,
+      "type": "number",
+      "eventName": "setpoint_temperature"
+    },
+    {
+      "name": "CurrentTemperature",
+      "isWriteable": false,
+      "type": "number",
+      "eventName": "current_temperature"
+    }
   ]
 }, {
   "name": "Microwave",
   "properties": [
-    { "name": "ProgramName",             "isWriteable": false, "type": "string", "eventName": "program_name" },
-    { "name": "EstimatedCompletionTime", "isWriteable": false, "type": "number", "eventName": "estimated_completion_time" }
+    {
+      "name": "ProgramName",
+      "isWriteable": false,
+      "type": "string",
+      "eventName": "program_name"
+    },
+    {
+      "name": "EstimatedCompletionTime",
+      "isWriteable": false,
+      "type": "number",
+      "eventName": "estimated_completion_time"
+    }
   ]
 }, {
   "name": "Dishwasher",
   "properties": [
-    { "name": "ProgramName",             "isWriteable": false, "type": "string",  "eventName": "program_name" },
-    { "name": "EstimatedCompletionTime", "isWriteable": false, "type": "number",  "eventName": "estimated_completion_time" },
-    { "name": "IsSaltLow",               "isWriteable": false, "type": "boolean", "eventName": "is_salt_low" },
-    { "name": "IsRinseAidLow",           "isWriteable": false, "type": "boolean", "eventName": "is_rinse_aid_low" }
+    {
+      "name": "ProgramName",
+      "isWriteable": false,
+      "type": "string",
+      "eventName": "program_name"
+    },
+    {
+      "name": "EstimatedCompletionTime",
+      "isWriteable": false,
+      "type": "number",
+      "eventName": "estimated_completion_time"
+    },
+    {
+      "name": "IsSaltLow",
+      "isWriteable": false,
+      "type": "boolean",
+      "eventName": "is_salt_low"
+    },
+    {
+      "name": "IsRinseAidLow",
+      "isWriteable": false,
+      "type": "boolean",
+      "eventName": "is_rinse_aid_low"
+    }
   ]
 }]

--- a/server/src/capabilities.json
+++ b/server/src/capabilities.json
@@ -434,4 +434,25 @@
       "eventName": "energy_standing_charge"
     }
   ]
+}, {
+  "name": "Oven",
+  "properties": [
+    { "name": "ProgramName",         "isWriteable": false, "type": "string", "eventName": "program_name" },
+    { "name": "SetpointTemperature", "isWriteable": false, "type": "number", "eventName": "setpoint_temperature" },
+    { "name": "CurrentTemperature",  "isWriteable": false, "type": "number", "eventName": "current_temperature" }
+  ]
+}, {
+  "name": "Microwave",
+  "properties": [
+    { "name": "ProgramName",             "isWriteable": false, "type": "string", "eventName": "program_name" },
+    { "name": "EstimatedCompletionTime", "isWriteable": false, "type": "number", "eventName": "estimated_completion_time" }
+  ]
+}, {
+  "name": "Dishwasher",
+  "properties": [
+    { "name": "ProgramName",             "isWriteable": false, "type": "string",  "eventName": "program_name" },
+    { "name": "EstimatedCompletionTime", "isWriteable": false, "type": "number",  "eventName": "estimated_completion_time" },
+    { "name": "IsSaltLow",               "isWriteable": false, "type": "boolean", "eventName": "is_salt_low" },
+    { "name": "IsRinseAidLow",           "isWriteable": false, "type": "boolean", "eventName": "is_rinse_aid_low" }
+  ]
 }]

--- a/server/src/codegen/templates/capabilities.ts.hbs
+++ b/server/src/codegen/templates/capabilities.ts.hbs
@@ -6,6 +6,7 @@ import {
   setBooleanProperty,
   getStringProperty,
   setStringProperty,
+  clearStringProperty,
   getBooleanPropertyHistory,
   getNumericPropertyHistory,
   getStringPropertyHistory,
@@ -85,6 +86,15 @@ export class {{className}} {
 
     if (event !== null) {
       DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}Changed(new StringEvent(event));
+    }
+  }
+
+  async clear{{propertyName}}State(stateTimestamp?: Date, reportedAt?: Date): Promise<void> {
+    const now = new Date();
+    const event = await clearStringProperty(this.device, '{{fieldName}}', stateTimestamp ?? now, reportedAt ?? now);
+
+    if (event !== null) {
+      DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}Changed(event);
     }
   }
 

--- a/server/src/components/capabilities/registry.tsx
+++ b/server/src/components/capabilities/registry.tsx
@@ -825,25 +825,14 @@ export const registry: CapabilityUIRegistry = {
         value: (e) => e.value ? 'Low' : 'OK',
         isIssue: (e) => e.value,
       }),
-      ...(cap.lastSelfCareRun !== null ? [
-        createCapability(cap.lastSelfCareRun, {
-          icon: faWrench,
-          title: 'Machine Care',
-          value: (e) => dayjs(e.end ?? e.start).fromNow(),
-          isIssue: (e) => {
-            const ts = e.end ?? e.start;
-            return Date.now() - new Date(ts).getTime() > 30 * 24 * 3600_000;
-          },
-        }),
-      ] : [
-        createCapability(null, {
-          icon: faWrench,
-          title: 'Machine Care',
-          value: 'Never run',
-          isIssue: true,
-          footer: undefined,
-        }),
-      ]),
+      createCapability(cap.lastSelfCareRun, {
+        icon: faWrench,
+        title: 'Machine Care',
+        value: (e) => e !== null
+          ? (e.end === null ? 'Running now' : dayjs(e.end).fromNow())
+          : 'Never run',
+        isIssue: (e) => e === null || (e.end !== null && Date.now() - new Date(e.end).getTime() > 30 * 24 * 3600_000),
+      }),
     ],
   },
 };

--- a/server/src/components/capabilities/registry.tsx
+++ b/server/src/components/capabilities/registry.tsx
@@ -50,6 +50,7 @@ import ChargeScheduleModal from '../modals/charge-schedule-modal';
 import ChargeLimitModal from '../modals/charge-limit-modal';
 import dayjs from '../../dayjs';
 import { humanDate, formatDuration } from '../../helpers/date';
+import { RelativeDuration } from '../relative-duration';
 import type {
   MetricDisplayVariant,
   CapabilityUIRegistry,
@@ -766,6 +767,11 @@ export const registry: CapabilityUIRegistry = {
         value: (e) => e.value ?? 'Off',
         iconHighlighted: (e) => e.value !== null,
         iconColor: '#e67e22',
+      }),
+      createCapability(cap.runningProgram, {
+        icon: faClock,
+        title: 'Running for',
+        value: (e) => <RelativeDuration since={e.start} />,
       }),
       createCapability(cap.setpointTemperature, {
         icon: faThermometerFull,

--- a/server/src/components/capabilities/registry.tsx
+++ b/server/src/components/capabilities/registry.tsx
@@ -37,6 +37,11 @@ import {
   faBell,
   faSignal,
   faSterlingSign,
+  faClock,
+  faMicrochip,
+  faWrench,
+  faFlaskVial,
+  faWind,
 } from '@fortawesome/free-solid-svg-icons';
 import { useQueryClient, QueryClient } from '@tanstack/react-query';
 import type { CapabilityApiResponse, RestDeviceResponse, DeviceApiResponse, LightUpdateRequest, LockUpdateRequest } from '../../api/types';
@@ -749,6 +754,96 @@ export const registry: CapabilityUIRegistry = {
         iconHighlighted: (e) => !e.value,
         isIssue: (e) => !e.value,
       }),
+    ],
+  },
+
+  OVEN: {
+    priority: 12,
+    getCapabilityMetrics: (cap) => [
+      createCapability(cap.runningProgram, {
+        icon: faFire,
+        title: 'Program',
+        value: (e) => e.value ?? 'Off',
+        iconHighlighted: (e) => e.value !== null,
+        iconColor: '#e67e22',
+      }),
+      createCapability(cap.setpointTemperature, {
+        icon: faThermometerFull,
+        title: 'Target Temp',
+        value: (e) => `${e.value}°`,
+      }),
+      createCapability(cap.currentTemperature, {
+        icon: faThermometerQuarter,
+        title: 'Cavity Temp',
+        value: (e) => `${e.value}°`,
+      }),
+    ],
+  },
+
+  MICROWAVE: {
+    priority: 13,
+    getCapabilityMetrics: (cap) => [
+      createCapability(cap.runningProgram, {
+        icon: faMicrochip,
+        title: 'Program',
+        value: (e) => e.value ?? 'Off',
+        iconHighlighted: (e) => e.value !== null,
+        iconColor: '#3498db',
+      }),
+      createCapability(cap.estimatedCompletionTime, {
+        icon: faClock,
+        title: 'Finishes',
+        value: (e) => dayjs(e.value).fromNow(),
+      }),
+    ],
+  },
+
+  DISHWASHER: {
+    priority: 14,
+    getCapabilityMetrics: (cap) => [
+      createCapability(cap.runningProgram, {
+        icon: faWind,
+        title: 'Program',
+        value: (e) => e.value ?? 'Off',
+        iconHighlighted: (e) => e.value !== null,
+        iconColor: '#2980b9',
+      }),
+      createCapability(cap.estimatedCompletionTime, {
+        icon: faClock,
+        title: 'Finishes',
+        value: (e) => dayjs(e.value).fromNow(),
+      }),
+      createCapability(cap.isSaltLow, {
+        icon: faFlaskVial,
+        title: 'Salt',
+        value: (e) => e.value ? 'Low' : 'OK',
+        isIssue: (e) => e.value,
+      }),
+      createCapability(cap.isRinseAidLow, {
+        icon: faDroplet,
+        title: 'Rinse Aid',
+        value: (e) => e.value ? 'Low' : 'OK',
+        isIssue: (e) => e.value,
+      }),
+      ...(cap.lastSelfCareRun !== null ? [
+        createCapability(cap.lastSelfCareRun, {
+          icon: faWrench,
+          title: 'Machine Care',
+          value: (e) => dayjs(e.end ?? e.start).fromNow(),
+          isIssue: (e) => {
+            const ts = e.end ?? e.start;
+            return Date.now() - new Date(ts).getTime() > 30 * 24 * 3600_000;
+          },
+        }),
+      ] : [
+        createCapability(null, {
+          icon: faWrench,
+          title: 'Machine Care',
+          value: 'Never run',
+          isIssue: true,
+          footer: undefined,
+        }),
+      ]),
     ],
   },
 };

--- a/server/src/components/relative-duration.tsx
+++ b/server/src/components/relative-duration.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { useNow } from '../hooks/use-now';
+import dayjs from '../dayjs';
+
+export function RelativeDuration({ since }: { since: string }) {
+  const now = useNow(60_000);
+
+  return <>{dayjs(since).from(dayjs(now), true)}</>;
+}

--- a/server/src/config.d.ts
+++ b/server/src/config.d.ts
@@ -89,7 +89,7 @@ declare namespace _default {
     const client_id: string;
     const client_secret: string;
     const secret: string;
-    const access_token: string;
+    let refresh_token: string;
   }
   export namespace octopus {
     const api_key: string;

--- a/server/src/hooks/use-now.ts
+++ b/server/src/hooks/use-now.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+export function useNow(intervalMs: number = 60_000): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+
+  return now;
+}

--- a/server/src/models/capabilities/helpers/index.ts
+++ b/server/src/models/capabilities/helpers/index.ts
@@ -2,7 +2,7 @@ import { BooleanEvent, Device, Event, NumericEvent, StringEvent, Op } from "../.
 
 export type TimeRangeSelector = { since: Date; until: Date };
 export type ValueFilter =
-  | { eq: number }
+  | { eq: string | number }
   | { ne: number }
   | { gt: number }
   | { gte: number }
@@ -224,7 +224,7 @@ async function getEventsInRange(device: Device, propertyName: string, selector: 
 
   if (selector.value) {
     const f = selector.value;
-    if ('eq'  in f) valueWhere = { value: f.eq };
+    if ('eq'  in f) valueWhere = typeof f.eq === 'string' ? { stringValue: f.eq } : { value: f.eq };
     else if ('ne'  in f) valueWhere = { value: { [Op.ne]:  f.ne  } };
     else if ('gt'  in f) valueWhere = { value: { [Op.gt]:  f.gt  } };
     else if ('gte' in f) valueWhere = { value: { [Op.gte]: f.gte } };
@@ -282,4 +282,18 @@ export async function getNumericPropertyHistory(device: Device, propertyName: st
 export async function getStringPropertyHistory(device: Device, propertyName: string, timeRangeSelector: HistorySelector): Promise<StringEvent[]> {
   const events = await getEventsInRange(device, propertyName, timeRangeSelector);
   return events.map((event) => new StringEvent(event));
+}
+
+export async function clearStringProperty(device: Device, eventName: string, endTime: Date, reportedAt: Date): Promise<StringEvent | null> {
+  const currentEvent = await Event.findOne({
+    where: { deviceId: device.id, type: eventName, end: null },
+    order: [['start', 'DESC']]
+  });
+
+  if (currentEvent) {
+    await currentEvent.update({ end: endTime, lastReported: reportedAt });
+    return new StringEvent(currentEvent);
+  }
+
+  return null;
 }

--- a/server/src/models/capabilities/helpers/index.ts
+++ b/server/src/models/capabilities/helpers/index.ts
@@ -29,7 +29,10 @@ export async function getLatestNumericEvent(device: Device, propertyName: string
 }
 
 export async function getLatestStringEvent(device: Device, propertyName: string): Promise<StringEvent | null> {
-  const event = await device.getLatestEvent(propertyName);
+  const event = await Event.findOne({
+    where: { deviceId: device.id, type: propertyName, end: null },
+    order: [['start', 'DESC']]
+  });
   return event ? new StringEvent(event) : null;
 }
 

--- a/server/src/models/device.ts
+++ b/server/src/models/device.ts
@@ -9,6 +9,7 @@ import {
   ProviderThermostatCapability,
   ProviderSwitchCapability,
   ProviderElectricVehicleCapability,
+  ProviderOvenCapability,
 
   LightSensorCapability,
   HumiditySensorCapability,
@@ -284,6 +285,7 @@ type ProviderHandler = {
   provideLockCapability?(): ProviderLockCapability;
   provideThermostatCapability?(): ProviderThermostatCapability;
   provideSwitchCapability?(): ProviderSwitchCapability;
+  provideOvenCapability?(): ProviderOvenCapability;
   provideSpeakerCapability?(): ProviderSpeakerCapability;
   provideElectricVehicleCapability?(): ProviderElectricVehicleCapability;
 

--- a/server/src/models/device.ts
+++ b/server/src/models/device.ts
@@ -28,7 +28,10 @@ import {
   ContactSensorCapability,
   ConnectivityCapability,
   EnergyMonitorCapability,
-  EnergyCostCapability
+  EnergyCostCapability,
+  OvenCapability,
+  MicrowaveCapability,
+  DishwasherCapability
 } from './capabilities';
 
 export class Device extends Model<InferAttributes<Device>, InferCreationAttributes<Device>> {
@@ -143,6 +146,18 @@ export class Device extends Model<InferAttributes<Device>, InferCreationAttribut
 
   getEnergyCostCapability(): EnergyCostCapability {
     return this.#getCapabilityOrThrow(() => new EnergyCostCapability(this));
+  }
+
+  getOvenCapability(): OvenCapability {
+    return this.#getCapabilityOrThrow(() => new OvenCapability(this));
+  }
+
+  getMicrowaveCapability(): MicrowaveCapability {
+    return this.#getCapabilityOrThrow(() => new MicrowaveCapability(this));
+  }
+
+  getDishwasherCapability(): DishwasherCapability {
+    return this.#getCapabilityOrThrow(() => new DishwasherCapability(this));
   }
 
   getCapabilities(): Capability[] {

--- a/server/src/routes/api/device-helpers.ts
+++ b/server/src/routes/api/device-helpers.ts
@@ -1,6 +1,4 @@
 import { Device, NumericEvent, BooleanEvent, StringEvent } from '../../models';
-
-const openOnly = (e: StringEvent | null) => (e && e.end === null ? e : null);
 import { NumericStateApiResponse, BooleanStateApiResponse, EnumStateApiResponse, RestDeviceResponse, CapabilityApiResponse } from '../../api/types';
 import dayjs from '../../dayjs';
 import { awaitPromises } from '../../helpers/promises';
@@ -281,10 +279,10 @@ export async function getCapabilityData(device: Device, capability: string): Pro
 
     case 'OVEN': {
       const oven = device.getOvenCapability();
-      const programEvent = await oven.getProgramNameEvent();
+
       return awaitPromises({
         type: 'OVEN' as const,
-        runningProgram: mapStringState(Promise.resolve(openOnly(programEvent)), device),
+        runningProgram: mapStringState(oven.getProgramNameEvent().then(e => e?.end ? null : e), device),
         setpointTemperature: mapNumericState(oven.getSetpointTemperatureEvent(), device),
         currentTemperature: mapNumericState(oven.getCurrentTemperatureEvent(), device),
       });
@@ -292,10 +290,10 @@ export async function getCapabilityData(device: Device, capability: string): Pro
 
     case 'MICROWAVE': {
       const mw = device.getMicrowaveCapability();
-      const programEvent = await mw.getProgramNameEvent();
+
       return awaitPromises({
         type: 'MICROWAVE' as const,
-        runningProgram: mapStringState(Promise.resolve(openOnly(programEvent)), device),
+        runningProgram: mapStringState(mw.getProgramNameEvent().then(e => e?.end ? null : e), device),
         estimatedCompletionTime: mapNumericState(mw.getEstimatedCompletionTimeEvent(), device),
       });
     }
@@ -303,19 +301,17 @@ export async function getCapabilityData(device: Device, capability: string): Pro
     case 'DISHWASHER': {
       const dw = device.getDishwasherCapability();
       const now = new Date();
-      const [programEvent, machineCareRuns] = await Promise.all([
-        dw.getProgramNameEvent(),
-        dw.getProgramNameHistory({
-          since: device.createdAt,
-          until: now,
-          value: { eq: 'Machine Care' },
-          limit: 2,
-        }),
-      ]);
-      const lastSelfCareRun = machineCareRuns.find(e => e.end !== null) ?? null;
+      const machineCareRuns = await dw.getProgramNameHistory({
+        since: device.createdAt,
+        until: now,
+        value: { eq: 'Machine Care' },
+        limit: 1,
+      });
+      const lastSelfCareRun = machineCareRuns[0] ?? null;
+
       return awaitPromises({
         type: 'DISHWASHER' as const,
-        runningProgram: mapStringState(Promise.resolve(openOnly(programEvent)), device),
+        runningProgram: mapStringState(dw.getProgramNameEvent().then(e => e?.end ? null : e), device),
         estimatedCompletionTime: mapNumericState(dw.getEstimatedCompletionTimeEvent(), device),
         lastSelfCareRun: lastSelfCareRun ? mapStringState(Promise.resolve(lastSelfCareRun), device) : Promise.resolve(null),
         isSaltLow: mapBooleanState(dw.getIsSaltLowEvent(), device),

--- a/server/src/routes/api/device-helpers.ts
+++ b/server/src/routes/api/device-helpers.ts
@@ -282,7 +282,7 @@ export async function getCapabilityData(device: Device, capability: string): Pro
 
       return awaitPromises({
         type: 'OVEN' as const,
-        runningProgram: mapStringState(oven.getProgramNameEvent().then(e => e?.end ? null : e), device),
+        runningProgram: mapStringState(oven.getProgramNameEvent(), device),
         setpointTemperature: mapNumericState(oven.getSetpointTemperatureEvent(), device),
         currentTemperature: mapNumericState(oven.getCurrentTemperatureEvent(), device),
       });
@@ -293,7 +293,7 @@ export async function getCapabilityData(device: Device, capability: string): Pro
 
       return awaitPromises({
         type: 'MICROWAVE' as const,
-        runningProgram: mapStringState(mw.getProgramNameEvent().then(e => e?.end ? null : e), device),
+        runningProgram: mapStringState(mw.getProgramNameEvent(), device),
         estimatedCompletionTime: mapNumericState(mw.getEstimatedCompletionTimeEvent(), device),
       });
     }
@@ -311,7 +311,7 @@ export async function getCapabilityData(device: Device, capability: string): Pro
 
       return awaitPromises({
         type: 'DISHWASHER' as const,
-        runningProgram: mapStringState(dw.getProgramNameEvent().then(e => e?.end ? null : e), device),
+        runningProgram: mapStringState(dw.getProgramNameEvent(), device),
         estimatedCompletionTime: mapNumericState(dw.getEstimatedCompletionTimeEvent(), device),
         lastSelfCareRun: lastSelfCareRun ? mapStringState(Promise.resolve(lastSelfCareRun), device) : Promise.resolve(null),
         isSaltLow: mapBooleanState(dw.getIsSaltLowEvent(), device),

--- a/server/src/routes/api/device-helpers.ts
+++ b/server/src/routes/api/device-helpers.ts
@@ -1,4 +1,6 @@
 import { Device, NumericEvent, BooleanEvent, StringEvent } from '../../models';
+
+const openOnly = (e: StringEvent | null) => (e && e.end === null ? e : null);
 import { NumericStateApiResponse, BooleanStateApiResponse, EnumStateApiResponse, RestDeviceResponse, CapabilityApiResponse } from '../../api/types';
 import dayjs from '../../dayjs';
 import { awaitPromises } from '../../helpers/promises';
@@ -274,6 +276,50 @@ export async function getCapabilityData(device: Device, capability: string): Pro
         type: 'ENERGY_COST' as const,
         unitRate: mapNumericState(energyCost.getUnitRateEvent(), device),
         standingCharge: mapNumericState(energyCost.getStandingChargeEvent(), device)
+      });
+    }
+
+    case 'OVEN': {
+      const oven = device.getOvenCapability();
+      const programEvent = await oven.getProgramNameEvent();
+      return awaitPromises({
+        type: 'OVEN' as const,
+        runningProgram: mapStringState(Promise.resolve(openOnly(programEvent)), device),
+        setpointTemperature: mapNumericState(oven.getSetpointTemperatureEvent(), device),
+        currentTemperature: mapNumericState(oven.getCurrentTemperatureEvent(), device),
+      });
+    }
+
+    case 'MICROWAVE': {
+      const mw = device.getMicrowaveCapability();
+      const programEvent = await mw.getProgramNameEvent();
+      return awaitPromises({
+        type: 'MICROWAVE' as const,
+        runningProgram: mapStringState(Promise.resolve(openOnly(programEvent)), device),
+        estimatedCompletionTime: mapNumericState(mw.getEstimatedCompletionTimeEvent(), device),
+      });
+    }
+
+    case 'DISHWASHER': {
+      const dw = device.getDishwasherCapability();
+      const now = new Date();
+      const [programEvent, machineCareRuns] = await Promise.all([
+        dw.getProgramNameEvent(),
+        dw.getProgramNameHistory({
+          since: device.createdAt,
+          until: now,
+          value: { eq: 'Machine Care' },
+          limit: 2,
+        }),
+      ]);
+      const lastSelfCareRun = machineCareRuns.find(e => e.end !== null) ?? null;
+      return awaitPromises({
+        type: 'DISHWASHER' as const,
+        runningProgram: mapStringState(Promise.resolve(openOnly(programEvent)), device),
+        estimatedCompletionTime: mapNumericState(dw.getEstimatedCompletionTimeEvent(), device),
+        lastSelfCareRun: lastSelfCareRun ? mapStringState(Promise.resolve(lastSelfCareRun), device) : Promise.resolve(null),
+        isSaltLow: mapBooleanState(dw.getIsSaltLowEvent(), device),
+        isRinseAidLow: mapBooleanState(dw.getIsRinseAidLowEvent(), device),
       });
     }
 

--- a/server/src/routes/homeconnect.ts
+++ b/server/src/routes/homeconnect.ts
@@ -29,12 +29,8 @@ router.get('/authorize', async (req, res) => {
       method: 'POST'
     });
 
-    const token = await request.json() as { access_token: string; refresh_token: string; expires_in: number };
-
-    if (!token.refresh_token) {
-      logger.error({ token }, 'HomeConnect OAuth response missing refresh_token');
-      return res.status(500).send('OAuth error: no refresh_token in response');
-    }
+    type HomeConnectTokenResponse = { access_token: string; refresh_token: string; expires_in: number };
+    const token = await request.json() as HomeConnectTokenResponse;
 
     config.homeconnect.refresh_token = token.refresh_token;
     saveConfig();

--- a/server/src/routes/homeconnect.ts
+++ b/server/src/routes/homeconnect.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import config from '../config';
 import { stringify} from 'querystring';
 import logger from '../logger';
+import { saveConfig } from '../helpers/config';
 
 const router = express.Router();
 
@@ -28,9 +29,17 @@ router.get('/authorize', async (req, res) => {
       method: 'POST'
     });
 
-    const token = await request.json();
+    const token = await request.json() as { access_token: string; refresh_token: string; expires_in: number };
 
-    logger.info(token);
+    if (!token.refresh_token) {
+      logger.error({ token }, 'HomeConnect OAuth response missing refresh_token');
+      return res.status(500).send('OAuth error: no refresh_token in response');
+    }
+
+    config.homeconnect.refresh_token = token.refresh_token;
+    saveConfig();
+    logger.info('HomeConnect authorized successfully');
+    res.send('HomeConnect authorized. You can close this tab.');
   } else {
     res.redirect(`https://api.home-connect.com/security/oauth/authorize?response_type=code&client_id=${config.homeconnect.client_id}`);
   }

--- a/server/src/services/alexa/smarthome/discovery.ts
+++ b/server/src/services/alexa/smarthome/discovery.ts
@@ -167,6 +167,147 @@ export function buildDiscoveryEndpoints(devices: Device[]): AlexaDiscoveryEndpoi
           version: '3'
         }]
       });
+    } else if (capabilities.includes('OVEN')) {
+      endpoints.push({
+        friendlyName: device.name,
+        endpointId: String(device.id),
+        displayCategories: ['OVEN'],
+        manufacturerName: device.manufacturer,
+        description: device.name,
+        capabilities: [{
+          type: 'AlexaInterface',
+          interface: 'Alexa.Cooking',
+          version: '3',
+          properties: {
+            supported: [{ name: 'cookingMode' }],
+            proactivelyReported: false,
+            retrievable: true
+          },
+          configuration: {
+            supportsRemoteStart: true,
+            supportedCookingModes: [{ value: 'OFF' }, { value: 'BAKE' }]
+          }
+        }, {
+          type: 'AlexaInterface',
+          interface: 'Alexa.Cooking.TemperatureController',
+          version: '3',
+          properties: {
+            supported: [{ name: 'targetCookingTemperature' }],
+            proactivelyReported: false,
+            retrievable: true
+          },
+          configuration: {
+            supportsRemoteStart: true,
+            supportedCookingModes: [{ value: 'BAKE' }]
+          }
+        }, {
+          type: 'AlexaInterface',
+          interface: 'Alexa.Cooking.TemperatureSensor',
+          version: '3',
+          properties: {
+            supported: [{ name: 'currentCookingTemperature' }],
+            proactivelyReported: false,
+            retrievable: true
+          }
+        }, {
+          type: 'AlexaInterface',
+          interface: 'Alexa.PowerController',
+          version: '3',
+          properties: {
+            supported: [{ name: 'powerState' }],
+            proactivelyReported: false,
+            retrievable: true
+          }
+        }, {
+          type: 'AlexaInterface',
+          interface: 'Alexa.EndpointHealth',
+          version: '3',
+          properties: {
+            supported: [{ name: 'connectivity' }],
+            proactivelyReported: false,
+            retrievable: true
+          }
+        }, {
+          type: 'AlexaInterface',
+          interface: 'Alexa',
+          version: '3'
+        }]
+      });
+    } else if (capabilities.includes('MICROWAVE')) {
+      endpoints.push({
+        friendlyName: device.name,
+        endpointId: String(device.id),
+        displayCategories: ['MICROWAVE_OVEN'],
+        manufacturerName: device.manufacturer,
+        description: device.name,
+        capabilities: [{
+          type: 'AlexaInterface',
+          interface: 'Alexa.Cooking',
+          version: '3',
+          properties: {
+            supported: [{ name: 'cookingMode' }],
+            proactivelyReported: false,
+            retrievable: true
+          },
+          configuration: {
+            supportsRemoteStart: false,
+            supportedCookingModes: [{ value: 'OFF' }]
+          }
+        }, {
+          type: 'AlexaInterface',
+          interface: 'Alexa.PowerController',
+          version: '3',
+          properties: {
+            supported: [{ name: 'powerState' }],
+            proactivelyReported: false,
+            retrievable: true
+          }
+        }, {
+          type: 'AlexaInterface',
+          interface: 'Alexa.EndpointHealth',
+          version: '3',
+          properties: {
+            supported: [{ name: 'connectivity' }],
+            proactivelyReported: false,
+            retrievable: true
+          }
+        }, {
+          type: 'AlexaInterface',
+          interface: 'Alexa',
+          version: '3'
+        }]
+      });
+    } else if (capabilities.includes('DISHWASHER')) {
+      endpoints.push({
+        friendlyName: device.name,
+        endpointId: String(device.id),
+        displayCategories: ['WASHER'],
+        manufacturerName: device.manufacturer,
+        description: device.name,
+        capabilities: [{
+          type: 'AlexaInterface',
+          interface: 'Alexa.PowerController',
+          version: '3',
+          properties: {
+            supported: [{ name: 'powerState' }],
+            proactivelyReported: false,
+            retrievable: true
+          }
+        }, {
+          type: 'AlexaInterface',
+          interface: 'Alexa.EndpointHealth',
+          version: '3',
+          properties: {
+            supported: [{ name: 'connectivity' }],
+            proactivelyReported: false,
+            retrievable: true
+          }
+        }, {
+          type: 'AlexaInterface',
+          interface: 'Alexa',
+          version: '3'
+        }]
+      });
     } else if (capabilities.includes('BUTTON')) {
       const instanceId = `${device.id}-1`;
       endpoints.push({

--- a/server/src/services/alexa/smarthome/discovery.ts
+++ b/server/src/services/alexa/smarthome/discovery.ts
@@ -211,6 +211,27 @@ export function buildDiscoveryEndpoints(devices: Device[]): AlexaDiscoveryEndpoi
           }
         }, {
           type: 'AlexaInterface',
+          interface: 'Alexa.RangeController',
+          instance: 'Oven.RunningTime',
+          version: '3',
+          properties: {
+            supported: [{ name: 'rangeValue' }],
+            proactivelyReported: false,
+            retrievable: true
+          },
+          capabilityResources: {
+            friendlyNames: [
+              { '@type': 'text', value: { text: 'running time', locale: 'en-US' } },
+              { '@type': 'text', value: { text: 'running time', locale: 'en-GB' } },
+              { '@type': 'text', value: { text: 'elapsed time', locale: 'en-GB' } }
+            ]
+          },
+          configuration: {
+            supportedRange: { minimumValue: 0, maximumValue: 1440, precision: 1 },
+            unitOfMeasure: 'Alexa.Unit.Time.Minute'
+          }
+        }, {
+          type: 'AlexaInterface',
           interface: 'Alexa.PowerController',
           version: '3',
           properties: {

--- a/server/src/services/alexa/smarthome/handlers.ts
+++ b/server/src/services/alexa/smarthome/handlers.ts
@@ -22,6 +22,7 @@ export type AlexaRequestWithEndpoint = Extract<AlexaSmartHomeRequest, { endpoint
 
 interface AlexaEndpointProperty {
   namespace: string;
+  instance?: string;
   name: string;
   value: unknown;
   timeOfSample: string;
@@ -187,6 +188,9 @@ async function createOvenResponseProperties(device: Device, sampleTime: Date, un
   ]);
 
   const isRunning = programEvent !== null;
+  const runningMinutes = programEvent
+    ? Math.max(0, Math.floor((sampleTime.getTime() - programEvent.start.getTime()) / 60_000))
+    : 0;
   const props: AlexaEndpointProperty[] = [{
     namespace: 'Alexa.PowerController',
     name: 'powerState',
@@ -197,6 +201,13 @@ async function createOvenResponseProperties(device: Device, sampleTime: Date, un
     namespace: 'Alexa.Cooking',
     name: 'cookingMode',
     value: { value: isRunning ? 'BAKE' : 'OFF' },
+    timeOfSample: sampleTime.toISOString(),
+    uncertaintyInMilliseconds
+  }, {
+    namespace: 'Alexa.RangeController',
+    instance: 'Oven.RunningTime',
+    name: 'rangeValue',
+    value: runningMinutes,
     timeOfSample: sampleTime.toISOString(),
     uncertaintyInMilliseconds
   }, {

--- a/server/src/services/alexa/smarthome/handlers.ts
+++ b/server/src/services/alexa/smarthome/handlers.ts
@@ -12,6 +12,8 @@ import {
   AlexaSetBrightnessRequest,
   AlexaAdjustBrightnessRequest,
   AlexaSecurityPanelRequest,
+  AlexaSetCookingModeRequest,
+  AlexaCookByTemperatureRequest,
   AlexaRequestEndpoint
 } from './types';
 import { ALARM_ENDPOINT_ID, buildDiscoveryEndpoints } from './discovery';
@@ -163,6 +165,175 @@ export async function handleAcceptGrant(request: AlexaAcceptGrantRequest) {
   };
 }
 
+function toCelsius(temp: { value: number; scale: 'CELSIUS' | 'FAHRENHEIT' | 'KELVIN' }): number {
+  if (temp.scale === 'CELSIUS') {
+    return temp.value;
+  }
+  if (temp.scale === 'FAHRENHEIT') {
+    return (temp.value - 32) * 5 / 9;
+  }
+  return temp.value - 273.15;
+}
+
+async function createOvenResponseProperties(device: Device, sampleTime: Date, uncertaintyInMilliseconds: number): Promise<AlexaEndpointProperty[]> {
+  const oven = device.getOvenCapability();
+  const [programEvent, currentTemp, targetTemp, connectivity] = await Promise.all([
+    oven.getProgramNameEvent(),
+    oven.getCurrentTemperature(),
+    oven.getSetpointTemperature(),
+    getConnectivityValue(device),
+  ]);
+
+  const isRunning = programEvent !== null && programEvent.end === null;
+  const props: AlexaEndpointProperty[] = [{
+    namespace: 'Alexa.PowerController',
+    name: 'powerState',
+    value: isRunning ? 'ON' : 'OFF',
+    timeOfSample: sampleTime.toISOString(),
+    uncertaintyInMilliseconds
+  }, {
+    namespace: 'Alexa.Cooking',
+    name: 'cookingMode',
+    value: { value: isRunning ? 'BAKE' : 'OFF' },
+    timeOfSample: sampleTime.toISOString(),
+    uncertaintyInMilliseconds
+  }, {
+    namespace: 'Alexa.EndpointHealth',
+    name: 'connectivity',
+    value: { value: connectivity },
+    timeOfSample: sampleTime.toISOString(),
+    uncertaintyInMilliseconds
+  }];
+
+  if (currentTemp !== null) {
+    props.push({
+      namespace: 'Alexa.Cooking.TemperatureSensor',
+      name: 'currentCookingTemperature',
+      value: { value: { value: currentTemp, scale: 'CELSIUS' } },
+      timeOfSample: sampleTime.toISOString(),
+      uncertaintyInMilliseconds
+    });
+  }
+
+  if (targetTemp !== null) {
+    props.push({
+      namespace: 'Alexa.Cooking.TemperatureController',
+      name: 'targetCookingTemperature',
+      value: { value: { value: targetTemp, scale: 'CELSIUS' } },
+      timeOfSample: sampleTime.toISOString(),
+      uncertaintyInMilliseconds
+    });
+  }
+
+  return props;
+}
+
+async function createMicrowaveResponseProperties(device: Device, sampleTime: Date, uncertaintyInMilliseconds: number): Promise<AlexaEndpointProperty[]> {
+  const mw = device.getMicrowaveCapability();
+  const [programEvent, connectivity] = await Promise.all([
+    mw.getProgramNameEvent(),
+    getConnectivityValue(device),
+  ]);
+
+  const isRunning = programEvent !== null && programEvent.end === null;
+  return [{
+    namespace: 'Alexa.PowerController',
+    name: 'powerState',
+    value: isRunning ? 'ON' : 'OFF',
+    timeOfSample: sampleTime.toISOString(),
+    uncertaintyInMilliseconds
+  }, {
+    namespace: 'Alexa.Cooking',
+    name: 'cookingMode',
+    value: { value: isRunning ? 'DEFROST' : 'OFF' },
+    timeOfSample: sampleTime.toISOString(),
+    uncertaintyInMilliseconds
+  }, {
+    namespace: 'Alexa.EndpointHealth',
+    name: 'connectivity',
+    value: { value: connectivity },
+    timeOfSample: sampleTime.toISOString(),
+    uncertaintyInMilliseconds
+  }];
+}
+
+async function createDishwasherResponseProperties(device: Device, sampleTime: Date, uncertaintyInMilliseconds: number): Promise<AlexaEndpointProperty[]> {
+  const dw = device.getDishwasherCapability();
+  const [programEvent, connectivity] = await Promise.all([
+    dw.getProgramNameEvent(),
+    getConnectivityValue(device),
+  ]);
+
+  const isRunning = programEvent !== null && programEvent.end === null;
+  return [{
+    namespace: 'Alexa.PowerController',
+    name: 'powerState',
+    value: isRunning ? 'ON' : 'OFF',
+    timeOfSample: sampleTime.toISOString(),
+    uncertaintyInMilliseconds
+  }, {
+    namespace: 'Alexa.EndpointHealth',
+    name: 'connectivity',
+    value: { value: connectivity },
+    timeOfSample: sampleTime.toISOString(),
+    uncertaintyInMilliseconds
+  }];
+}
+
+const APPLIANCE_CAPS = ['OVEN', 'MICROWAVE', 'DISHWASHER'] as const;
+
+async function responsePropsForAppliance(device: Device, sampleTime: Date, uncertainty: number): Promise<AlexaEndpointProperty[]> {
+  const caps = device.getCapabilities();
+  if (caps.includes('OVEN')) {
+    return createOvenResponseProperties(device, sampleTime, uncertainty);
+  }
+  if (caps.includes('MICROWAVE')) {
+    return createMicrowaveResponseProperties(device, sampleTime, uncertainty);
+  }
+  return createDishwasherResponseProperties(device, sampleTime, uncertainty);
+}
+
+export async function handleAppliancePowerOff(request: AlexaTurnOnOffRequest): Promise<object> {
+  if (request.header.name !== 'TurnOff') {
+    throw new Error('Remote start of this appliance is not supported');
+  }
+
+  const device = await Device.findByIdOrError(request.endpoint.endpointId);
+  const { stopHomeConnectProgram } = await import('../../homeconnect');
+  await stopHomeConnectProgram(device.providerId);
+
+  const then = new Date();
+  return controlResponse(request, await responsePropsForAppliance(device, then, 0));
+}
+
+export async function handleApplianceSetCookingMode(request: AlexaSetCookingModeRequest): Promise<object> {
+  const mode = request.payload?.cookingMode?.value;
+  const device = await Device.findByIdOrError(request.endpoint.endpointId);
+  const { stopHomeConnectProgram, cookOven } = await import('../../homeconnect');
+
+  if (mode === 'OFF') {
+    await stopHomeConnectProgram(device.providerId);
+  } else if (device.getCapabilities().includes('OVEN')) {
+    const setpoint = await device.getOvenCapability().getSetpointTemperature();
+    await cookOven(device.providerId, setpoint || 180);
+  } else {
+    throw new Error(`Cooking mode ${mode} not supported on this appliance`);
+  }
+
+  const then = new Date();
+  return controlResponse(request, await responsePropsForAppliance(device, then, 0));
+}
+
+export async function handleOvenCookByTemperature(request: AlexaCookByTemperatureRequest): Promise<object> {
+  const device = await Device.findByIdOrError(request.endpoint.endpointId);
+  const celsius = toCelsius(request.payload.targetCookingTemperature);
+  const { cookOven } = await import('../../homeconnect');
+  await cookOven(device.providerId, Math.round(celsius));
+
+  const then = new Date();
+  return controlResponse(request, await responsePropsForAppliance(device, then, 0));
+}
+
 export async function handleReportState(request: AlexaReportStateRequest) {
   const endpointId = request.endpoint.endpointId;
   const then = new Date();
@@ -178,6 +349,8 @@ export async function handleReportState(request: AlexaReportStateRequest) {
     return stateReport(request, await createLightResponseProperties(device, then, Date.now() - then.valueOf()));
   } else if (capabilities.includes('THERMOSTAT')) {
     return stateReport(request, await createThermostatResponseProperties(device, then, Date.now() - then.valueOf()));
+  } else if (capabilities.some(c => (APPLIANCE_CAPS as readonly string[]).includes(c))) {
+    return stateReport(request, await responsePropsForAppliance(device, then, Date.now() - then.valueOf()));
   } else {
     throw new Error(`Unable to report state on ${endpointId}`);
   }

--- a/server/src/services/alexa/smarthome/handlers.ts
+++ b/server/src/services/alexa/smarthome/handlers.ts
@@ -186,7 +186,7 @@ async function createOvenResponseProperties(device: Device, sampleTime: Date, un
     getConnectivityValue(device),
   ]);
 
-  const isRunning = programEvent !== null && programEvent.end === null;
+  const isRunning = programEvent !== null;
   const props: AlexaEndpointProperty[] = [{
     namespace: 'Alexa.PowerController',
     name: 'powerState',
@@ -237,7 +237,7 @@ async function createMicrowaveResponseProperties(device: Device, sampleTime: Dat
     getConnectivityValue(device),
   ]);
 
-  const isRunning = programEvent !== null && programEvent.end === null;
+  const isRunning = programEvent !== null;
   return [{
     namespace: 'Alexa.PowerController',
     name: 'powerState',
@@ -266,7 +266,7 @@ async function createDishwasherResponseProperties(device: Device, sampleTime: Da
     getConnectivityValue(device),
   ]);
 
-  const isRunning = programEvent !== null && programEvent.end === null;
+  const isRunning = programEvent !== null;
   return [{
     namespace: 'Alexa.PowerController',
     name: 'powerState',

--- a/server/src/services/alexa/smarthome/handlers.ts
+++ b/server/src/services/alexa/smarthome/handlers.ts
@@ -169,9 +169,11 @@ function toCelsius(temp: { value: number; scale: 'CELSIUS' | 'FAHRENHEIT' | 'KEL
   if (temp.scale === 'CELSIUS') {
     return temp.value;
   }
+
   if (temp.scale === 'FAHRENHEIT') {
     return (temp.value - 32) * 5 / 9;
   }
+
   return temp.value - 273.15;
 }
 
@@ -299,8 +301,7 @@ export async function handleAppliancePowerOff(request: AlexaTurnOnOffRequest): P
   }
 
   const device = await Device.findByIdOrError(request.endpoint.endpointId);
-  const { stopHomeConnectProgram } = await import('../../homeconnect');
-  await stopHomeConnectProgram(device.providerId);
+  await device.getSwitchCapability().setIsOn(false);
 
   const then = new Date();
   return controlResponse(request, await responsePropsForAppliance(device, then, 0));
@@ -309,13 +310,12 @@ export async function handleAppliancePowerOff(request: AlexaTurnOnOffRequest): P
 export async function handleApplianceSetCookingMode(request: AlexaSetCookingModeRequest): Promise<object> {
   const mode = request.payload?.cookingMode?.value;
   const device = await Device.findByIdOrError(request.endpoint.endpointId);
-  const { stopHomeConnectProgram, cookOven } = await import('../../homeconnect');
 
   if (mode === 'OFF') {
-    await stopHomeConnectProgram(device.providerId);
+    await device.getSwitchCapability().setIsOn(false);
   } else if (device.getCapabilities().includes('OVEN')) {
     const setpoint = await device.getOvenCapability().getSetpointTemperature();
-    await cookOven(device.providerId, setpoint || 180);
+    await device.getOvenCapability().setSetpointTemperature(setpoint || 180);
   } else {
     throw new Error(`Cooking mode ${mode} not supported on this appliance`);
   }
@@ -327,8 +327,7 @@ export async function handleApplianceSetCookingMode(request: AlexaSetCookingMode
 export async function handleOvenCookByTemperature(request: AlexaCookByTemperatureRequest): Promise<object> {
   const device = await Device.findByIdOrError(request.endpoint.endpointId);
   const celsius = toCelsius(request.payload.targetCookingTemperature);
-  const { cookOven } = await import('../../homeconnect');
-  await cookOven(device.providerId, Math.round(celsius));
+  await device.getOvenCapability().setSetpointTemperature(Math.round(celsius));
 
   const then = new Date();
   return controlResponse(request, await responsePropsForAppliance(device, then, 0));
@@ -349,8 +348,12 @@ export async function handleReportState(request: AlexaReportStateRequest) {
     return stateReport(request, await createLightResponseProperties(device, then, Date.now() - then.valueOf()));
   } else if (capabilities.includes('THERMOSTAT')) {
     return stateReport(request, await createThermostatResponseProperties(device, then, Date.now() - then.valueOf()));
-  } else if (capabilities.some(c => (APPLIANCE_CAPS as readonly string[]).includes(c))) {
-    return stateReport(request, await responsePropsForAppliance(device, then, Date.now() - then.valueOf()));
+  } else if (capabilities.includes('OVEN')) {
+    return stateReport(request, await createOvenResponseProperties(device, then, Date.now() - then.valueOf()));
+  } else if (capabilities.includes('MICROWAVE')) {
+    return stateReport(request, await createMicrowaveResponseProperties(device, then, Date.now() - then.valueOf()));
+  } else if (capabilities.includes('DISHWASHER')) {
+    return stateReport(request, await createDishwasherResponseProperties(device, then, Date.now() - then.valueOf()));
   } else {
     throw new Error(`Unable to report state on ${endpointId}`);
   }

--- a/server/src/services/alexa/smarthome/index.ts
+++ b/server/src/services/alexa/smarthome/index.ts
@@ -9,6 +9,9 @@ import {
   handleReportState,
   handleLightControl,
   handleAlarmControl,
+  handleAppliancePowerOff,
+  handleApplianceSetCookingMode,
+  handleOvenCookByTemperature,
   AlexaRequestWithEndpoint
 } from './handlers';
 import {
@@ -18,7 +21,9 @@ import {
   AlexaDiscoverRequest,
   AlexaAcceptGrantRequest,
   AlexaReportStateRequest,
-  AlexaSecurityPanelRequest
+  AlexaSecurityPanelRequest,
+  AlexaSetCookingModeRequest,
+  AlexaCookByTemperatureRequest
 } from './types';
 
 export type { AlexaRequestWithEndpoint };
@@ -73,11 +78,22 @@ export async function syncDiscovery(): Promise<void> {
 
 export type SmartHomeRequestHandler = (r: AlexaSmartHomeRequest) => Promise<object>;
 
+const APPLIANCE_CAPS = ['OVEN', 'MICROWAVE', 'DISHWASHER'];
+
 export const smarthomeHandlers: Record<string, SmartHomeRequestHandler> = {
   'Alexa.Discovery': (r) => handleDiscover(r as AlexaDiscoverRequest),
   'Alexa.Authorization': (r) => handleAcceptGrant(r as AlexaAcceptGrantRequest),
   'Alexa': (r) => handleReportState(r as AlexaReportStateRequest),
-  'Alexa.PowerController': (r) => handleLightControl(r as AlexaTurnOnOffRequest),
+  'Alexa.PowerController': async (r) => {
+    const req = r as AlexaTurnOnOffRequest;
+    const device = await Device.findByIdOrError(req.endpoint.endpointId);
+    if (device.getCapabilities().some(c => APPLIANCE_CAPS.includes(c))) {
+      return handleAppliancePowerOff(req);
+    }
+    return handleLightControl(req);
+  },
   'Alexa.BrightnessController': (r) => handleLightControl(r as AlexaBrightnessRequest),
-  'Alexa.SecurityPanelController': (r) => handleAlarmControl(r as AlexaSecurityPanelRequest)
+  'Alexa.SecurityPanelController': (r) => handleAlarmControl(r as AlexaSecurityPanelRequest),
+  'Alexa.Cooking': (r) => handleApplianceSetCookingMode(r as AlexaSetCookingModeRequest),
+  'Alexa.Cooking.TemperatureController': (r) => handleOvenCookByTemperature(r as AlexaCookByTemperatureRequest),
 };

--- a/server/src/services/alexa/smarthome/types.ts
+++ b/server/src/services/alexa/smarthome/types.ts
@@ -52,13 +52,27 @@ export interface AlexaSecurityPanelRequest {
   payload: { armState?: string };
 }
 
+export interface AlexaSetCookingModeRequest {
+  header: AlexaRequestHeader & { namespace: 'Alexa.Cooking'; name: 'SetCookingMode' };
+  endpoint: AlexaRequestEndpoint;
+  payload: { cookingMode: { value: string }; cookingPower?: { value: number; unit: string } };
+}
+
+export interface AlexaCookByTemperatureRequest {
+  header: AlexaRequestHeader & { namespace: 'Alexa.Cooking.TemperatureController'; name: 'CookByTemperature' };
+  endpoint: AlexaRequestEndpoint;
+  payload: { targetCookingTemperature: { value: number; scale: 'CELSIUS' | 'FAHRENHEIT' | 'KELVIN' } };
+}
+
 export type AlexaSmartHomeRequest =
   | AlexaAcceptGrantRequest
   | AlexaDiscoverRequest
   | AlexaReportStateRequest
   | AlexaTurnOnOffRequest
   | AlexaBrightnessRequest
-  | AlexaSecurityPanelRequest;
+  | AlexaSecurityPanelRequest
+  | AlexaSetCookingModeRequest
+  | AlexaCookByTemperatureRequest;
 
 // Responses (outbound from Karen → Alexa)
 

--- a/server/src/services/homeconnect/index.ts
+++ b/server/src/services/homeconnect/index.ts
@@ -7,6 +7,15 @@ import ApiClient from './lib/client';
 import type { SseType } from './lib/client';
 import { formatProgramName } from './lib/format';
 
+type SSEOperation =
+  | { key: 'BSH.Common.Status.OperationState'; value: string; timestamp: number }
+  | { key: 'BSH.Common.Root.ActiveProgram'; value: string; timestamp: number }
+  | { key: 'BSH.Common.Option.RemainingProgramTime'; value: number; timestamp: number }
+  | { key: 'Cooking.Oven.Option.SetpointTemperature'; value: number; timestamp: number }
+  | { key: 'Cooking.Oven.Status.CurrentCavityTemperature'; value: number; timestamp: number }
+  | { key: 'Dishcare.Dishwasher.Status.SaltNearlyEmpty'; value: boolean; timestamp: number }
+  | { key: 'Dishcare.Dishwasher.Status.RinseAidNearlyEmpty'; value: boolean; timestamp: number };
+
 const CAPABILITY_MAP: Record<string, string> = {
   Oven: 'OVEN',
   Microwave: 'MICROWAVE',
@@ -46,68 +55,62 @@ async function getAccessToken(): Promise<string> {
 
 const client = new ApiClient(getAccessToken);
 
-async function applyItem(device: Device, applianceType: string, item: { key: string; timestamp: number; value: unknown }, now: Date): Promise<void> {
+async function applyItem(device: Device, applianceType: string, item: SSEOperation, now: Date): Promise<void> {
   const ts = new Date(item.timestamp * 1000);
 
   if (applianceType === 'Oven') {
     const capability = device.getOvenCapability();
 
     if (item.key === 'BSH.Common.Status.OperationState') {
-      const isRun = (item.value as string).endsWith('.Run');
-      if (!isRun) {
+      if (!item.value.endsWith('.Run')) {
         await capability.clearProgramNameState(ts, now);
       }
     } else if (item.key === 'BSH.Common.Root.ActiveProgram') {
-      const programKey = item.value as string;
-      if (programKey) {
-        await capability.setProgramNameState(formatProgramName(programKey), ts, now);
+      if (item.value) {
+        await capability.setProgramNameState(formatProgramName(item.value), ts, now);
       } else {
         await capability.clearProgramNameState(ts, now);
       }
     } else if (item.key === 'Cooking.Oven.Option.SetpointTemperature') {
-      await capability.setSetpointTemperatureState(item.value as number, ts, now);
+      await capability.setSetpointTemperatureState(item.value, ts, now);
     } else if (item.key === 'Cooking.Oven.Status.CurrentCavityTemperature') {
-      await capability.setCurrentTemperatureState(item.value as number, ts, now);
+      await capability.setCurrentTemperatureState(item.value, ts, now);
     }
   } else if (applianceType === 'Microwave') {
     const capability = device.getMicrowaveCapability();
 
     if (item.key === 'BSH.Common.Status.OperationState') {
-      const isRun = (item.value as string).endsWith('.Run');
-      if (!isRun) {
+      if (!item.value.endsWith('.Run')) {
         await capability.clearProgramNameState(ts, now);
       }
     } else if (item.key === 'BSH.Common.Root.ActiveProgram') {
-      const programKey = item.value as string;
-      if (programKey) {
-        await capability.setProgramNameState(formatProgramName(programKey), ts, now);
+      if (item.value) {
+        await capability.setProgramNameState(formatProgramName(item.value), ts, now);
       } else {
         await capability.clearProgramNameState(ts, now);
       }
     } else if (item.key === 'BSH.Common.Option.RemainingProgramTime') {
-      await capability.setEstimatedCompletionTimeState(item.timestamp * 1000 + (item.value as number) * 1000, ts, now);
+      await capability.setEstimatedCompletionTimeState(item.timestamp * 1000 + item.value * 1000, ts, now);
     }
   } else if (applianceType === 'Dishwasher') {
     const capability = device.getDishwasherCapability();
 
     if (item.key === 'BSH.Common.Status.OperationState') {
-      const isRun = (item.value as string).endsWith('.Run');
-      if (!isRun) {
+      if (!item.value.endsWith('.Run')) {
         await capability.clearProgramNameState(ts, now);
       }
     } else if (item.key === 'BSH.Common.Root.ActiveProgram') {
-      const programKey = item.value as string;
-      if (programKey) {
-        await capability.setProgramNameState(formatProgramName(programKey), ts, now);
+      if (item.value) {
+        await capability.setProgramNameState(formatProgramName(item.value), ts, now);
       } else {
         await capability.clearProgramNameState(ts, now);
       }
     } else if (item.key === 'BSH.Common.Option.RemainingProgramTime') {
-      await capability.setEstimatedCompletionTimeState(item.timestamp * 1000 + (item.value as number) * 1000, ts, now);
+      await capability.setEstimatedCompletionTimeState(item.timestamp * 1000 + item.value * 1000, ts, now);
     } else if (item.key === 'Dishcare.Dishwasher.Status.SaltNearlyEmpty') {
-      await capability.setIsSaltLowState(item.value as boolean, ts, now);
+      await capability.setIsSaltLowState(item.value, ts, now);
     } else if (item.key === 'Dishcare.Dishwasher.Status.RinseAidNearlyEmpty') {
-      await capability.setIsRinseAidLowState(item.value as boolean, ts, now);
+      await capability.setIsRinseAidLowState(item.value, ts, now);
     }
   }
 }
@@ -139,8 +142,8 @@ async function handleSseMessage(msg: { haId: string; items: { key: string; times
 
   // Process ActiveProgram items before OperationState so the program name is
   // set before the state check potentially clears it
-  const sorted = [...msg.items].sort((a, b) => {
-    const priority = (key: string) => key === 'BSH.Common.Root.ActiveProgram' ? 0 : 1;
+  const sorted = ([...msg.items] as SSEOperation[]).sort((a, b) => {
+    const priority = (key: SSEOperation['key']) => key === 'BSH.Common.Root.ActiveProgram' ? 0 : 1;
     return priority(a.key) - priority(b.key);
   });
 
@@ -153,6 +156,9 @@ async function handleSseMessage(msg: { haId: string; items: { key: string; times
   }
 }
 
+// Hardcoded to 3D Hot Air — the only program used via voice.
+const OVEN_DEFAULT_PROGRAM = 'Cooking.Oven.Program.HeatingMode.HotAir3D';
+
 Device.registerProvider('homeconnect', {
   getCapabilities(device) {
     const type = device.meta.applianceType as string | undefined;
@@ -160,12 +166,27 @@ Device.registerProvider('homeconnect', {
     return cap ? [cap as Capability, 'CONNECTIVITY'] : [];
   },
 
-  async synchronize() {
-    if (!config.homeconnect.refresh_token) {
-      logger.info('Home Connect not authorized yet (no refresh_token); skipping sync');
-      return;
-    }
+  provideSwitchCapability() {
+    return {
+      setIsOn: async (device: Device, value: boolean) => {
+        if (!value) {
+          await client.stopActiveProgram(device.providerId);
+        }
+      }
+    };
+  },
 
+  provideOvenCapability() {
+    return {
+      setSetpointTemperature: async (device: Device, celsius: number) => {
+        await client.startActiveProgram(device.providerId, OVEN_DEFAULT_PROGRAM, [
+          { key: 'Cooking.Oven.Option.SetpointTemperature', value: celsius, unit: '°C' },
+        ]);
+      }
+    };
+  },
+
+  async synchronize() {
     const appliances = await client.getAppliances();
 
     for (const appliance of appliances) {
@@ -192,19 +213,4 @@ Device.registerProvider('homeconnect', {
 
 // Subscribe to events at module load — exactly once, not in synchronize()
 // so periodic re-syncs don't open a second EventSource.
-if (config.homeconnect.refresh_token) {
-  client.subscribeToEvents(handleSseMessage);
-}
-
-export function stopHomeConnectProgram(haId: string): Promise<void> {
-  return client.stopActiveProgram(haId);
-}
-
-// Hardcoded to 3D Hot Air — the only program used via voice.
-const OVEN_DEFAULT_PROGRAM = 'Cooking.Oven.Program.HeatingMode.HotAir3D';
-
-export function cookOven(haId: string, temperatureCelsius: number): Promise<void> {
-  return client.startActiveProgram(haId, OVEN_DEFAULT_PROGRAM, [
-    { key: 'Cooking.Oven.Option.SetpointTemperature', value: temperatureCelsius, unit: '°C' },
-  ]);
-}
+client.subscribeToEvents(handleSseMessage);

--- a/server/src/services/homeconnect/index.ts
+++ b/server/src/services/homeconnect/index.ts
@@ -163,6 +163,7 @@ Device.registerProvider('homeconnect', {
   getCapabilities(device) {
     const type = device.meta.applianceType as string | undefined;
     const cap = type ? CAPABILITY_MAP[type] : undefined;
+
     return cap ? [cap as Capability, 'CONNECTIVITY'] : [];
   },
 
@@ -171,6 +172,8 @@ Device.registerProvider('homeconnect', {
       setIsOn: async (device: Device, value: boolean) => {
         if (!value) {
           await client.stopActiveProgram(device.providerId);
+        } else {
+          throw new Error('Remote start is not supported for Home Connect appliances');
         }
       }
     };

--- a/server/src/services/homeconnect/index.ts
+++ b/server/src/services/homeconnect/index.ts
@@ -116,13 +116,7 @@ async function applyItem(device: Device, applianceType: string, item: SSEOperati
 }
 
 async function handleSseMessage(msg: { haId: string; items: { key: string; timestamp: number; value: unknown }[] }, type: SseType): Promise<void> {
-  const device = await Device.findOne({ where: { provider: 'homeconnect', providerId: msg.haId } });
-
-  if (!device) {
-    logger.warn({ haId: msg.haId }, 'Home Connect SSE message for unknown device');
-    return;
-  }
-
+  const device = await Device.findByProviderIdOrError('homeconnect', msg.haId);
   const now = new Date();
 
   if (type === 'CONNECTED') {
@@ -136,9 +130,6 @@ async function handleSseMessage(msg: { haId: string; items: { key: string; times
   }
 
   const applianceType = device.meta.applianceType as string;
-  if (!applianceType) {
-    return;
-  }
 
   // Process ActiveProgram items before OperationState so the program name is
   // set before the state check potentially clears it

--- a/server/src/services/homeconnect/index.ts
+++ b/server/src/services/homeconnect/index.ts
@@ -191,14 +191,15 @@ Device.registerProvider('homeconnect', {
       const existing = await Device.findByProviderId('homeconnect', appliance.haId);
 
       if (!existing) {
-        await Device.create({
+        const device = Device.build({
           provider: 'homeconnect',
           providerId: appliance.haId,
           name: appliance.name,
           manufacturer: 'Home Connect',
           model: appliance.type,
-          metaStringified: JSON.stringify({ applianceType: appliance.type }),
         });
+        device.meta.applianceType = appliance.type;
+        await device.save();
       }
     }
   }

--- a/server/src/services/homeconnect/index.ts
+++ b/server/src/services/homeconnect/index.ts
@@ -194,7 +194,7 @@ Device.registerProvider('homeconnect', {
         continue;
       }
 
-      const existing = await Device.findOne({ where: { provider: 'homeconnect', providerId: appliance.haId } });
+      const existing = await Device.findByProviderId('homeconnect', appliance.haId);
 
       if (!existing) {
         await Device.create({
@@ -205,12 +205,9 @@ Device.registerProvider('homeconnect', {
           model: appliance.type,
           metaStringified: JSON.stringify({ applianceType: appliance.type }),
         });
-        logger.info({ haId: appliance.haId, type: appliance.type }, 'Home Connect appliance discovered');
       }
     }
   }
 });
 
-// Subscribe to events at module load — exactly once, not in synchronize()
-// so periodic re-syncs don't open a second EventSource.
 client.subscribeToEvents(handleSseMessage);

--- a/server/src/services/homeconnect/index.ts
+++ b/server/src/services/homeconnect/index.ts
@@ -1,11 +1,210 @@
+import config from '../../config';
+import logger from '../../logger';
+import { saveConfig } from '../../helpers/config';
 import { Device } from '../../models';
+import type { Capability } from '../../models/capabilities';
+import ApiClient from './lib/client';
+import type { SseType } from './lib/client';
+import { formatProgramName } from './lib/format';
+
+const CAPABILITY_MAP: Record<string, string> = {
+  Oven: 'OVEN',
+  Microwave: 'MICROWAVE',
+  Dishwasher: 'DISHWASHER',
+};
+
+let cachedToken: string | null = null;
+let tokenExpiresAt = 0;
+
+async function getAccessToken(): Promise<string> {
+  if (cachedToken && Date.now() < tokenExpiresAt - 5 * 60_000) {
+    return cachedToken;
+  }
+
+  const res = await fetch('https://api.home-connect.com/security/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: config.homeconnect.client_id,
+      client_secret: config.homeconnect.client_secret,
+      refresh_token: config.homeconnect.refresh_token,
+    })
+  });
+
+  const token = await res.json() as { access_token: string; refresh_token?: string; expires_in: number };
+  cachedToken = token.access_token;
+  tokenExpiresAt = Date.now() + token.expires_in * 1000;
+
+  if (token.refresh_token && token.refresh_token !== config.homeconnect.refresh_token) {
+    config.homeconnect.refresh_token = token.refresh_token;
+    saveConfig();
+  }
+
+  return cachedToken;
+}
+
+const client = new ApiClient(getAccessToken);
+
+async function applyItem(device: Device, applianceType: string, item: { key: string; timestamp: number; value: unknown }, now: Date): Promise<void> {
+  const ts = new Date(item.timestamp * 1000);
+
+  if (applianceType === 'Oven') {
+    const capability = device.getOvenCapability();
+
+    if (item.key === 'BSH.Common.Status.OperationState') {
+      const isRun = (item.value as string).endsWith('.Run');
+      if (!isRun) {
+        await capability.clearProgramNameState(ts, now);
+      }
+    } else if (item.key === 'BSH.Common.Root.ActiveProgram') {
+      const programKey = item.value as string;
+      if (programKey) {
+        await capability.setProgramNameState(formatProgramName(programKey), ts, now);
+      } else {
+        await capability.clearProgramNameState(ts, now);
+      }
+    } else if (item.key === 'Cooking.Oven.Option.SetpointTemperature') {
+      await capability.setSetpointTemperatureState(item.value as number, ts, now);
+    } else if (item.key === 'Cooking.Oven.Status.CurrentCavityTemperature') {
+      await capability.setCurrentTemperatureState(item.value as number, ts, now);
+    }
+  } else if (applianceType === 'Microwave') {
+    const capability = device.getMicrowaveCapability();
+
+    if (item.key === 'BSH.Common.Status.OperationState') {
+      const isRun = (item.value as string).endsWith('.Run');
+      if (!isRun) {
+        await capability.clearProgramNameState(ts, now);
+      }
+    } else if (item.key === 'BSH.Common.Root.ActiveProgram') {
+      const programKey = item.value as string;
+      if (programKey) {
+        await capability.setProgramNameState(formatProgramName(programKey), ts, now);
+      } else {
+        await capability.clearProgramNameState(ts, now);
+      }
+    } else if (item.key === 'BSH.Common.Option.RemainingProgramTime') {
+      await capability.setEstimatedCompletionTimeState(item.timestamp * 1000 + (item.value as number) * 1000, ts, now);
+    }
+  } else if (applianceType === 'Dishwasher') {
+    const capability = device.getDishwasherCapability();
+
+    if (item.key === 'BSH.Common.Status.OperationState') {
+      const isRun = (item.value as string).endsWith('.Run');
+      if (!isRun) {
+        await capability.clearProgramNameState(ts, now);
+      }
+    } else if (item.key === 'BSH.Common.Root.ActiveProgram') {
+      const programKey = item.value as string;
+      if (programKey) {
+        await capability.setProgramNameState(formatProgramName(programKey), ts, now);
+      } else {
+        await capability.clearProgramNameState(ts, now);
+      }
+    } else if (item.key === 'BSH.Common.Option.RemainingProgramTime') {
+      await capability.setEstimatedCompletionTimeState(item.timestamp * 1000 + (item.value as number) * 1000, ts, now);
+    } else if (item.key === 'Dishcare.Dishwasher.Status.SaltNearlyEmpty') {
+      await capability.setIsSaltLowState(item.value as boolean, ts, now);
+    } else if (item.key === 'Dishcare.Dishwasher.Status.RinseAidNearlyEmpty') {
+      await capability.setIsRinseAidLowState(item.value as boolean, ts, now);
+    }
+  }
+}
+
+async function handleSseMessage(msg: { haId: string; items: { key: string; timestamp: number; value: unknown }[] }, type: SseType): Promise<void> {
+  const device = await Device.findOne({ where: { provider: 'homeconnect', providerId: msg.haId } });
+
+  if (!device) {
+    logger.warn({ haId: msg.haId }, 'Home Connect SSE message for unknown device');
+    return;
+  }
+
+  const now = new Date();
+
+  if (type === 'CONNECTED') {
+    await device.getConnectivityCapability().setIsConnectedState(true, now, now);
+    return;
+  }
+
+  if (type === 'DISCONNECTED') {
+    await device.getConnectivityCapability().setIsConnectedState(false, now, now);
+    return;
+  }
+
+  const applianceType = device.meta.applianceType as string;
+  if (!applianceType) {
+    return;
+  }
+
+  // Process ActiveProgram items before OperationState so the program name is
+  // set before the state check potentially clears it
+  const sorted = [...msg.items].sort((a, b) => {
+    const priority = (key: string) => key === 'BSH.Common.Root.ActiveProgram' ? 0 : 1;
+    return priority(a.key) - priority(b.key);
+  });
+
+  for (const item of sorted) {
+    try {
+      await applyItem(device, applianceType, item, now);
+    } catch (err) {
+      logger.warn({ err, key: item.key, haId: msg.haId }, 'Home Connect SSE item error');
+    }
+  }
+}
 
 Device.registerProvider('homeconnect', {
   getCapabilities(device) {
-    return [];
+    const type = device.meta.applianceType as string | undefined;
+    const cap = type ? CAPABILITY_MAP[type] : undefined;
+    return cap ? [cap as Capability, 'CONNECTIVITY'] : [];
   },
 
   async synchronize() {
-    return Promise.resolve();
+    if (!config.homeconnect.refresh_token) {
+      logger.info('Home Connect not authorized yet (no refresh_token); skipping sync');
+      return;
+    }
+
+    const appliances = await client.getAppliances();
+
+    for (const appliance of appliances) {
+      if (!CAPABILITY_MAP[appliance.type]) {
+        continue;
+      }
+
+      const existing = await Device.findOne({ where: { provider: 'homeconnect', providerId: appliance.haId } });
+
+      if (!existing) {
+        await Device.create({
+          provider: 'homeconnect',
+          providerId: appliance.haId,
+          name: appliance.name,
+          manufacturer: 'Home Connect',
+          model: appliance.type,
+          metaStringified: JSON.stringify({ applianceType: appliance.type }),
+        });
+        logger.info({ haId: appliance.haId, type: appliance.type }, 'Home Connect appliance discovered');
+      }
+    }
   }
 });
+
+// Subscribe to events at module load — exactly once, not in synchronize()
+// so periodic re-syncs don't open a second EventSource.
+if (config.homeconnect.refresh_token) {
+  client.subscribeToEvents(handleSseMessage);
+}
+
+export function stopHomeConnectProgram(haId: string): Promise<void> {
+  return client.stopActiveProgram(haId);
+}
+
+// Hardcoded to 3D Hot Air — the only program used via voice.
+const OVEN_DEFAULT_PROGRAM = 'Cooking.Oven.Program.HeatingMode.HotAir3D';
+
+export function cookOven(haId: string, temperatureCelsius: number): Promise<void> {
+  return client.startActiveProgram(haId, OVEN_DEFAULT_PROGRAM, [
+    { key: 'Cooking.Oven.Option.SetpointTemperature', value: temperatureCelsius, unit: '°C' },
+  ]);
+}

--- a/server/src/services/homeconnect/lib/client.ts
+++ b/server/src/services/homeconnect/lib/client.ts
@@ -1,92 +1,125 @@
-import logger from "../../../logger";
-import { EventEmitter } from 'events';
+import logger from '../../../logger';
 import { EventSource } from 'eventsource';
 
-enum Events {
-  PROGRAM_START = 'PROGRAM_START',
-}
+const API_BASE = 'https://api.home-connect.com/api';
 
-type ApiClientConfig = {
-  access_token: string;
-}
-
-type OnProgramStartPayload = {
-  deviceId: string;
-}
-
-type Appliance = {
+export type Appliance = {
   connected: boolean;
   haId: string;
-  name: 'Oven' | 'Dishwasher' | 'Microwave'
-  type: 'Oven' | 'Dishwasher';
+  name: string;
+  type: string;
 }
 
-export default class ApiClient {
-  #accessToken: string;
-  #eventEmitter: EventEmitter;
+type SseItem = { key: string; timestamp: number; value: unknown };
+export type SseType = 'NOTIFY' | 'EVENT' | 'STATUS' | 'CONNECTED' | 'DISCONNECTED';
+export type SseCallback = (msg: { haId: string; items: SseItem[] }, type: SseType) => void;
 
-  constructor(config: ApiClientConfig) {
-    this.#accessToken = config.access_token;
-    this.#eventEmitter = new EventEmitter();
+export default class ApiClient {
+  #getToken: () => Promise<string>;
+
+  constructor(getToken: () => Promise<string>) {
+    this.#getToken = getToken;
   }
 
-  async #request(path: string) {
-    const req = await fetch(`https://api.home-connect.com/api${path}`, {
+  async #request(path: string, options: RequestInit = {}): Promise<unknown> {
+    const token = await this.#getToken();
+    const req = await fetch(`${API_BASE}${path}`, {
+      ...options,
       headers: {
-        Authorization: `Bearer ${this.#accessToken}`
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        ...options.headers as Record<string, string>
       }
     });
+
+    if (req.status === 204) {
+      return null;
+    }
 
     const json = await req.json();
 
     if (req.ok) {
       return json.data;
     } else {
-      throw new Error(`${req.status}: ${await req.text()}`);
+      throw new Error(`HomeConnect API ${req.status}: ${JSON.stringify(json)}`);
     }
   }
 
   async getAppliances(): Promise<Appliance[]> {
-    return (await this.#request('/homeappliances')).homeappliances;
+    const data = await this.#request('/homeappliances') as { homeappliances: Appliance[] };
+    return data.homeappliances;
   }
 
-  subscribeToEvents() {
-    const accessToken = this.#accessToken;
-    const sse = new EventSource('https://api.home-connect.com/api/homeappliances/events', {
-      fetch: (url, init) => fetch(url, {
-        ...init,
-        headers: {
-          ...init?.headers as Record<string, string>,
-          Authorization: `Bearer ${accessToken}`
-        }
-      })
+  async stopActiveProgram(haId: string): Promise<void> {
+    await this.#request(`/homeappliances/${haId}/programs/active`, { method: 'DELETE' });
+  }
+
+  async startActiveProgram(haId: string, programKey: string, options: Array<{ key: string; value: number | string; unit?: string }>): Promise<void> {
+    await this.#request(`/homeappliances/${haId}/programs/active`, {
+      method: 'PUT',
+      body: JSON.stringify({ data: { key: programKey, options } })
     });
+  }
 
-    ['NOTIFY', 'EVENT', 'STATUS'].forEach((type) => {
-      sse.addEventListener(type, (message: MessageEvent) => {
-        const data = JSON.parse(message.data);
-
-        logger.info({
-          type,
-          data
+  subscribeToEvents(onMessage: SseCallback): void {
+    const connect = async () => {
+      try {
+        const token = await this.#getToken();
+        const es = new EventSource(`${API_BASE}/homeappliances/events`, {
+          fetch: (url, init) => fetch(url, {
+            ...init,
+            headers: {
+              ...init?.headers as Record<string, string>,
+              Authorization: `Bearer ${token}`
+            }
+          })
         });
-      });
-    });
 
-    sse.addEventListener('STATUS', (message: MessageEvent) => {
-      const data = JSON.parse(message.data);
+        const handleEvent = (type: SseType) => (message: MessageEvent) => {
+          try {
+            const data = JSON.parse(message.data);
+            const items: SseItem[] = data.items ?? [];
+            onMessage({ haId: data.haId, items }, type);
+          } catch (err) {
+            logger.warn({ err, type }, 'Home Connect SSE parse error');
+          }
+        };
 
-      this.#eventEmitter.emit(Events.PROGRAM_START, {
-        deviceId: data.haId
-      });
-    });
+        (['NOTIFY', 'EVENT', 'STATUS'] as const).forEach(type => {
+          es.addEventListener(type, handleEvent(type));
+        });
 
-    sse.onmessage = logger.info;
+        es.addEventListener('CONNECTED', (message: MessageEvent) => {
+          try {
+            const data = JSON.parse(message.data);
+            onMessage({ haId: data.haId, items: [] }, 'CONNECTED');
+          } catch (err) {
+            logger.warn({ err }, 'Home Connect CONNECTED parse error');
+          }
+        });
 
-    sse.onerror = logger.info;
-  }
+        es.addEventListener('DISCONNECTED', (message: MessageEvent) => {
+          try {
+            const data = JSON.parse(message.data);
+            onMessage({ haId: data.haId, items: [] }, 'DISCONNECTED');
+          } catch (err) {
+            logger.warn({ err }, 'Home Connect DISCONNECTED parse error');
+          }
+        });
 
-  onProgramStart(listener: (payload: OnProgramStartPayload) => void) {
-    this.#eventEmitter.addListener(Events.PROGRAM_START, listener);
+        es.onerror = (err) => {
+          logger.warn({ err }, 'Home Connect SSE error; reconnecting in 30s');
+          es.close();
+          setTimeout(connect, 30_000);
+        };
+
+        logger.info('Home Connect SSE connected');
+      } catch (err) {
+        logger.warn({ err }, 'Home Connect SSE connect failed; retrying in 30s');
+        setTimeout(connect, 30_000);
+      }
+    };
+
+    connect();
   }
 }

--- a/server/src/services/homeconnect/lib/client.ts
+++ b/server/src/services/homeconnect/lib/client.ts
@@ -76,13 +76,9 @@ export default class ApiClient {
         });
 
         const handleEvent = (type: SseType) => (message: MessageEvent) => {
-          try {
-            const data = JSON.parse(message.data);
-            const items: SseItem[] = data.items ?? [];
-            onMessage({ haId: data.haId, items }, type);
-          } catch (err) {
-            logger.warn({ err, type }, 'Home Connect SSE parse error');
-          }
+          const data = JSON.parse(message.data);
+          const items: SseItem[] = data.items ?? [];
+          onMessage({ haId: data.haId, items }, type);
         };
 
         (['NOTIFY', 'EVENT', 'STATUS'] as const).forEach(type => {
@@ -90,21 +86,13 @@ export default class ApiClient {
         });
 
         es.addEventListener('CONNECTED', (message: MessageEvent) => {
-          try {
-            const data = JSON.parse(message.data);
-            onMessage({ haId: data.haId, items: [] }, 'CONNECTED');
-          } catch (err) {
-            logger.warn({ err }, 'Home Connect CONNECTED parse error');
-          }
+          const data = JSON.parse(message.data);
+          onMessage({ haId: data.haId, items: [] }, 'CONNECTED');
         });
 
         es.addEventListener('DISCONNECTED', (message: MessageEvent) => {
-          try {
-            const data = JSON.parse(message.data);
-            onMessage({ haId: data.haId, items: [] }, 'DISCONNECTED');
-          } catch (err) {
-            logger.warn({ err }, 'Home Connect DISCONNECTED parse error');
-          }
+          const data = JSON.parse(message.data);
+          onMessage({ haId: data.haId, items: [] }, 'DISCONNECTED');
         });
 
         es.onerror = (err) => {

--- a/server/src/services/homeconnect/lib/format.ts
+++ b/server/src/services/homeconnect/lib/format.ts
@@ -1,0 +1,7 @@
+export function formatProgramName(key: string): string {
+  const last = key.split('.').at(-1) ?? key;
+  return last
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/([a-zA-Z])(\d)/g, '$1 $2')
+    .replace(/\s*Watt$/, 'W');
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Home Connect service**: Full implementation replacing the stub. OAuth refresh token persisted to config; in-memory token cache with 5-min pre-expiry refresh. SSE subscription at module load (not in `synchronize`) so re-syncs don't open duplicate connections. Auto-reconnect on `onerror` with 30s backoff. `CONNECTED`/`DISCONNECTED` SSE events drive the Connectivity capability.
- **New capabilities**: Oven (ProgramName, SetpointTemperature, CurrentTemperature), Microwave (ProgramName, EstimatedCompletionTime), Dishwasher (ProgramName, EstimatedCompletionTime, IsSaltLow, IsRinseAidLow). All three include CONNECTIVITY.
- **Non-contiguous string events**: Added `clearStringProperty` helper and `clear*State` codegen method. When a program ends (OperationState → not Run, or ActiveProgram cleared), the open event is closed with `end` set — no sentinel value. `openOnly()` in device-helpers filters the closed event out so `runningProgram.value` is null when idle.
- **ValueFilter string support**: Extended `ValueFilter` to `{ eq: string | number }` and routes string `eq` to the `stringValue` DB column. Used for `lastSelfCareRun` Machine Care history query (`limit: 2`).
- **UI registry**: Status (program name + highlighted when running), estimated completion, oven temps, salt/rinse-aid issue indicators, machine care "last run / never run / overdue" metric.
- **Alexa**: Oven gets `Alexa.Cooking` + `Alexa.Cooking.TemperatureController` + `Alexa.Cooking.TemperatureSensor` — supports "turn off the oven", "set the oven to 200 degrees" (hardcoded 3D Hot Air program), and temperature queries. Microwave gets Cooking (OFF only). Dishwasher gets PowerController only. `handleReportState` extended for all three.

## Test plan

- [ ] Complete OAuth flow at `/homeconnect/authorize` — confirm `refresh_token` written to `config.json`, no `access_token`
- [ ] Start server — confirm SSE connected log, appliances discovered in DB with correct `applianceType` meta
- [ ] Start a dishwasher program — confirm `runningProgram` / `estimatedCompletionTime` update live in the UI; `runningProgram.value` null when idle; DB has closed events with `end` set (no sentinel)
- [ ] Salt/rinse-aid: simulate `SaltNearlyEmpty=true` SSE — confirm "Low" + red issue indicator on device card
- [ ] Run Machine Care — confirm `lastSelfCareRun` shows with `start`/`end`; overdue warning after 30 days
- [ ] Kill the EventSource (or wait 24h) — confirm reconnect loop re-establishes the stream
- [ ] Alexa: "Is the oven on?" / "What's the oven temperature?" — correct state response
- [ ] Alexa: "Set the oven to 200 degrees" — `PUT /programs/active` with HotAir3D + 200°C setpoint
- [ ] Alexa: "Turn off the oven" / "Turn off the dishwasher" — `DELETE /programs/active`
- [ ] Unplug appliance — confirm CONNECTIVITY flips to offline, Alexa reports UNREACHABLE

https://claude.ai/code/session_014F9zpqL2pH1Fb4KqHN6ffL
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014F9zpqL2pH1Fb4KqHN6ffL)_