### PR TITLE
Refactor Octopus service: split meterPoint meta, move mpan/serialNumber to config

### DIFF
--- a/server/src/config.d.ts
+++ b/server/src/config.d.ts
@@ -95,6 +95,8 @@ declare namespace _default {
     const api_key: string;
     const account_number: string;
     const poll_interval_minutes: number;
+    const mpan: string;
+    const serial_number: string;
   }
   export namespace smartcar {
     const application_id: string;

--- a/server/src/services/octopus/client.ts
+++ b/server/src/services/octopus/client.ts
@@ -12,13 +12,6 @@ export interface RateInterval {
   value: number; // pence (inc. VAT)
 }
 
-export interface MeterPoint {
-  mpan: string;
-  serialNumber: string;
-  productCode: string;
-  tariffCode: string;
-}
-
 interface AccountResponse {
   properties: {
     electricity_meter_points: {
@@ -88,25 +81,20 @@ function productCodeFromTariff(tariffCode: string): string {
   return tariffCode.replace(/^E-1R-/, '').replace(/-[A-Z]$/, '');
 }
 
-export async function getMeterPoint(): Promise<MeterPoint> {
+export async function getTariff(): Promise<{ tariffCode: string; productCode: string }> {
   const account = await request<AccountResponse>(
     `${BASE_URL}/v1/accounts/${config.octopus.account_number}/`
   );
 
   const meterPoint = account.properties[0].electricity_meter_points[0];
-  const meter = meterPoint.meters[0];
   const agreement = meterPoint.agreements[meterPoint.agreements.length - 1];
+  const tariffCode = agreement.tariff_code;
 
-  return {
-    mpan: meterPoint.mpan,
-    serialNumber: meter.serial_number,
-    tariffCode: agreement.tariff_code,
-    productCode: productCodeFromTariff(agreement.tariff_code)
-  };
+  return { tariffCode, productCode: productCodeFromTariff(tariffCode) };
 }
 
-export async function getConsumption(meterPoint: MeterPoint, since: Date, until: Date): Promise<ConsumptionInterval[]> {
-  const url = `${BASE_URL}/v1/electricity-meter-points/${meterPoint.mpan}/meters/${meterPoint.serialNumber}`
+export async function getConsumption(since: Date, until: Date): Promise<ConsumptionInterval[]> {
+  const url = `${BASE_URL}/v1/electricity-meter-points/${config.octopus.mpan}/meters/${config.octopus.serial_number}`
     + `/consumption/?period_from=${since.toISOString()}&period_to=${until.toISOString()}&page_size=25000&order_by=period`;
 
   const results = await requestAllPages<ConsumptionResult>(url);
@@ -118,15 +106,15 @@ export async function getConsumption(meterPoint: MeterPoint, since: Date, until:
   }));
 }
 
-export async function getUnitRates(meterPoint: MeterPoint, since: Date, until: Date): Promise<RateInterval[]> {
-  const url = `${BASE_URL}/v1/products/${meterPoint.productCode}/electricity-tariffs/${meterPoint.tariffCode}`
+export async function getUnitRates(tariffCode: string, productCode: string, since: Date, until: Date): Promise<RateInterval[]> {
+  const url = `${BASE_URL}/v1/products/${productCode}/electricity-tariffs/${tariffCode}`
     + `/standard-unit-rates/?period_from=${since.toISOString()}&period_to=${until.toISOString()}&page_size=25000`;
 
   return mapRates(await requestAllPages<RateResult>(url));
 }
 
-export async function getStandingCharges(meterPoint: MeterPoint, since: Date, until: Date): Promise<RateInterval[]> {
-  const url = `${BASE_URL}/v1/products/${meterPoint.productCode}/electricity-tariffs/${meterPoint.tariffCode}`
+export async function getStandingCharges(tariffCode: string, productCode: string, since: Date, until: Date): Promise<RateInterval[]> {
+  const url = `${BASE_URL}/v1/products/${productCode}/electricity-tariffs/${tariffCode}`
     + `/standing-charges/?period_from=${since.toISOString()}&period_to=${until.toISOString()}&page_size=25000`;
 
   return mapRates(await requestAllPages<RateResult>(url));

--- a/server/src/services/octopus/index.ts
+++ b/server/src/services/octopus/index.ts
@@ -3,7 +3,7 @@ import config from '../../config';
 import nowAndSetInterval from '../../helpers/now-and-set-interval';
 import { createBackgroundTransaction } from '../../helpers/newrelic';
 import type { Capability } from '../../models/capabilities';
-import { getMeterPoint, getConsumption, getUnitRates, getStandingCharges, MeterPoint } from './client';
+import { getTariff, getConsumption, getUnitRates, getStandingCharges } from './client';
 
 const PROVIDER_ID = 'electricity-meter';
 
@@ -25,14 +25,19 @@ Device.registerProvider('octopus', {
 
     device.manufacturer = 'Octopus Energy';
     device.model = 'Smart Meter';
-    device.meta.meterPoint = await getMeterPoint();
+
+    const { tariffCode, productCode } = await getTariff();
+    device.meta.tariffCode = tariffCode;
+    device.meta.productCode = productCode;
 
     await device.save();
   },
 });
 
-async function poll(meterPoint: MeterPoint, device: Device) {
+async function poll(device: Device) {
   const now = new Date();
+  const tariffCode = device.meta.tariffCode as string;
+  const productCode = device.meta.productCode as string;
   const energyMonitor = device.getEnergyMonitorCapability();
   const energyCost = device.getEnergyCostCapability();
 
@@ -56,7 +61,7 @@ async function poll(meterPoint: MeterPoint, device: Device) {
   // it like any other EnergyMonitor device.
   await sync(
     () => energyMonitor.getCurrentPowerEvent(),
-    (since, until) => getConsumption(meterPoint, since, until),
+    (since, until) => getConsumption(since, until),
     (interval) => {
       const durationHours = (interval.end.getTime() - interval.start.getTime()) / (60 * 60 * 1000);
       const averageWatts = durationHours > 0 ? Math.round((interval.consumption / durationHours) * 1000) : 0;
@@ -69,13 +74,13 @@ async function poll(meterPoint: MeterPoint, device: Device) {
   // time, so this naturally records near-future rates too.
   await sync(
     () => energyCost.getUnitRateEvent(),
-    (since, until) => getUnitRates(meterPoint, since, until),
+    (since, until) => getUnitRates(tariffCode, productCode, since, until),
     (rate) => energyCost.setUnitRateState(rate.value, rate.start)
   );
 
   await sync(
     () => energyCost.getStandingChargeEvent(),
-    (since, until) => getStandingCharges(meterPoint, since, until),
+    (since, until) => getStandingCharges(tariffCode, productCode, since, until),
     (standingCharge) => energyCost.setStandingChargeState(standingCharge.value, standingCharge.start)
   );
 }
@@ -83,5 +88,5 @@ async function poll(meterPoint: MeterPoint, device: Device) {
 nowAndSetInterval(createBackgroundTransaction('octopus:poll', async () => {
   const device = await Device.findByProviderIdOrError('octopus', PROVIDER_ID);
 
-  await poll(device.meta.meterPoint as MeterPoint, device);
+  await poll(device);
 }), Math.max(config.octopus.poll_interval_minutes, 1) * 60 * 1000);


### PR DESCRIPTION
## Summary

- Removes `device.meta.meterPoint` (a single blob containing all four fields) and replaces it with `device.meta.tariffCode` and `device.meta.productCode`, set during `Device.synchronize()`
- `mpan` and `serial_number` move from being derived via the Octopus account API to static fields in `config.json`, typed in `config.d.ts`
- `getTariff()` replaces `getMeterPoint()` in `client.ts` — it only fetches the current tariff/product codes from the account API, which can change when the user switches tariff
- Client functions `getConsumption`, `getUnitRates`, `getStandingCharges` no longer take a `MeterPoint` object; `getConsumption` reads `mpan`/`serial_number` directly from config, while `getUnitRates`/`getStandingCharges` take `tariffCode` and `productCode` as explicit parameters
- The `MeterPoint` interface is removed as it is no longer needed

## Test plan

- [ ] Add `mpan` and `serial_number` under `octopus` in `config.json` before deploying
- [ ] Confirm `npm run lint` passes with zero warnings
- [ ] After deploy, verify `device.meta` for the electricity meter device contains `tariffCode` and `productCode` but no longer contains `meterPoint`
- [ ] Confirm polling continues to record consumption, unit rates, and standing charges as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)