### PR TITLE
Door-aware auto-relock (Shelly BLU) + ContactSensor/AlarmSensor taxonomy fix

### DIFF
--- a/server/src/api/types.ts
+++ b/server/src/api/types.ts
@@ -71,9 +71,12 @@ export type CapabilityApiResponse = {
   odometer: NumericStateApiResponse;
   chargeSchedule: { targetPercentage: number; targetTime: string; calculatedStartTime: string | null } | null;
 } | {
-  type: 'CONTACT_SENSOR';
-  isClosed: BooleanStateApiResponse;
+  type: 'ALARM_SENSOR';
+  isTriggered: BooleanStateApiResponse;
   lastTriggered: { start: string; end: string | null; durationSeconds: number | null } | null;
+} | {
+  type: 'CONTACT_SENSOR';
+  isOpen: BooleanStateApiResponse;
 } | {
   type: 'BIN_COLLECTION';
   color: string;

--- a/server/src/automations/auto-relock.ts
+++ b/server/src/automations/auto-relock.ts
@@ -5,11 +5,8 @@ import { createBackgroundTransaction } from '../helpers/newrelic';
 
 type AutoRelockParameters = {
   locks: {
-    name: string;
+    lockName: string;
     delaySeconds: number;
-    // Door/window sensor whose state vetoes the relock (see below). Required:
-    // without one, Karen has no way to tell the door was opened, and blindly
-    // re-throwing the bolt on a timer risks jamming it against an open door.
     doorSensorName: string;
   }[];
 };
@@ -20,7 +17,7 @@ type PendingRelock = {
 };
 
 export default function ({ locks }: AutoRelockParameters) {
-  for (const { name: lockName, delaySeconds, doorSensorName } of locks) {
+  for (const { lockName, delaySeconds, doorSensorName } of locks) {
     let pending: PendingRelock | undefined;
 
     function cancelPendingRelock(): void {
@@ -75,7 +72,11 @@ export default function ({ locks }: AutoRelockParameters) {
         // door is already open, there is nothing we can safely do.
         const doorSensor = await Device.findByName(doorSensorName);
 
-        if (doorSensor !== null && await doorSensor.getContactSensorCapability().getIsOpen()) {
+        if (doorSensor === null) {
+          throw new Error(`Auto-relock for lock '${lockName}' is misconfigured: door sensor '${doorSensorName}' does not exist`);
+        }
+
+        if (await doorSensor.getContactSensorCapability().getIsOpen()) {
           return;
         }
 

--- a/server/src/automations/auto-relock.ts
+++ b/server/src/automations/auto-relock.ts
@@ -20,94 +20,77 @@ type PendingRelock = {
 };
 
 export default function ({ locks }: AutoRelockParameters) {
-  const configByLockName = new Map(locks.map(lock => [lock.name, lock]));
-  const pending = new Map<string, PendingRelock>();
+  for (const { name: lockName, delaySeconds, doorSensorName } of locks) {
+    let pending: PendingRelock | undefined;
 
-  // Reverse lookup: door sensor name -> the lock(s) it vetoes.
-  const locksByDoorSensor = new Map<string, string[]>();
-
-  for (const lock of locks) {
-    const existing = locksByDoorSensor.get(lock.doorSensorName) ?? [];
-
-    existing.push(lock.name);
-    locksByDoorSensor.set(lock.doorSensorName, existing);
-  }
-
-  function cancelPendingRelock(lockName: string): void {
-    const existing = pending.get(lockName);
-
-    if (existing !== undefined) {
-      clearTimeout(existing.timeout);
-      existing.controller.abort();
-      pending.delete(lockName);
+    function cancelPendingRelock(): void {
+      if (pending !== undefined) {
+        clearTimeout(pending.timeout);
+        pending.controller.abort();
+        pending = undefined;
+      }
     }
-  }
 
-  function scheduleRelock(lockName: string, device: Device, delaySeconds: number): void {
-    const controller = new AbortController();
+    function scheduleRelock(device: Device): void {
+      const controller = new AbortController();
 
-    const timeout = setTimeout(createBackgroundTransaction('automations:auto-relock:relock', async () => {
-      try {
-        await device.getLockCapability().ensureIsLocked(controller.signal);
-      } catch (err) {
-        // An abort means a newer unlock (or a door opening) superseded this
-        // relock; that's expected, not a failure worth alerting on.
-        if (!controller.signal.aborted) {
-          bus.emit(NOTIFICATION_TO_ADMINS, {
-            message: `Failed to auto-relock ${lockName}: ${err instanceof Error ? err.message : String(err)}`
-          });
+      const timeout = setTimeout(createBackgroundTransaction('automations:auto-relock:relock', async () => {
+        try {
+          await device.getLockCapability().ensureIsLocked(controller.signal);
+        } catch (err) {
+          // An abort means a newer unlock (or a door opening) superseded this
+          // relock; that's expected, not a failure worth alerting on.
+          if (!controller.signal.aborted) {
+            bus.emit(NOTIFICATION_TO_ADMINS, {
+              message: `Failed to auto-relock ${lockName}: ${err instanceof Error ? err.message : String(err)}`
+            });
+          }
+        } finally {
+          // Only clear if this attempt is still the current one for the lock.
+          if (pending?.controller === controller) {
+            pending = undefined;
+          }
         }
-      } finally {
-        // Only clear if this attempt is still the current one for the lock.
-        if (pending.get(lockName)?.controller === controller) {
-          pending.delete(lockName);
+      }), delaySeconds * 1000);
+
+      pending = { timeout, controller };
+    }
+
+    DeviceCapabilityEvents.onLockIsLockedChanged(
+      device => device.name === lockName,
+      createBackgroundTransaction('automations:auto-relock:lock-changed', async (event: BooleanEvent) => {
+        const device = await event.getDevice();
+
+        // Any lock state change supersedes a scheduled relock.
+        cancelPendingRelock();
+
+        // hasEnded() === true means the "locked" event has ended, i.e. the lock is
+        // now unlocked. We only ever auto-relock a lock that was left unlocked.
+        if (!event.hasEnded()) {
+          return;
         }
-      }
-    }), delaySeconds * 1000);
 
-    pending.set(lockName, { timeout, controller });
+        // The bolt can only be re-thrown remotely while the door has stayed shut —
+        // once opened, the handle must be lifted manually to re-engage. So if the
+        // door is already open, there is nothing we can safely do.
+        const doorSensor = await Device.findByName(doorSensorName);
+
+        if (doorSensor !== null && await doorSensor.getContactSensorCapability().getIsOpen()) {
+          return;
+        }
+
+        scheduleRelock(device);
+      })
+    );
+
+    // If the door opens during the unlocked window, cancel the pending relock.
+    // Once opened, the lock needs a manual handle-lift and can't be re-thrown
+    // remotely, so we never relock this cycle (nor reschedule when it closes).
+    DeviceCapabilityEvents.onContactSensorIsOpenStart(
+      device => device.name === doorSensorName,
+      createBackgroundTransaction('automations:auto-relock:door-opened', async () => {
+        cancelPendingRelock();
+      })
+    );
   }
-
-  DeviceCapabilityEvents.onLockIsLockedChanged(
-    device => configByLockName.has(device.name),
-    createBackgroundTransaction('automations:auto-relock:lock-changed', async (event: BooleanEvent) => {
-      const device = await event.getDevice();
-      const lockName = device.name;
-      const lock = configByLockName.get(lockName)!;
-
-      // Any lock state change supersedes a scheduled relock.
-      cancelPendingRelock(lockName);
-
-      // hasEnded() === true means the "locked" event has ended, i.e. the lock is
-      // now unlocked. We only ever auto-relock a lock that was left unlocked.
-      if (!event.hasEnded()) {
-        return;
-      }
-
-      // The bolt can only be re-thrown remotely while the door has stayed shut —
-      // once opened, the handle must be lifted manually to re-engage. So if the
-      // door is already open, there is nothing we can safely do.
-      const doorSensor = await Device.findByName(lock.doorSensorName);
-
-      if (doorSensor !== null && await doorSensor.getContactSensorCapability().getIsOpen()) {
-        return;
-      }
-
-      scheduleRelock(lockName, device, lock.delaySeconds);
-    })
-  );
-
-  // If the door opens during the unlocked window, cancel the pending relock.
-  // Once opened, the lock needs a manual handle-lift and can't be re-thrown
-  // remotely, so we never relock this cycle (nor reschedule when it closes).
-  DeviceCapabilityEvents.onContactSensorIsOpenStart(
-    device => locksByDoorSensor.has(device.name),
-    createBackgroundTransaction('automations:auto-relock:door-opened', async (event: BooleanEvent) => {
-      const doorSensor = await event.getDevice();
-
-      for (const lockName of locksByDoorSensor.get(doorSensor.name) ?? []) {
-        cancelPendingRelock(lockName);
-      }
-    })
-  );
 }

--- a/server/src/automations/auto-relock.ts
+++ b/server/src/automations/auto-relock.ts
@@ -1,0 +1,116 @@
+import bus, { NOTIFICATION_TO_ADMINS } from '../bus';
+import { BooleanEvent, Device } from '../models';
+import { DeviceCapabilityEvents } from '../models/capabilities';
+import { createBackgroundTransaction } from '../helpers/newrelic';
+
+type AutoRelockParameters = {
+  locks: {
+    name: string;
+    delaySeconds: number;
+    // Optional door/window sensor. If set, the auto-relock is vetoed the moment
+    // the door opens (see below). Omit for timer-only relocking.
+    doorSensorName?: string;
+  }[];
+};
+
+type PendingRelock = {
+  timeout: ReturnType<typeof setTimeout>;
+  controller: AbortController;
+};
+
+export default function ({ locks }: AutoRelockParameters) {
+  const configByLockName = new Map(locks.map(lock => [lock.name, lock]));
+  const pending = new Map<string, PendingRelock>();
+
+  // Reverse lookup: door sensor name -> the lock(s) it vetoes.
+  const locksByDoorSensor = new Map<string, string[]>();
+
+  for (const lock of locks) {
+    if (lock.doorSensorName !== undefined) {
+      const existing = locksByDoorSensor.get(lock.doorSensorName) ?? [];
+
+      existing.push(lock.name);
+      locksByDoorSensor.set(lock.doorSensorName, existing);
+    }
+  }
+
+  function cancelPendingRelock(lockName: string): void {
+    const existing = pending.get(lockName);
+
+    if (existing !== undefined) {
+      clearTimeout(existing.timeout);
+      existing.controller.abort();
+      pending.delete(lockName);
+    }
+  }
+
+  function scheduleRelock(lockName: string, device: Device, delaySeconds: number): void {
+    const controller = new AbortController();
+
+    const timeout = setTimeout(createBackgroundTransaction('automations:auto-relock:relock', async () => {
+      try {
+        await device.getLockCapability().ensureIsLocked(controller.signal);
+      } catch (err) {
+        // An abort means a newer unlock (or a door opening) superseded this
+        // relock; that's expected, not a failure worth alerting on.
+        if (!controller.signal.aborted) {
+          bus.emit(NOTIFICATION_TO_ADMINS, {
+            message: `Failed to auto-relock ${lockName}: ${err instanceof Error ? err.message : String(err)}`
+          });
+        }
+      } finally {
+        // Only clear if this attempt is still the current one for the lock.
+        if (pending.get(lockName)?.controller === controller) {
+          pending.delete(lockName);
+        }
+      }
+    }), delaySeconds * 1000);
+
+    pending.set(lockName, { timeout, controller });
+  }
+
+  DeviceCapabilityEvents.onLockIsLockedChanged(
+    device => configByLockName.has(device.name),
+    createBackgroundTransaction('automations:auto-relock:lock-changed', async (event: BooleanEvent) => {
+      const device = await event.getDevice();
+      const lockName = device.name;
+      const lock = configByLockName.get(lockName)!;
+
+      // Any lock state change supersedes a scheduled relock.
+      cancelPendingRelock(lockName);
+
+      // hasEnded() === true means the "locked" event has ended, i.e. the lock is
+      // now unlocked. We only ever auto-relock a lock that was left unlocked.
+      if (!event.hasEnded()) {
+        return;
+      }
+
+      // The bolt can only be re-thrown remotely while the door has stayed shut —
+      // once opened, the handle must be lifted manually to re-engage. So if the
+      // door is already open, there is nothing we can safely do.
+      if (lock.doorSensorName !== undefined) {
+        const doorSensor = await Device.findByName(lock.doorSensorName);
+
+        if (doorSensor !== null && await doorSensor.getContactSensorCapability().getIsOpen()) {
+          return;
+        }
+      }
+
+      scheduleRelock(lockName, device, lock.delaySeconds);
+    })
+  );
+
+  // If the door opens during the unlocked window, cancel the pending relock.
+  // Once opened, the lock needs a manual handle-lift and can't be re-thrown
+  // remotely, so we never relock this cycle (nor reschedule when it closes).
+  DeviceCapabilityEvents.onContactSensorIsOpenStart(
+    device => locksByDoorSensor.has(device.name),
+    createBackgroundTransaction('automations:auto-relock:door-opened', async (event: BooleanEvent) => {
+      const doorSensor = await event.getDevice();
+
+      for (const lockName of locksByDoorSensor.get(doorSensor.name) ?? []) {
+        cancelPendingRelock(lockName);
+      }
+    })
+  );
+}

--- a/server/src/automations/auto-relock.ts
+++ b/server/src/automations/auto-relock.ts
@@ -7,9 +7,10 @@ type AutoRelockParameters = {
   locks: {
     name: string;
     delaySeconds: number;
-    // Optional door/window sensor. If set, the auto-relock is vetoed the moment
-    // the door opens (see below). Omit for timer-only relocking.
-    doorSensorName?: string;
+    // Door/window sensor whose state vetoes the relock (see below). Required:
+    // without one, Karen has no way to tell the door was opened, and blindly
+    // re-throwing the bolt on a timer risks jamming it against an open door.
+    doorSensorName: string;
   }[];
 };
 
@@ -26,12 +27,10 @@ export default function ({ locks }: AutoRelockParameters) {
   const locksByDoorSensor = new Map<string, string[]>();
 
   for (const lock of locks) {
-    if (lock.doorSensorName !== undefined) {
-      const existing = locksByDoorSensor.get(lock.doorSensorName) ?? [];
+    const existing = locksByDoorSensor.get(lock.doorSensorName) ?? [];
 
-      existing.push(lock.name);
-      locksByDoorSensor.set(lock.doorSensorName, existing);
-    }
+    existing.push(lock.name);
+    locksByDoorSensor.set(lock.doorSensorName, existing);
   }
 
   function cancelPendingRelock(lockName: string): void {
@@ -88,12 +87,10 @@ export default function ({ locks }: AutoRelockParameters) {
       // The bolt can only be re-thrown remotely while the door has stayed shut —
       // once opened, the handle must be lifted manually to re-engage. So if the
       // door is already open, there is nothing we can safely do.
-      if (lock.doorSensorName !== undefined) {
-        const doorSensor = await Device.findByName(lock.doorSensorName);
+      const doorSensor = await Device.findByName(lock.doorSensorName);
 
-        if (doorSensor !== null && await doorSensor.getContactSensorCapability().getIsOpen()) {
-          return;
-        }
+      if (doorSensor !== null && await doorSensor.getContactSensorCapability().getIsOpen()) {
+        return;
       }
 
       scheduleRelock(lockName, device, lock.delaySeconds);

--- a/server/src/automations/fire-alarm.ts
+++ b/server/src/automations/fire-alarm.ts
@@ -24,7 +24,7 @@ async function describeWhoIsHome(): Promise<string> {
 export default function ({ deviceName }: FireAlarmAutomationParameters) {
   const isThisDevice = (d: Device) => d.name === deviceName;
 
-  DeviceCapabilityEvents.onContactSensorIsClosedStart(isThisDevice, createBackgroundTransaction('automations:fire-alarm:triggered', async (event: BooleanEvent) => {
+  DeviceCapabilityEvents.onAlarmSensorIsTriggeredStart(isThisDevice, createBackgroundTransaction('automations:fire-alarm:triggered', async (event: BooleanEvent) => {
     const time = dayjs(event.start).format('HH:mm');
     const homeList = await describeWhoIsHome();
     const message = `Fire alarm activated at ${time}. ${homeList}.`;

--- a/server/src/capabilities.json
+++ b/server/src/capabilities.json
@@ -384,13 +384,23 @@
     }
   ]
 }, {
-  "name": "ContactSensor",
+  "name": "AlarmSensor",
   "properties": [
     {
-      "name": "IsClosed",
+      "name": "IsTriggered",
       "isWriteable": false,
       "type": "boolean",
       "eventName": "closed"
+    }
+  ]
+}, {
+  "name": "ContactSensor",
+  "properties": [
+    {
+      "name": "IsOpen",
+      "isWriteable": false,
+      "type": "boolean",
+      "eventName": "open"
     }
   ]
 }, {

--- a/server/src/components/capabilities/registry.tsx
+++ b/server/src/components/capabilities/registry.tsx
@@ -554,11 +554,11 @@ export const registry: CapabilityUIRegistry = {
     ],
   },
 
-  CONTACT_SENSOR: {
+  ALARM_SENSOR: {
     priority: 55,
     getCapabilityMetrics: (cap) => {
       const metrics: CapabilityMetric[] = [
-        createCapability(cap.isClosed, {
+        createCapability(cap.isTriggered, {
           icon: faBell,
           title: 'Status',
           value: (e) => e.value ? 'TRIGGERED' : 'OK',
@@ -583,6 +583,22 @@ export const registry: CapabilityUIRegistry = {
 
       return metrics;
     },
+    getGraphs: () => [
+      { id: 'alarm-sensor', title: 'Activity' },
+    ],
+  },
+
+  CONTACT_SENSOR: {
+    priority: 55,
+    getCapabilityMetrics: (cap) => [
+      createCapability(cap.isOpen, {
+        icon: (e) => e.value ? faDoorOpen : faDoorClosed,
+        title: 'Status',
+        value: (e) => e.value ? 'Open' : 'Closed',
+        iconHighlighted: (e) => e.value,
+        iconColor: '#04A7F4',
+      }),
+    ],
     getGraphs: () => [
       { id: 'contact-sensor', title: 'Activity' },
     ],

--- a/server/src/models/device.ts
+++ b/server/src/models/device.ts
@@ -25,6 +25,7 @@ import {
   ElectricVehicleCapability,
   BinCollectionCapability,
   ButtonCapability,
+  AlarmSensorCapability,
   ContactSensorCapability,
   ConnectivityCapability,
   EnergyMonitorCapability,
@@ -131,6 +132,10 @@ export class Device extends Model<InferAttributes<Device>, InferCreationAttribut
 
   getButtonCapability(): ButtonCapability {
     return this.#getCapabilityOrThrow(() => new ButtonCapability(this));
+  }
+
+  getAlarmSensorCapability(): AlarmSensorCapability {
+    return this.#getCapabilityOrThrow(() => new AlarmSensorCapability(this));
   }
 
   getContactSensorCapability(): ContactSensorCapability {

--- a/server/src/routes/api/device-helpers.ts
+++ b/server/src/routes/api/device-helpers.ts
@@ -206,13 +206,13 @@ export async function getCapabilityData(device: Device, capability: string): Pro
       });
     }
 
-    case 'CONTACT_SENSOR': {
-      const sensor = device.getContactSensorCapability();
-      const event = await sensor.getIsClosedEvent();
+    case 'ALARM_SENSOR': {
+      const sensor = device.getAlarmSensorCapability();
+      const event = await sensor.getIsTriggeredEvent();
 
       return {
-        type: 'CONTACT_SENSOR' as const,
-        isClosed: await mapBooleanState(Promise.resolve(event), device),
+        type: 'ALARM_SENSOR' as const,
+        isTriggered: await mapBooleanState(Promise.resolve(event), device),
         lastTriggered: event ? {
           start: event.start.toISOString(),
           end: event.end?.toISOString() ?? null,
@@ -221,6 +221,14 @@ export async function getCapabilityData(device: Device, capability: string): Pro
             : null
         } : null
       };
+    }
+
+    case 'CONTACT_SENSOR': {
+      const sensor = device.getContactSensorCapability();
+      return awaitPromises({
+        type: 'CONTACT_SENSOR' as const,
+        isOpen: mapBooleanState(sensor.getIsOpenEvent(), device)
+      });
     }
 
     case 'BIN_COLLECTION': {

--- a/server/src/routes/api/device/history.ts
+++ b/server/src/routes/api/device/history.ts
@@ -293,17 +293,33 @@ const historyFetchers = new Map<string, HistoryFetcher>([
     });
   }],
 
-  // Contact Sensor (input/dry-contact, e.g. fire alarm relay)
+  // Alarm Sensor (input/dry-contact, e.g. fire alarm relay)
+  ['alarm-sensor', async (device, selector) => {
+    const sensor = device.getAlarmSensorCapability();
+
+    return {
+      lines: [],
+      modes: await mapBooleanHistoryToResponse((hs) => sensor.getIsTriggeredHistory(hs), selector)
+        .then(data => ({
+          data,
+          details: [
+            { value: true as const, label: 'Triggered', fillColor: 'rgba(231, 76, 60, 0.35)' }
+          ]
+        }))
+    };
+  }],
+
+  // Contact Sensor (door/window open-closed position)
   ['contact-sensor', async (device, selector) => {
     const sensor = device.getContactSensorCapability();
 
     return {
       lines: [],
-      modes: await mapBooleanHistoryToResponse((hs) => sensor.getIsClosedHistory(hs), selector)
+      modes: await mapBooleanHistoryToResponse((hs) => sensor.getIsOpenHistory(hs), selector)
         .then(data => ({
           data,
           details: [
-            { value: true as const, label: 'Triggered', fillColor: 'rgba(231, 76, 60, 0.35)' }
+            { value: true as const, label: 'Open', fillColor: 'rgba(52, 152, 219, 0.3)' }
           ]
         }))
     };

--- a/server/src/routes/shelly.js
+++ b/server/src/routes/shelly.js
@@ -79,25 +79,29 @@ async function setupBLUDevice(ip, mac, name) {
   await device.save();
 }
 
-router.get('/install', async (req, res) => {
-  const { ip, mac, name } = req.query;
+router.get('/install-wifi', async (req, res) => {
+  const { ip } = req.query;
 
   if (!ip) {
     return res.end('Pass ip in query string');
   }
 
-  if (mac) {
-    if (!name) {
-      return res.end('Pass name in query string when installing a BLU device (mac was given)');
-    }
+  await setupWiFiDevice(ip);
 
-    try {
-      await setupBLUDevice(ip, mac, name);
-    } catch (err) {
-      return res.status(404).end(err.message);
-    }
-  } else {
-    await setupWiFiDevice(ip);
+  res.sendStatus(201).end();
+});
+
+router.get('/install-blu', async (req, res) => {
+  const { ip, mac, name } = req.query;
+
+  if (!ip || !mac || !name) {
+    return res.end('Pass ip (gateway), mac (sensor BLE MAC), and name in query string');
+  }
+
+  try {
+    await setupBLUDevice(ip, mac, name);
+  } catch (err) {
+    return res.status(404).end(err.message);
   }
 
   res.sendStatus(201).end();

--- a/server/src/routes/shelly.js
+++ b/server/src/routes/shelly.js
@@ -13,7 +13,13 @@ router.use((req, res, next) => {
   }
 });
 
-async function setupWiFiDevice(ip) {
+router.get('/install-wifi', async (req, res) => {
+  const { ip } = req.query;
+
+  if (!ip) {
+    return res.end('Pass ip in query string');
+  }
+
   const client = await DeviceClient.for(ip, config.shelly.user, config.shelly.password);
   const model = await client.getModel();
   const mqttId = await client.getMqttId();
@@ -50,18 +56,26 @@ async function setupWiFiDevice(ip) {
 
   await client.reboot();
   await device.save();
-}
+
+  res.sendStatus(201).end();
+});
 
 // Onboards a BLU (Bluetooth) sensor that's already been paired locally (not just
 // cloud relay) to a gateway device, e.g. via the Shelly app's Bluetooth settings
 // for that gateway. `ip` is the gateway's own IP; `mac` is the sensor's BLE MAC.
-async function setupBLUDevice(ip, mac, name) {
+router.get('/install-blu', async (req, res) => {
+  const { ip, mac, name } = req.query;
+
+  if (!ip || !mac || !name) {
+    return res.end('Pass ip (gateway), mac (sensor BLE MAC), and name in query string');
+  }
+
   const client = await DeviceClient.for(ip, config.shelly.user, config.shelly.password);
   const gatewayProviderId = await client.getMqttId();
   const sensors = await client.getBTHomeSensorsFor(mac);
 
   if (Object.keys(sensors).length === 0) {
-    throw new Error(`No known BTHome sensor objects found for ${mac} on ${ip}. Has it been paired locally to this gateway (not just cloud relay)?`);
+    return res.status(404).end(`No known BTHome sensor objects found for ${mac} on ${ip}. Has it been paired locally to this gateway (not just cloud relay)?`);
   }
 
   let device = await Device.findByProviderId('shelly', mac);
@@ -77,32 +91,6 @@ async function setupBLUDevice(ip, mac, name) {
   device.meta.sensors = sensors;
 
   await device.save();
-}
-
-router.get('/install-wifi', async (req, res) => {
-  const { ip } = req.query;
-
-  if (!ip) {
-    return res.end('Pass ip in query string');
-  }
-
-  await setupWiFiDevice(ip);
-
-  res.sendStatus(201).end();
-});
-
-router.get('/install-blu', async (req, res) => {
-  const { ip, mac, name } = req.query;
-
-  if (!ip || !mac || !name) {
-    return res.end('Pass ip (gateway), mac (sensor BLE MAC), and name in query string');
-  }
-
-  try {
-    await setupBLUDevice(ip, mac, name);
-  } catch (err) {
-    return res.status(404).end(err.message);
-  }
 
   res.sendStatus(201).end();
 });

--- a/server/src/routes/shelly.js
+++ b/server/src/routes/shelly.js
@@ -5,13 +5,15 @@ import DeviceClient from '../services/shelly/client/device';
 
 const router = express.Router();
 
-router.get('/install', async (req, res) => {
-  const ip = req.query.ip;
-
-  if (!ip) {
-    return res.end('Pass IP in query string');
+router.use((req, res, next) => {
+  if (req.query.secret !== config.shelly.secret) {
+    return res.sendStatus(401).end();
+  } else {
+    next();
   }
+});
 
+async function setupWiFiDevice(ip) {
   const client = await DeviceClient.for(ip, config.shelly.user, config.shelly.password);
   const model = await client.getModel();
   const mqttId = await client.getMqttId();
@@ -48,32 +50,24 @@ router.get('/install', async (req, res) => {
 
   await client.reboot();
   await device.save();
-
-  res.sendStatus(201).end();
-});
+}
 
 // Onboards a BLU (Bluetooth) sensor that's already been paired locally (not just
 // cloud relay) to a gateway device, e.g. via the Shelly app's Bluetooth settings
-// for that gateway. `ip` is the gateway's own IP; `addr` is the sensor's BLE MAC.
-router.get('/install-blu', async (req, res) => {
-  const { ip, addr, name } = req.query;
-
-  if (!ip || !addr || !name) {
-    return res.end('Pass ip (gateway), addr (sensor BLE MAC), and name in query string');
-  }
-
+// for that gateway. `ip` is the gateway's own IP; `mac` is the sensor's BLE MAC.
+async function setupBLUDevice(ip, mac, name) {
   const client = await DeviceClient.for(ip, config.shelly.user, config.shelly.password);
   const gatewayProviderId = await client.getMqttId();
-  const sensors = await client.getBTHomeSensorsFor(addr);
+  const sensors = await client.getBTHomeSensorsFor(mac);
 
   if (Object.keys(sensors).length === 0) {
-    return res.status(404).end(`No known BTHome sensor objects found for ${addr} on ${ip}. Has it been paired locally to this gateway (not just cloud relay)?`);
+    throw new Error(`No known BTHome sensor objects found for ${mac} on ${ip}. Has it been paired locally to this gateway (not just cloud relay)?`);
   }
 
-  let device = await Device.findByProviderId('shelly', addr);
+  let device = await Device.findByProviderId('shelly', mac);
 
   if (!device) {
-    device = Device.build({ provider: 'shelly', providerId: addr });
+    device = Device.build({ provider: 'shelly', providerId: mac });
   }
 
   device.name = name;
@@ -83,6 +77,28 @@ router.get('/install-blu', async (req, res) => {
   device.meta.sensors = sensors;
 
   await device.save();
+}
+
+router.get('/install', async (req, res) => {
+  const { ip, mac, name } = req.query;
+
+  if (!ip) {
+    return res.end('Pass ip in query string');
+  }
+
+  if (mac) {
+    if (!name) {
+      return res.end('Pass name in query string when installing a BLU device (mac was given)');
+    }
+
+    try {
+      await setupBLUDevice(ip, mac, name);
+    } catch (err) {
+      return res.status(404).end(err.message);
+    }
+  } else {
+    await setupWiFiDevice(ip);
+  }
 
   res.sendStatus(201).end();
 });

--- a/server/src/routes/shelly.js
+++ b/server/src/routes/shelly.js
@@ -52,4 +52,39 @@ router.get('/install', async (req, res) => {
   res.sendStatus(201).end();
 });
 
+// Onboards a BLU (Bluetooth) sensor that's already been paired locally (not just
+// cloud relay) to a gateway device, e.g. via the Shelly app's Bluetooth settings
+// for that gateway. `ip` is the gateway's own IP; `addr` is the sensor's BLE MAC.
+router.get('/install-blu', async (req, res) => {
+  const { ip, addr, name } = req.query;
+
+  if (!ip || !addr || !name) {
+    return res.end('Pass ip (gateway), addr (sensor BLE MAC), and name in query string');
+  }
+
+  const client = await DeviceClient.for(ip, config.shelly.user, config.shelly.password);
+  const gatewayProviderId = await client.getMqttId();
+  const sensors = await client.getBTHomeSensorsFor(addr);
+
+  if (Object.keys(sensors).length === 0) {
+    return res.status(404).end(`No known BTHome sensor objects found for ${addr} on ${ip}. Has it been paired locally to this gateway (not just cloud relay)?`);
+  }
+
+  let device = await Device.findByProviderId('shelly', addr);
+
+  if (!device) {
+    device = Device.build({ provider: 'shelly', providerId: addr });
+  }
+
+  device.name = name;
+  device.manufacturer = 'Shelly';
+  device.model = 'SBDW-002C';
+  device.meta.gatewayProviderId = gatewayProviderId;
+  device.meta.sensors = sensors;
+
+  await device.save();
+
+  res.sendStatus(201).end();
+});
+
 export default router;

--- a/server/src/services/shelly/client/gen2plus-device.js
+++ b/server/src/services/shelly/client/gen2plus-device.js
@@ -1,5 +1,3 @@
-// BTHome object ids (https://bthome.io/format) mapped to the capability
-// property Karen exposes them as.
 const BTHOME_OBJECT_ID_TO_PROPERTY = {
   1: 'battery',
   45: 'contact',

--- a/server/src/services/shelly/client/gen2plus-device.js
+++ b/server/src/services/shelly/client/gen2plus-device.js
@@ -1,3 +1,10 @@
+// BTHome object ids (https://bthome.io/format) mapped to the capability
+// property Karen exposes them as.
+const BTHOME_OBJECT_ID_TO_PROPERTY = {
+  1: 'battery',
+  45: 'contact',
+};
+
 export default class Gen2PlusDeviceClient {
   constructor(ip, username, password, generation) {
     this._ip = ip;
@@ -68,5 +75,28 @@ export default class Gen2PlusDeviceClient {
 
   async setLedMode(mode) {
     return await this._request(`/rpc/PLUGUK_UI.SetConfig?config={"leds":{"mode":"${mode}"}}`);
+  }
+
+  // Returns the `{ [localSensorId]: property }` mapping for a BTHome (BLU) device
+  // already paired to this gateway, restricted to object types Karen understands.
+  async getBTHomeSensorsFor(addr) {
+    const { components } = await this._request('/rpc/Shelly.GetComponents?dynamic_only=true');
+    const sensors = {};
+
+    for (const component of components) {
+      if (!component.key.startsWith('bthomesensor:') || component.config.addr !== addr) {
+        continue;
+      }
+
+      const property = BTHOME_OBJECT_ID_TO_PROPERTY[component.config.obj_id];
+
+      if (property) {
+        const id = component.key.split(':')[1];
+
+        sensors[id] = property;
+      }
+    }
+
+    return sensors;
   }
 }

--- a/server/src/services/shelly/client/gen2plus-device.js
+++ b/server/src/services/shelly/client/gen2plus-device.js
@@ -77,12 +77,12 @@ export default class Gen2PlusDeviceClient {
 
   // Returns the `{ [localSensorId]: property }` mapping for a BTHome (BLU) device
   // already paired to this gateway, restricted to object types Karen understands.
-  async getBTHomeSensorsFor(addr) {
+  async getBTHomeSensorsFor(mac) {
     const { components } = await this._request('/rpc/Shelly.GetComponents?dynamic_only=true');
     const sensors = {};
 
     for (const component of components) {
-      if (!component.key.startsWith('bthomesensor:') || component.config.addr !== addr) {
+      if (!component.key.startsWith('bthomesensor:') || component.config.addr !== mac) {
         continue;
       }
 

--- a/server/src/services/shelly/index.ts
+++ b/server/src/services/shelly/index.ts
@@ -19,7 +19,7 @@ Device.registerProvider('shelly', {
         return ['ALARM_SENSOR', 'CONNECTIVITY'];
 
       case 'SBDW-002C':    // Shelly BLU Door/Window (via BLE gateway)
-        return ['CONTACT_SENSOR'];
+        return ['CONTACT_SENSOR', 'BATTERY_LEVEL_INDICATOR'];
 
       default:
         throw new Error(`Cannot infer capabilities for device ${device.id} (${device.model})`);

--- a/server/src/services/shelly/index.ts
+++ b/server/src/services/shelly/index.ts
@@ -16,7 +16,10 @@ Device.registerProvider('shelly', {
         return ['SWITCH', 'CONNECTIVITY'];
 
       case 'S4SW-001X8EU': // Shelly 1 Mini Gen4 (Fire Alarm)
-        return ['CONTACT_SENSOR', 'CONNECTIVITY'];
+        return ['ALARM_SENSOR', 'CONNECTIVITY'];
+
+      case 'SBDW-002C':    // Shelly BLU Door/Window (via BLE gateway)
+        return ['CONTACT_SENSOR'];
 
       default:
         throw new Error(`Cannot infer capabilities for device ${device.id} (${device.model})`);

--- a/server/src/services/shelly/mqtt.ts
+++ b/server/src/services/shelly/mqtt.ts
@@ -24,6 +24,7 @@ function getClient(): MqttClient {
         `${TOPIC_PREFIX}/+/light/0/power`,
         `${TOPIC_PREFIX}/+/status/switch:0`,
         `${TOPIC_PREFIX}/+/status/input:0`,
+        `${TOPIC_PREFIX}/+/blu`,
       ], (err) => {
         if (err) {
           logger.error(err, 'Shelly MQTT subscribe failed');
@@ -48,13 +49,26 @@ function getClient(): MqttClient {
 async function handleMessage(topic: string, payload: string): Promise<void> {
   const segments = topic.split('/');
   const mqttId = segments[1];
-  const device = await Device.findByProviderId('shelly', mqttId);
+  const subtopic = segments.slice(2).join('/');
+
+  let device = await Device.findByProviderId('shelly', mqttId);
 
   if (device === null) {
-    return;
+    // BLU (Bluetooth) door/window sensors can't be onboarded via the HTTP
+    // install route (they have no IP), so auto-provision them on first sighting.
+    // The gateway script publishes to `shellies/<blu-mac>/blu`, which places the
+    // MAC in the existing providerId slot. Any other unknown device is ignored.
+    if (subtopic !== 'blu') {
+      return;
+    }
+
+    device = Device.build({ provider: 'shelly', providerId: mqttId });
+    device.name = mqttId;
+    device.manufacturer = 'Shelly';
+    device.model = 'SBDW-002C';
+    await device.save();
   }
 
-  const subtopic = segments.slice(2).join('/');
   const capabilities = device.getCapabilities();
 
   if (subtopic === 'online') {
@@ -95,10 +109,21 @@ async function handleMessage(topic: string, payload: string): Promise<void> {
     return;
   }
 
-  if (subtopic === 'status/input:0' && capabilities.includes('CONTACT_SENSOR')) {
+  if (subtopic === 'status/input:0' && capabilities.includes('ALARM_SENSOR')) {
     const data = JSON.parse(payload);
 
-    await device.getContactSensorCapability().setIsClosedState(data.state);
+    await device.getAlarmSensorCapability().setIsTriggeredState(data.state);
+
+    return;
+  }
+
+  if (subtopic === 'blu' && capabilities.includes('CONTACT_SENSOR')) {
+    const data = JSON.parse(payload);
+
+    // PROVISIONAL: the exact payload shape is defined by the BLE-gateway script
+    // and must be confirmed against a captured message. BTHome window/door
+    // (object 0x2D) reports 1 = open, 0 = closed.
+    await device.getContactSensorCapability().setIsOpenState(Boolean(data.window));
 
     return;
   }

--- a/server/src/services/shelly/mqtt.ts
+++ b/server/src/services/shelly/mqtt.ts
@@ -22,9 +22,7 @@ function getClient(): MqttClient {
         `${TOPIC_PREFIX}/+/online`,
         `${TOPIC_PREFIX}/+/light/0/status`,
         `${TOPIC_PREFIX}/+/light/0/power`,
-        `${TOPIC_PREFIX}/+/status/switch:0`,
-        `${TOPIC_PREFIX}/+/status/input:0`,
-        `${TOPIC_PREFIX}/+/blu`,
+        `${TOPIC_PREFIX}/+/status/+`,
       ], (err) => {
         if (err) {
           logger.error(err, 'Shelly MQTT subscribe failed');
@@ -51,22 +49,10 @@ async function handleMessage(topic: string, payload: string): Promise<void> {
   const mqttId = segments[1];
   const subtopic = segments.slice(2).join('/');
 
-  let device = await Device.findByProviderId('shelly', mqttId);
+  const device = await Device.findByProviderId('shelly', mqttId);
 
   if (device === null) {
-    // BLU (Bluetooth) door/window sensors can't be onboarded via the HTTP
-    // install route (they have no IP), so auto-provision them on first sighting.
-    // The gateway script publishes to `shellies/<blu-mac>/blu`, which places the
-    // MAC in the existing providerId slot. Any other unknown device is ignored.
-    if (subtopic !== 'blu') {
-      return;
-    }
-
-    device = Device.build({ provider: 'shelly', providerId: mqttId });
-    device.name = mqttId;
-    device.manufacturer = 'Shelly';
-    device.model = 'SBDW-002C';
-    await device.save();
+    return;
   }
 
   const capabilities = device.getCapabilities();
@@ -117,13 +103,27 @@ async function handleMessage(topic: string, payload: string): Promise<void> {
     return;
   }
 
-  if (subtopic === 'blu' && capabilities.includes('CONTACT_SENSOR')) {
+  // BLU (Bluetooth) sensors are relayed under their pairing gateway's own topic,
+  // keyed by a small integer the gateway assigns locally when the sensor is bound
+  // (see BTHome.AddDevice) rather than by the sensor's own MAC. That id isn't
+  // stable across a delete/re-pair, so devices carry the current
+  // `{ [sensorId]: property }` mapping in `meta.sensors`, keyed against the
+  // gateway they're paired to via `meta.gatewayProviderId`.
+  if (subtopic.startsWith('status/bthomesensor:')) {
+    const sensorId = subtopic.slice('status/bthomesensor:'.length);
     const data = JSON.parse(payload);
+    const children = await Device.findByProvider('shelly');
+    const child = children.find((d) => d.meta.gatewayProviderId === mqttId && (d.meta.sensors as Record<string, string> | undefined)?.[sensorId]);
 
-    // PROVISIONAL: the exact payload shape is defined by the BLE-gateway script
-    // and must be confirmed against a captured message. BTHome window/door
-    // (object 0x2D) reports 1 = open, 0 = closed.
-    await device.getContactSensorCapability().setIsOpenState(Boolean(data.window));
+    if (child) {
+      const property = (child.meta.sensors as Record<string, string>)[sensorId];
+
+      if (property === 'contact') {
+        await child.getContactSensorCapability().setIsOpenState(Boolean(data.value));
+      } else if (property === 'battery') {
+        await child.getBatteryLevelIndicatorCapability().setBatteryPercentageState(data.value);
+      }
+    }
 
     return;
   }

--- a/server/src/services/shelly/mqtt.ts
+++ b/server/src/services/shelly/mqtt.ts
@@ -104,11 +104,13 @@ async function handleMessage(topic: string, payload: string): Promise<void> {
   }
 
   // BLU (Bluetooth) sensors are relayed under their pairing gateway's own topic,
-  // keyed by a small integer the gateway assigns locally when the sensor is bound
-  // (see BTHome.AddDevice) rather than by the sensor's own MAC. That id isn't
-  // stable across a delete/re-pair, so devices carry the current
-  // `{ [sensorId]: property }` mapping in `meta.sensors`, keyed against the
-  // gateway they're paired to via `meta.gatewayProviderId`.
+  // keyed by a small integer the gateway assigns locally when the sensor is
+  // bound (see BTHome.AddDevice) rather than by the sensor's own MAC. That id
+  // isn't unique across Shelly devices — only within one gateway — so it can't
+  // be the child's providerId; and the gateway's own providerId is already
+  // taken by the gateway device itself. So each BLU child stores its pairing
+  // in meta (`gatewayProviderId` + `sensors: { [sensorId]: property }`) and we
+  // look it up by that pair.
   if (subtopic.startsWith('status/bthomesensor:')) {
     const sensorId = subtopic.slice('status/bthomesensor:'.length);
     const data = JSON.parse(payload);


### PR DESCRIPTION
## The original ask

"Can we have an automation that supports auto-relocking for locks?" The first cut of `automations/auto-relock.ts` did the obvious thing: when a lock is unlocked, wait a configurable delay and relock it.

## The problem (found in testing)

That naive version is unsafe and, on the real hardware, often **physically impossible**:

- **The lock can't be re-thrown remotely once the door has been opened.** The handle has to be lifted manually to re-engage the bolt. A remote `setIsLocked(true)` only works while the door has *stayed shut* in the frame.
- **The lock's own telemetry is unreliable.** Testing showed the Z-Wave lock module's `doorStatus` just mirrors bolt state (it flips "open" the instant you unlock, while the door is still shut) and `latchStatus` is static. Neither reports the actual door leaf position.

So a fixed-delay relock would either fail (jam) or fire at the wrong time. What's needed is an **independent door-open signal**, and a rule that only relocks when it's actually possible:

> **Auto-relock only if the lock was unlocked *and* the door was never opened before the timer expires.** If the door opens during the unlocked window, cancel the relock — Karen can't re-lock an opened door anyway. The door sensor is purely a **veto**, never a trigger to relock on close.

## The approach

A **Shelly BLU Door/Window sensor** provides the independent signal.

**1. Door sensor capability, and a taxonomy fix.**
The existing `ContactSensor` capability was a misnomer: it was wired to the fire alarm and behaved like one (`IsClosed`, `true` → red "TRIGGERED"). In standard home-automation terms, a "contact sensor" *is* a door/window sensor. So:
  - existing `ContactSensor` → **`AlarmSensor`** (`IsTriggered`, keeps the red Triggered/OK UI);
  - the door sensor becomes the new, conventionally-named **`ContactSensor`** (`IsOpen`, neutral Open/Closed UI), and also exposes **`BatteryLevelIndicator`** (BTHome reports battery % alongside contact state);
  - **No DB migration:** the alarm's stored `eventName` stays `"closed"`, so its history is untouched. Only capability/property *names* changed in code.

**2. Auto-relock automation**, rewritten to the veto model: `doorSensorName` is a **mandatory** per-lock config field (not optional — without one, Karen has no way to know the door opened, and blindly re-throwing the bolt on a timer risks jamming it against an open door). If the configured sensor device doesn't exist, the automation throws rather than silently skipping the veto. Relock is only scheduled when unlocked *and* the door is currently closed; opening the door cancels any pending relock outright (never rescheduled on close, per the manual-handle constraint above). Each lock owns its own timer/abort state via a dedicated closure rather than a shared map. `ensureIsLocked` still confirms the bolt threw and notifies admins on a genuine failure.

## What live testing against real hardware changed

The first version of the MQTT parsing (marked `PROVISIONAL`) turned out to be wrong on two structural points, not just payload details, once tested against an actual BLU Door/Window sensor and its Shelly gateway:

- **Pairing mode matters.** A BLU sensor added to a gateway via the general "add device" flow in the Shelly app pairs in **cloud-relay mode** — the gateway just forwards raw encrypted BLE bytes up to Shelly Cloud for parsing, and *nothing* reaches local MQTT/RPC. The sensor has to be paired **locally** to the gateway (its own Bluetooth settings, not the cloud/app flow) for the gateway to decode it and publish updates. No encryption bind key turned out to be needed once paired this way.
- **There's no per-sensor MQTT topic.** The original assumption was a `shellies/<sensor-mac>/blu` topic per device. In reality, everything is relayed under the **gateway's own topic** as `status/bthomesensor:<id>`, where `<id>` is a small integer the gateway assigns *locally* when the sensor object is bound — not the sensor's MAC, and not guaranteed unique outside that one gateway, and not stable across a delete/re-pair.

Because of that second point, a BLU sensor can no longer be auto-provisioned from an incoming MQTT message the way the provisional code assumed — the message carries no globally-identifying information at all. Each BLU sensor is instead modelled as its own `Device` (`providerId` = its BLE MAC, which *is* globally unique and stable across re-pairing), onboarded via a new `/shelly/install-blu` route that reads the gateway's current sensor-object mapping over RPC and stores it in the device's `meta` (the volatile `{ [sensorId]: property }` mapping, plus which gateway it's paired to). Incoming MQTT messages are routed to the right `Device` by matching on that `meta` — not a direct `providerId` lookup, since the wire message only ever carries the gateway's id and the local sensor id, never a stable identity.

The existing `/shelly/install` route was renamed to `/shelly/install-wifi` for symmetry with `/shelly/install-blu`. Both routes now also enforce the `secret` query-string check that every other webhook-style route in this codebase already has (`synology.ts` etc.) — it turned out to be defined in config but never actually wired up, leaving Shelly device onboarding open to anyone who could reach the server.

## Verification done

`npm run codegen && npm run lint && npm run test && npm run build` all pass (43 tests, zero lint warnings). Live-tested end-to-end against a real Shelly BLU Door/Window sensor and Z-Wave lock: unlock → timer scheduled → door opened → timer cancelled; unlock → door stays shut → relock fires and succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
