### PR TITLE
Remove hardcoded 30°C max from thermostat temperature graph

### DIFF
--- a/server/src/components/capabilities/registry.tsx
+++ b/server/src/components/capabilities/registry.tsx
@@ -344,7 +344,7 @@ export const registry: CapabilityUIRegistry = {
         id: 'thermostat',
         title: 'Temperature & Power',
         yAxis: {
-          yTemperature: { position: 'left', min: 0, max: 30 },
+          yTemperature: { position: 'left', min: 0 },
           yPercentage: { position: 'right', min: 0, max: 100 },
         },
       },

--- a/server/src/components/capabilities/registry.tsx
+++ b/server/src/components/capabilities/registry.tsx
@@ -344,7 +344,7 @@ export const registry: CapabilityUIRegistry = {
         id: 'thermostat',
         title: 'Temperature & Power',
         yAxis: {
-          yTemperature: { position: 'left', min: 0 },
+          yTemperature: { position: 'left', min: 0, suggestedMax: 30 },
           yPercentage: { position: 'right', min: 0, max: 100 },
         },
       },

--- a/server/src/components/capability-graphs/capability-graph.tsx
+++ b/server/src/components/capability-graphs/capability-graph.tsx
@@ -100,6 +100,7 @@ export type CapabilityGraphProps = {
     position?: 'left' | 'right',
     max?: number,
     min?: number,
+    suggestedMax?: number,
   }>
 
   yMin?: number


### PR DESCRIPTION
## Summary

- Removes the `max: 30` cap on the thermostat capability's temperature y-axis (`registry.tsx:347`)
- Chart.js will now auto-scale the upper bound based on actual data, so readings above 30°C are no longer clipped
- `min: 0` is retained to keep the floor sensible for room temperatures
- The `yPercentage` axis (`max: 100`) is unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8FozomuWhrX8HEnRqYy94)_