### PR TITLE
Prevent heating automations from overriding explicit OFF state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,8 @@ Device.registerProvider('providerName', {
 
 **Configuration-Driven Automations**: Automations are configured in `config.json` and dynamically loaded at startup. Each automation module receives parameters and registers event handlers. Each automation exports a default function with a named `FooAutomationParameters` type for its config object (see `automations/bathroom.ts`). Required parameters have no defaults.
 
+**Runtime mutable config**: For settings that need to persist across server restarts and be changeable at runtime (e.g. feature flags, seasonal overrides), add a field to `config.json` and use `saveConfig()` from `helpers/config.js` to write back to disk atomically. Do NOT create a new DB settings table — `saveConfig` is the established pattern already used for Tado/Alexa/SmartCar token persistence and costs zero infrastructure.
+
 **Capability UI Registry**: UI configuration for device capabilities is centralized in `/components/capabilities/`. When adding a new capability type, only update `registry.tsx`:
 
 ```typescript

--- a/server/src/automations/heating-warmup.ts
+++ b/server/src/automations/heating-warmup.ts
@@ -50,7 +50,6 @@ export default function ({
 
     for (const device of thermostatDevices) {
       const thermostat = device.getThermostatCapability();
-
       const targetTemperature = await thermostat.getTargetTemperature();
       if (targetTemperature === 0) {
         continue;

--- a/server/src/automations/heating-warmup.ts
+++ b/server/src/automations/heating-warmup.ts
@@ -50,6 +50,12 @@ export default function ({
 
     for (const device of thermostatDevices) {
       const thermostat = device.getThermostatCapability();
+
+      const targetTemperature = await thermostat.getTargetTemperature();
+      if (targetTemperature === 0) {
+        continue;
+      }
+
       const nextScheduledChange = await thermostat.getNextScheduledChange();
 
       if (nextScheduledChange) {

--- a/server/src/automations/occupancy.ts
+++ b/server/src/automations/occupancy.ts
@@ -124,6 +124,11 @@ export default function (config: OccupanyAutomationConfiguration) {
     }
 
     const thermostats = await Device.findByCapability('THERMOSTAT');
-    await Promise.all(thermostats.map(async (thermostat) => await thermostat.getThermostatCapability().setIsOn(true)));
+    await Promise.all(thermostats.map(async (thermostat) => {
+      const targetTemperature = await thermostat.getThermostatCapability().getTargetTemperature();
+      if (targetTemperature !== 0) {
+        await thermostat.getThermostatCapability().setIsOn(true);
+      }
+    }));
   }));
 }

--- a/server/src/automations/occupancy.ts
+++ b/server/src/automations/occupancy.ts
@@ -126,6 +126,7 @@ export default function (config: OccupanyAutomationConfiguration) {
     const thermostats = await Device.findByCapability('THERMOSTAT');
     await Promise.all(thermostats.map(async (thermostat) => {
       const targetTemperature = await thermostat.getThermostatCapability().getTargetTemperature();
+
       if (targetTemperature !== 0) {
         await thermostat.getThermostatCapability().setIsOn(true);
       }


### PR DESCRIPTION
## Summary

- **`occupancy.ts`**: When `FIRST_USER_HOME` fires, `setIsOn(true)` is now skipped for any thermostat whose `targetTemperature` is `0`. Previously this was called unconditionally, meaning coming home would always re-enable heating even if it had been explicitly turned off.
- **`heating-warmup.ts`**: `checkAtHomeWarmup` now skips any zone with `targetTemperature === 0`, so the pre-heat logic won't raise a temperature that was deliberately set to off.
- **`CLAUDE.md`**: Added a note on the `saveConfig()` pattern for runtime-mutable config, so future sessions don't reach for a new DB settings table when a config.json field + `saveConfig` is the established approach.

`checkAwayWarmup` is intentionally left unchanged — it only runs when the user has set an ETA, which is an explicit signal that they want heating ready on arrival.

SETBACK behaviour is unaffected: setback temperatures are `> 0`, so `setIsOn(true)` still fires correctly on arrival from away mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDR8YhXQPBtpJA8fqq5EXa)_