### PR TITLE
Add train-status automation with per-user Pushover targeting

### DIFF
--- a/server/src/automations/train-status.ts
+++ b/server/src/automations/train-status.ts
@@ -1,0 +1,99 @@
+import bus, { NOTIFICATION_TO_USER } from '../bus';
+import dayjs from '../dayjs';
+import logger from '../logger';
+import setIntervalForTime from '../helpers/set-interval-for-time';
+import { getServiceStatus, ServiceStatus } from '../services/raildata/client';
+
+type TrainAlert = {
+  user: string;
+  day: string;
+  departureTime: string;
+  from: string;
+  to: string;
+};
+
+export type TrainStatusAutomationParameters = {
+  startCheckingAt: number;
+  checkInterval: number;
+  alerts: TrainAlert[];
+};
+
+const DAY_NAMES = new Set([
+  'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'
+]);
+
+const TRAFFIC_LIGHT: Record<ServiceStatus['kind'], string> = {
+  'on-time': '🟢',
+  'delayed': '🟠',
+  'cancelled': '🔴',
+  'not-found': '🔴',
+};
+
+function formatMessage(status: ServiceStatus, from: string, to: string): string {
+  const light = TRAFFIC_LIGHT[status.kind];
+  const platform = 'platform' in status && status.platform !== null
+    ? ` (Plat ${status.platform})`
+    : '';
+
+  switch (status.kind) {
+    case 'on-time':
+      return `🚆 ${light} ${status.scheduled} ${from} → ${to} is on time${platform}`;
+    case 'delayed':
+      return `🚆 ${light} ${status.scheduled} ${from} → ${to} delayed, now ${status.estimated}${platform}`;
+    case 'cancelled':
+      return `🚆 ${light} ${status.scheduled} ${from} → ${to} CANCELLED${status.reason ? ` — ${status.reason}` : ''}`;
+    case 'not-found':
+      return `🚆 ${light} ${status.scheduled} ${from} → ${to} not found on the departure board`;
+  }
+}
+
+function runAlert(alert: TrainAlert, checkInterval: number) {
+  if (dayjs().format('dddd').toLowerCase() !== alert.day.toLowerCase()) {
+    return;
+  }
+
+  const [depHour, depMinute] = alert.departureTime.split(':').map(Number);
+  const departure = dayjs().startOf('minute').hour(depHour).minute(depMinute);
+  let lastSentMessage: string | null = null;
+
+  async function runCheck(alwaysSend: boolean) {
+    try {
+      const status = await getServiceStatus(alert.from, alert.to, alert.departureTime);
+      const message = formatMessage(status, alert.from, alert.to);
+
+      if (alwaysSend || message !== lastSentMessage) {
+        bus.emit(NOTIFICATION_TO_USER, { userHandle: alert.user, message });
+        lastSentMessage = message;
+      }
+    } catch (e) {
+      logger.error(e, `train-status: check failed for ${alert.user}`);
+    }
+  }
+
+  function scheduleNext() {
+    const nextCheck = dayjs().add(checkInterval, 'minute');
+
+    if (nextCheck.isAfter(departure)) {
+      return;
+    }
+
+    setTimeout(async () => {
+      await runCheck(false);
+      scheduleNext();
+    }, checkInterval * 60 * 1000);
+  }
+
+  runCheck(true).then(scheduleNext);
+}
+
+export default function ({ startCheckingAt, checkInterval, alerts }: TrainStatusAutomationParameters) {
+  for (const alert of alerts) {
+    if (!DAY_NAMES.has(alert.day.toLowerCase())) {
+      throw new Error(`train-status: invalid day "${alert.day}"`);
+    }
+
+    setIntervalForTime(() => {
+      runAlert(alert, checkInterval);
+    }, `${alert.departureTime} - ${startCheckingAt}m`);
+  }
+}

--- a/server/src/bus.ts
+++ b/server/src/bus.ts
@@ -7,6 +7,7 @@ export const FIRST_USER_HOME = 'FIRST_USER_HOME';
 export const LAST_USER_LEAVES = 'LAST_USER_LEAVES';
 export const NOTIFICATION_TO_ALL = 'NOTIFICATION_TO_ALL';
 export const NOTIFICATION_TO_ADMINS = 'NOTIFICATION_TO_ADMINS';
+export const NOTIFICATION_TO_USER = 'NOTIFICATION_TO_USER';
 export const STAY_START = 'STAY_START';
 export const STAY_END = 'STAY_END';
 
@@ -15,6 +16,7 @@ const emitter: KarenEventBus = new EventEmitter();
 emitter.setMaxListeners(100);
 
 type NotificationEvents = 'NOTIFICATION_TO_ALL' | 'NOTIFICATION_TO_ADMINS';
+type UserNotificationEvents = 'NOTIFICATION_TO_USER';
 type StayEvents = 'FIRST_USER_HOME' | 'LAST_USER_LEAVES' | 'STAY_START' | 'STAY_END';
 
 type BaseNotificationPayload = {
@@ -27,12 +29,16 @@ type NotificationPayload =
   | (BaseNotificationPayload & { priority: 2, retry: number, expire: number })
   | (BaseNotificationPayload & { priority?: -2 | -1 | 0 | 1 });
 
+type UserNotificationPayload = NotificationPayload & { userHandle: string };
+
 interface KarenEventBus extends EventEmitter {
   emit(event: NotificationEvents, payload: NotificationPayload): boolean;
+  emit(event: UserNotificationEvents, payload: UserNotificationPayload): boolean;
   emit(event: StayEvents, payload: Stay): boolean;
   emit(event: DeviceCapabilityEvent, payload: NumericEvent | BooleanEvent | StringEvent): void;
 
   on(event: NotificationEvents, cb: (payload: NotificationPayload) => void): this;
+  on(event: UserNotificationEvents, cb: (payload: UserNotificationPayload) => void): this;
   on(event: StayEvents, cb: (payload: Stay) => void): this;
   on(event: DeviceCapabilityEvent, cb: (payload: NumericEvent) => unknown): this;
   on(event: DeviceCapabilityEvent, cb: (payload: BooleanEvent) => unknown): this;

--- a/server/src/config.d.ts
+++ b/server/src/config.d.ts
@@ -91,6 +91,9 @@ declare namespace _default {
     const secret: string;
     const access_token: string;
   }
+  export namespace raildata {
+    const api_key: string;
+  }
   export namespace octopus {
     const api_key: string;
     const account_number: string;

--- a/server/src/services/pushover/index.js
+++ b/server/src/services/pushover/index.js
@@ -1,7 +1,7 @@
 import Push from 'pushover-notifications';
 import config from '../../config';
 import logger from '../../logger';
-import bus, { NOTIFICATION_TO_ADMINS, NOTIFICATION_TO_ALL } from '../../bus';
+import bus, { NOTIFICATION_TO_ADMINS, NOTIFICATION_TO_ALL, NOTIFICATION_TO_USER } from '../../bus';
 import { User } from '../../models';
  
 const push = new Push({
@@ -39,6 +39,17 @@ bus.on(NOTIFICATION_TO_ADMINS, (e) => {
 
 bus.on(NOTIFICATION_TO_ALL, async (e) => {
   const users = await User.getThoseWithPushoverToken();
-  
+
   sendNotificationToUsers(users.map(x => x.pushoverToken), e);
+});
+
+bus.on(NOTIFICATION_TO_USER, async ({ userHandle, ...event }) => {
+  const [user] = await User.findByHandles([userHandle]);
+
+  if (!user?.pushoverToken) {
+    logger.warn(`No pushoverToken for user handle "${userHandle}"; notification dropped`);
+    return;
+  }
+
+  sendNotificationToUsers([user.pushoverToken], event);
 });

--- a/server/src/services/raildata/client.ts
+++ b/server/src/services/raildata/client.ts
@@ -1,0 +1,79 @@
+import config from '../../config';
+
+export type ServiceStatus =
+  | { kind: 'on-time'; scheduled: string; platform: string | null }
+  | { kind: 'delayed'; scheduled: string; estimated: string; platform: string | null }
+  | { kind: 'cancelled'; scheduled: string; reason: string | null }
+  | { kind: 'not-found'; scheduled: string };
+
+interface TrainService {
+  std: string;
+  etd: string;
+  platform: string | null;
+  isCancelled?: boolean;
+  cancelReason?: string | null;
+  delayReason?: string | null;
+}
+
+interface DepartureBoardResponse {
+  trainServices: TrainService[] | null;
+}
+
+const BASE_URL = 'https://api1.raildata.org.uk/1010-live-departure-board-dep1_2/LDBWS/api/20220120';
+
+async function request<T>(url: string): Promise<T> {
+  let response;
+
+  try {
+    response = await fetch(url, {
+      headers: {
+        'x-apikey': config.raildata.api_key
+      }
+    });
+  } catch (e: any) {
+    throw new Error(`Rail Data request to ${url} failed: ${e.message}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Rail Data request to ${url} failed with HTTP status ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export async function getServiceStatus(
+  fromCrs: string,
+  toCrs: string,
+  scheduledDeparture: string
+): Promise<ServiceStatus> {
+  const url = `${BASE_URL}/GetDepBoardWithDetails/${encodeURIComponent(fromCrs)}`
+    + `?filterCrs=${encodeURIComponent(toCrs)}&filterType=to`;
+
+  const board = await request<DepartureBoardResponse>(url);
+  const service = (board.trainServices ?? []).find(s => s.std === scheduledDeparture);
+
+  if (!service) {
+    return { kind: 'not-found', scheduled: scheduledDeparture };
+  }
+
+  const platform = service.platform ?? null;
+
+  if (service.isCancelled || service.etd === 'Cancelled') {
+    return {
+      kind: 'cancelled',
+      scheduled: scheduledDeparture,
+      reason: service.cancelReason ?? null
+    };
+  }
+
+  if (service.etd === 'On time') {
+    return { kind: 'on-time', scheduled: scheduledDeparture, platform };
+  }
+
+  return {
+    kind: 'delayed',
+    scheduled: scheduledDeparture,
+    estimated: service.etd,
+    platform
+  };
+}


### PR DESCRIPTION
## Summary

- New `train-status` automation. Config takes a list of alerts (each with a user handle, weekday name, scheduled departure time, and origin/destination CRS codes) plus two cadence knobs: `startCheckingAt` (minutes before departure to run the first check) and `checkInterval` (minutes between subsequent checks up to the scheduled departure). The first check always notifies; each follow-up only notifies when the status text has changed.
- New `services/raildata/client.ts` — thin HTTP wrapper around the National Rail LDBWS REST API (Rail Data Marketplace), following the same shape as `services/octopus/client.ts`. Exposes `getServiceStatus(from, to, scheduledDeparture)` returning a discriminated union: `on-time` / `delayed` / `cancelled` / `not-found`.
- New `NOTIFICATION_TO_USER` bus event so a notification can be routed to a single user by `handle` rather than broadcast. The Pushover service resolves the handle to that user's `pushoverToken`, or logs a warning and drops the notification if the user has no token set.
- `config.d.ts` gains a `raildata.api_key` namespace.

Message format uses a traffic-light indicator after the train emoji — 🟢 on time, 🟠 delayed, 🔴 cancelled or not found — with the scheduled time, route, platform, and (for cancellations) the reason returned by Darwin.

## Test plan

- [ ] `npm run codegen && npm run lint && npm test` all pass locally.
- [ ] With `raildata.api_key` populated in `config.json` and an alert whose `day` matches today and `departureTime` is a few minutes ahead of now (with small `startCheckingAt` / `checkInterval` values), the first Pushover message arrives at `departureTime - startCheckingAt` and subsequent checks fire on the configured interval, only notifying again if the status text changes.
- [ ] An alert whose `user` handle has no `pushoverToken` set in the DB produces a warning log and no Pushover call.
- [ ] An alert whose `departureTime` does not appear on the live board produces a 🔴 "not found" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChF5u2rBccFkMFSTY6KWs6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChF5u2rBccFkMFSTY6KWs6)_