### PR TITLE
Drop contact-sensor graph, add open events to device timeline

### DIFF
--- a/server/src/api/types.ts
+++ b/server/src/api/types.ts
@@ -202,6 +202,10 @@ export type DeviceTimelineEventApiResponse = {
   type: 'light-on' | 'light-off' | 'motion-start' | 'motion-end' | 'heatpump-mode' | 'button-press' | 'connectivity-online' | 'connectivity-offline';
   timestamp: string;
   value?: string;
+} | {
+  type: 'contact-opened';
+  timestamp: string;
+  durationSeconds: number | null;
 };
 
 export type DeviceTimelineApiResponse = {

--- a/server/src/components/capabilities/registry.tsx
+++ b/server/src/components/capabilities/registry.tsx
@@ -682,9 +682,6 @@ export const registry: CapabilityUIRegistry = {
         iconColor: '#04A7F4',
       }),
     ],
-    getGraphs: () => [
-      { id: 'contact-sensor', title: 'Activity' },
-    ],
   },
 
   HUMIDITY_SENSOR: {

--- a/server/src/components/device-timeline.tsx
+++ b/server/src/components/device-timeline.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useMemo } from 'react';
 import { Checkbox, Group, Title } from '@mantine/core';
-import { faLightbulb, faPersonWalking, faFireBurner, faHandPointer, faSignal } from '@fortawesome/free-solid-svg-icons';
+import { faLightbulb, faPersonWalking, faFireBurner, faHandPointer, faSignal, faDoorOpen } from '@fortawesome/free-solid-svg-icons';
 import { useDeviceTimeline } from '../hooks/queries/use-device-timeline';
 import { useDateRange, DateRangeSelector } from './date-range';
 import { DateRange, DateRangePreset } from './date-range/types';
 import Timeline, { TimelineItem } from './timeline/timeline';
 import { DeviceTimelineEventApiResponse } from '../api/types';
+import { formatDuration } from '../helpers/date';
 
 type DeviceTimelineProps = {
   deviceId: number;
@@ -29,6 +30,15 @@ function mapEventToTimelineItem(event: DeviceTimelineEventApiResponse): Timeline
       return { icon: faSignal, title: 'Device came online', timestamp: event.timestamp, iconColor: '#33aa33' };
     case 'connectivity-offline':
       return { icon: faSignal, title: 'Device went offline', timestamp: event.timestamp, iconColor: '#cc3333' };
+    case 'contact-opened':
+      return {
+        icon: faDoorOpen,
+        title: event.durationSeconds === null
+          ? 'Opened'
+          : `Opened for ${formatDuration(event.durationSeconds)}`,
+        timestamp: event.timestamp,
+        iconColor: '#04A7F4',
+      };
   }
 
   return null;

--- a/server/src/routes/api/device/history.ts
+++ b/server/src/routes/api/device/history.ts
@@ -309,22 +309,6 @@ const historyFetchers = new Map<string, HistoryFetcher>([
     };
   }],
 
-  // Contact Sensor (door/window open-closed position)
-  ['contact-sensor', async (device, selector) => {
-    const sensor = device.getContactSensorCapability();
-
-    return {
-      lines: [],
-      modes: await mapBooleanHistoryToResponse((hs) => sensor.getIsOpenHistory(hs), selector)
-        .then(data => ({
-          data,
-          details: [
-            { value: true as const, label: 'Open', fillColor: 'rgba(52, 152, 219, 0.3)' }
-          ]
-        }))
-    };
-  }],
-
   // Electric Vehicle - Monthly Mileage & Efficiency
   ['vehicle-monthly-mileage', async (device, selector) => {
     const ev = device.getElectricVehicleCapability();

--- a/server/src/routes/api/device/timeline.ts
+++ b/server/src/routes/api/device/timeline.ts
@@ -105,6 +105,27 @@ export default async function (req: Request<{ id: string }>, res: Response, next
         break;
       }
 
+      case 'CONTACT_SENSOR': {
+        const sensor = device.getContactSensorCapability();
+        historyPromises.push(
+          sensor.getIsOpenHistory(historySelector).then(history => {
+            for (const event of history) {
+              if (event.value) {
+                const durationSeconds = event.end
+                  ? Math.round((event.end.getTime() - event.start.getTime()) / 1000)
+                  : null;
+                events.push({
+                  type: 'contact-opened',
+                  timestamp: event.start.toISOString(),
+                  durationSeconds
+                });
+              }
+            }
+          })
+        );
+        break;
+      }
+
       case 'HEAT_PUMP': {
         const heatPump = device.getHeatPumpCapability();
         historyPromises.push(


### PR DESCRIPTION
## Summary

- Removed the activity graph from the contact-sensor device page (registry entry + `contact-sensor` history fetcher). It was low-signal for a binary door/window sensor.
- Added contact-sensor entries to the device timeline: one entry per open period, rendered as `Opened for 5 minutes` when the door was closed again, or just `Opened` if it's still open.
- Bumped `DeviceTimelineEventApiResponse` to a discriminated union so the new `contact-opened` event can carry `durationSeconds: number | null`.

## Test plan

- [ ] `npm run codegen && npm run lint && npm test` (all pass locally)
- [ ] Open a contact-sensor device page and confirm no graph renders
- [ ] Open the door, wait, close it, and confirm the timeline shows a single `Opened for …` entry
- [ ] Open the door and leave it open — confirm the timeline shows an `Opened` entry with no duration

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9U2PV4ToiSqd7QLCRKAE1)_