### PR TITLE
Make graph legend clicks isolate the clicked series

### DIFF
--- a/server/src/components/capability-graphs/capability-graph.tsx
+++ b/server/src/components/capability-graphs/capability-graph.tsx
@@ -186,6 +186,40 @@ export function CapabilityGraph(props: CapabilityGraphProps) {
 
       colors: {
         forceOverride: true
+      },
+
+      legend: {
+        onClick: (_e: unknown, legendItem: { datasetIndex: number }, legend: { chart: any }) => {
+          const chart = legend.chart;
+          const clickedIndex = legendItem.datasetIndex;
+          const eligible: number[] = chart.data.datasets
+            .map((d: { label?: string }, i: number) => ({ d, i }))
+            .filter(({ d }: { d: { label?: string } }) => d.label !== '')
+            .map(({ i }: { i: number }) => i);
+
+          const visibleCount = eligible.filter((i: number) => chart.isDatasetVisible(i)).length;
+          const clickedVisible = chart.isDatasetVisible(clickedIndex);
+
+          if (visibleCount === eligible.length) {
+            // All visible → isolate clicked
+            for (const i of eligible) {
+              chart.setDatasetVisibility(i, i === clickedIndex);
+            }
+          } else if (!clickedVisible) {
+            // Clicked a hidden one → add it
+            chart.setDatasetVisibility(clickedIndex, true);
+          } else if (visibleCount === 1) {
+            // Clicked the last visible one → restore all
+            for (const i of eligible) {
+              chart.setDatasetVisibility(i, true);
+            }
+          } else {
+            // Clicked a visible one, others still visible → hide it
+            chart.setDatasetVisibility(clickedIndex, false);
+          }
+
+          chart.update();
+        }
       }
     },
 


### PR DESCRIPTION
## Summary

Changes the device-graph legend so clicking a series **isolates** it rather than just toggling it off:

- When everything is visible, clicking a series shows **only** that one.
- With some series hidden, clicking a hidden one **adds** it to the visible set.
- Clicking a visible series with others still visible hides it.
- Clicking the last remaining visible series **restores all** — so you can never leave the graph blank.

Implemented by overriding `chartOptions.plugins.legend.onClick` in `capability-graph.tsx`. The dummy `''`-labelled dataset used in modes-only graphs is excluded from the count/toggle logic (matching the existing legend `labels.filter`). No React state added — Chart.js already tracks per-dataset visibility internally.

## Test plan

- [x] `npm run codegen && npm run lint && npm run build`
- [ ] Open a device page with a multi-series graph (e.g. heat pump, thermostat) and confirm:
  - [ ] Click one legend item → only that series is drawn
  - [ ] Click a second → both are drawn
  - [ ] Click one of the two visible ones → it hides
  - [ ] Click the last remaining visible one → all series come back
- [ ] Verify a modes-only graph (heat pump modes) still hides the dummy legend entry and isolates modes correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pm11zoFFc7HDJ6G1wknxyV)_