### PR TITLE
Add Security Insights page

### DIFF
--- a/server/src/api/types.ts
+++ b/server/src/api/types.ts
@@ -365,6 +365,7 @@ export interface SecurityInsightsApiResponse {
   currentArming: {
     mode: AlarmMode;
     start: string | null;
+    activationCount: number;
     lastActivation: {
       start: string;
       end?: string;

--- a/server/src/api/types.ts
+++ b/server/src/api/types.ts
@@ -424,8 +424,8 @@ export interface SecurityInsightsApiResponse {
   motionByDeviceHour: Array<{
     deviceId: number;
     label: string;
-    hour: number;
-    count: number;
+    // Always 24 entries, one motion count per hour of day (0-23).
+    countByHour: number[];
   }>;
   connectivityEvents: Array<{
     id: number;

--- a/server/src/api/types.ts
+++ b/server/src/api/types.ts
@@ -420,8 +420,8 @@ export interface SecurityInsightsApiResponse {
     isConnected: boolean;
     snapshotUrl: string;
   }>;
-  motionByRoomHour: Array<{
-    roomId: number | null;
+  motionByDeviceHour: Array<{
+    deviceId: number;
     label: string;
     hour: number;
     count: number;

--- a/server/src/api/types.ts
+++ b/server/src/api/types.ts
@@ -360,6 +360,81 @@ export type EnergyInsightsSeriesApiResponse = {
   series: (HistoryLineApiResponse & { deviceId: number; deviceName: string })[];
 };
 
+// /api/insights/security endpoint
+export interface SecurityInsightsApiResponse {
+  currentArming: {
+    mode: AlarmMode;
+    start: string | null;
+    lastActivation: {
+      start: string;
+      end?: string;
+      triggeringDevice?: { id: number; name: string };
+    } | null;
+  };
+  armings: Array<{
+    id: number;
+    mode: 'NIGHT' | 'AWAY';
+    start: string;
+    end: string | null;
+    activations: Array<{
+      id: number;
+      startedAt: string;
+      suppressFurtherAlertsUntil: string;
+      triggeringDevice: { id: number; name: string } | null;
+    }>;
+  }>;
+  motionEvents: Array<{
+    id: number;
+    deviceId: number;
+    deviceName: string;
+    roomId: number | null;
+    start: string;
+    end: string | null;
+    recordingId: number | null;
+  }>;
+  lockEvents: Array<{
+    id: number;
+    deviceId: number;
+    deviceName: string;
+    timestamp: string;
+    isLocked: boolean;
+  }>;
+  contactEvents: Array<{
+    id: number;
+    deviceId: number;
+    deviceName: string;
+    timestamp: string;
+    isOpen: boolean;
+  }>;
+  doorbellRings: Array<{
+    id: number;
+    deviceId: number;
+    deviceName: string;
+    timestamp: string;
+    hasThumbnail: boolean;
+  }>;
+  cameras: Array<{
+    id: number;
+    name: string;
+    roomId: number | null;
+    isConnected: boolean;
+    snapshotUrl: string;
+  }>;
+  motionByRoomHour: Array<{
+    roomId: number | null;
+    label: string;
+    hour: number;
+    count: number;
+  }>;
+  connectivityEvents: Array<{
+    id: number;
+    deviceId: number;
+    deviceName: string;
+    timestamp: string;
+    isConnected: boolean;
+  }>;
+}
+
 export interface DeviceUpdateEvent {
   type: 'device_update';
   device: RestDeviceResponse;

--- a/server/src/automations/security.ts
+++ b/server/src/automations/security.ts
@@ -136,7 +136,8 @@ export default async function ({
         await AlarmActivation.create({
           armingId: arming.id,
           startedAt: event.start,
-          suppressFurtherAlertsUntil: getSilencingWindowEndsAt(silencingWindow, event.start)
+          suppressFurtherAlertsUntil: getSilencingWindowEndsAt(silencingWindow, event.start),
+          triggeringDeviceId: device.id
         });
 
         bus.emit(NOTIFICATION_TO_ALL, {
@@ -149,7 +150,8 @@ export default async function ({
       const activation = await AlarmActivation.create({
         armingId: arming.id,
         startedAt: event.start,
-        suppressFurtherAlertsUntil: dayjs(event.start).add(alarmDurationMinutes, 'minutes').toDate()
+        suppressFurtherAlertsUntil: dayjs(event.start).add(alarmDurationMinutes, 'minutes').toDate(),
+        triggeringDeviceId: device.id
       });
 
       notifyAbsentUsersOfEvent(event);

--- a/server/src/capabilities.json
+++ b/server/src/capabilities.json
@@ -408,6 +408,17 @@
     }
   ]
 }, {
+  "name": "Doorbell",
+  "properties": [
+    {
+      "name": "Ring",
+      "isWriteable": false,
+      "type": "boolean",
+      "eventName": "ring",
+      "isMomentary": true
+    }
+  ]
+}, {
   "name": "AlarmSensor",
   "properties": [
     {

--- a/server/src/client.js
+++ b/server/src/client.js
@@ -20,6 +20,7 @@ import Login from './components/pages/login';
 import HeatingInsights from './components/pages/insights-heating';
 import EnergyInsights from './components/pages/insights-energy';
 import InsightsBins from './components/pages/insights-bins';
+import SecurityInsights from './components/pages/insights-security';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -61,6 +62,7 @@ const router = createBrowserRouter([
       { path: '/device/:id', element: <Device /> },
       { path: '/device', element: <Devices /> },
       { path: '/insights/bins', element: <InsightsBins /> },
+      { path: '/insights/security', element: <SecurityInsights /> },
     ],
   },
 ]);

--- a/server/src/codegen/templates/capabilities.ts.hbs
+++ b/server/src/codegen/templates/capabilities.ts.hbs
@@ -43,23 +43,28 @@ export class {{className}} {
     return getBooleanPropertyHistory(this.device, '{{fieldName}}', selection);
   }
 
-  async set{{propertyName}}State(value: boolean, stateTimestamp?: Date, reportedAt?: Date): Promise<void> {
+  async set{{propertyName}}State(value: boolean, stateTimestamp?: Date, reportedAt?: Date): Promise<BooleanEvent | null> {
     const event = await setBooleanProperty(this.device, '{{fieldName}}', value, {{#if isMomentary}}true{{else}}false{{/if}}, stateTimestamp, reportedAt);
 
-    if (event !== null) {
-      {{#if isMomentary}}
-      DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}(new BooleanEvent(event));
-      {{else}}
-      const eventWrapper = new BooleanEvent(event);
-      if (value) {
-        DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}Start(eventWrapper);
-      } else {
-        DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}End(eventWrapper);
-      }
-
-      DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}Changed(eventWrapper);
-      {{/if}}
+    if (event === null) {
+      return null;
     }
+
+    {{#if isMomentary}}
+    const eventWrapper = new BooleanEvent(event);
+    DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}(eventWrapper);
+    {{else}}
+    const eventWrapper = new BooleanEvent(event);
+    if (value) {
+      DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}Start(eventWrapper);
+    } else {
+      DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}End(eventWrapper);
+    }
+
+    DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}Changed(eventWrapper);
+    {{/if}}
+
+    return eventWrapper;
   }
   {{#if isWriteable}}
   set{{propertyName}}(value: boolean): Promise<void> {
@@ -80,12 +85,17 @@ export class {{className}} {
     return getStringPropertyHistory(this.device, '{{fieldName}}', selection);
   }
 
-  async set{{propertyName}}State(value: {{{valueType}}}, stateTimestamp?: Date, reportedAt?: Date): Promise<void> {
+  async set{{propertyName}}State(value: {{{valueType}}}, stateTimestamp?: Date, reportedAt?: Date): Promise<StringEvent | null> {
     const event = await setStringProperty(this.device, '{{fieldName}}', value, false, stateTimestamp, reportedAt);
 
-    if (event !== null) {
-      DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}Changed(new StringEvent(event));
+    if (event === null) {
+      return null;
     }
+
+    const eventWrapper = new StringEvent(event);
+    DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}Changed(eventWrapper);
+
+    return eventWrapper;
   }
 
   {{#if isWriteable}}
@@ -106,12 +116,17 @@ export class {{className}} {
     return getNumericPropertyHistory(this.device, '{{fieldName}}', selection);
   }
 
-  async set{{propertyName}}State(value: number, stateTimestamp?: Date, reportedAt?: Date): Promise<void> {
+  async set{{propertyName}}State(value: number, stateTimestamp?: Date, reportedAt?: Date): Promise<NumericEvent | null> {
     const event = await setNumericProperty(this.device, '{{fieldName}}', value, false, stateTimestamp, reportedAt);
 
-    if (event !== null) {
-      DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}Changed(new NumericEvent(event));
+    if (event === null) {
+      return null;
     }
+
+    const eventWrapper = new NumericEvent(event);
+    DeviceCapabilityEvents.emit{{../capabilityName}}{{propertyName}}Changed(eventWrapper);
+
+    return eventWrapper;
   }
 
   {{#if isWriteable}}

--- a/server/src/components/app-layout.tsx
+++ b/server/src/components/app-layout.tsx
@@ -10,7 +10,7 @@ import ErrorBoundary from './error-boundary';
 
 export default function AppLayout() {
   const location = useLocation();
-  const isHome = location.pathname === '/';
+  const isFullBleed = location.pathname === '/' || location.pathname === '/insights/security';
   const [sidebarOpened, { toggle: toggleSidebar, close: closeSidebar }] = useDisclosure(false);
   const isDesktop = useMediaQuery('(min-width: 62em)');
 
@@ -22,7 +22,7 @@ export default function AppLayout() {
         breakpoint: 'md',
         collapsed: { mobile: !sidebarOpened }
       }}
-      padding={isHome ? 0 : 'md'}
+      padding={isFullBleed ? 0 : 'md'}
       withBorder={false}
     >
       <AppShell.Header>

--- a/server/src/components/date-range/date-range-context.tsx
+++ b/server/src/components/date-range/date-range-context.tsx
@@ -28,11 +28,15 @@ export function getPresetRange(preset: DateRangePreset): DateRange {
 interface DateRangeProviderProps {
   children: ReactNode;
   defaultPreset?: DateRangePreset;
+  // Overrides the initial range computed from defaultPreset - lets a caller that already
+  // computed a range elsewhere (e.g. to also drive a request outside this provider) share the
+  // exact same since/until, rather than a second, independently-timestamped equivalent.
+  defaultRange?: DateRange;
 }
 
-export function DateRangeProvider({ children, defaultPreset = 'last6hours' }: DateRangeProviderProps) {
+export function DateRangeProvider({ children, defaultPreset = 'last6hours', defaultRange }: DateRangeProviderProps) {
   const [activePreset, setActivePreset] = useState<DateRangePreset>(defaultPreset);
-  const [globalRange, setGlobalRange] = useState<DateRange>(() => getPresetRange(defaultPreset));
+  const [globalRange, setGlobalRange] = useState<DateRange>(() => defaultRange ?? getPresetRange(defaultPreset));
 
   const handleSetActivePreset = (preset: DateRangePreset) => {
     setActivePreset(preset);

--- a/server/src/components/date-range/date-range-context.tsx
+++ b/server/src/components/date-range/date-range-context.tsx
@@ -27,11 +27,12 @@ export function getPresetRange(preset: DateRangePreset): DateRange {
 
 interface DateRangeProviderProps {
   children: ReactNode;
+  defaultPreset?: DateRangePreset;
 }
 
-export function DateRangeProvider({ children }: DateRangeProviderProps) {
-  const [activePreset, setActivePreset] = useState<DateRangePreset>('last6hours');
-  const [globalRange, setGlobalRange] = useState<DateRange>(() => getPresetRange('last6hours'));
+export function DateRangeProvider({ children, defaultPreset = 'last6hours' }: DateRangeProviderProps) {
+  const [activePreset, setActivePreset] = useState<DateRangePreset>(defaultPreset);
+  const [globalRange, setGlobalRange] = useState<DateRange>(() => getPresetRange(defaultPreset));
 
   const handleSetActivePreset = (preset: DateRangePreset) => {
     setActivePreset(preset);

--- a/server/src/components/nav-links.tsx
+++ b/server/src/components/nav-links.tsx
@@ -14,6 +14,7 @@ const insightsLinks = [
   { label: 'Heating', to: '/insights/heating' },
   { label: 'Energy', to: '/insights/energy' },
   { label: 'Bins', to: '/insights/bins' },
+  { label: 'Security', to: '/insights/security' },
 ];
 
 interface NavLinksProps {

--- a/server/src/components/pages/home.tsx
+++ b/server/src/components/pages/home.tsx
@@ -5,27 +5,16 @@ import Groups from '../groups';
 import HouseStatus from '../house-status';
 import PageLoader from '../page-loader';
 import { useDevices } from '../../hooks/queries/use-devices';
-import { forDeviceCapability } from '../../helpers/device';
-
-interface Camera {
-  id: number;
-  name: string;
-  snapshotUrl: string;
-}
+import { useCameraDevices } from '../../hooks/queries/use-camera-devices';
 
 export default function Home() {
   const { data, isLoading } = useDevices();
+  const { cameras } = useCameraDevices();
   const isDesktop = useMediaQuery('(min-width: 62em)');
 
   if (isLoading || !data) {
     return <PageLoader />;
   }
-
-  const cameras: Camera[] = forDeviceCapability(data.devices, 'CAMERA', (device, capability) => ({
-    id: device.id,
-    name: device.name,
-    snapshotUrl: capability.snapshotUrl.value,
-  }));
 
   return (
     <>

--- a/server/src/components/pages/insights-security.module.css
+++ b/server/src/components/pages/insights-security.module.css
@@ -53,6 +53,12 @@
   height: 100%;
 }
 
+/* Matches the 40px KpiIcon badge height, so text sitting next to the icon centers against it
+   rather than sitting flush with its top edge - used in both the KPI tiles and the status card. */
+.iconAlignedText {
+  min-height: 40px;
+}
+
 .alertBellIcon {
   display: inline-block;
 }

--- a/server/src/components/pages/insights-security.module.css
+++ b/server/src/components/pages/insights-security.module.css
@@ -52,3 +52,18 @@
 .kpiTile {
   height: 100%;
 }
+
+.alertBellIcon {
+  display: inline-block;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .alertBellIcon {
+    animation: bellPulse 1.2s ease-in-out infinite;
+  }
+}
+
+@keyframes bellPulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.3); opacity: 0.55; }
+}

--- a/server/src/components/pages/insights-security.module.css
+++ b/server/src/components/pages/insights-security.module.css
@@ -1,0 +1,36 @@
+.heatmapScroll {
+  overflow-x: auto;
+}
+
+.heatmapTable {
+  border-collapse: collapse;
+  width: 100%;
+  min-width: 760px;
+}
+
+.heatmapHour {
+  font-size: 0.7em;
+  font-weight: normal;
+  color: var(--mantine-color-dimmed);
+  text-align: center;
+  padding: 2px 4px;
+}
+
+.heatmapRowLabel {
+  text-align: left;
+  font-weight: 500;
+  white-space: nowrap;
+  padding-right: var(--mantine-spacing-sm);
+}
+
+.heatmapCell {
+  width: 26px;
+  height: 22px;
+  text-align: center;
+  font-size: 0.65em;
+  border: 1px solid var(--mantine-color-default-border);
+}
+
+.kpiTile {
+  height: 100%;
+}

--- a/server/src/components/pages/insights-security.module.css
+++ b/server/src/components/pages/insights-security.module.css
@@ -16,11 +16,24 @@
   padding: 2px 4px;
 }
 
+.heatmapCornerCell {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background-color: var(--mantine-color-body);
+  border-right: 1px solid var(--mantine-color-default-border);
+}
+
 .heatmapRowLabel {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background-color: var(--mantine-color-body);
   text-align: left;
   font-weight: 500;
   white-space: nowrap;
-  padding-right: var(--mantine-spacing-sm);
+  padding: 2px 8px 2px 4px;
+  border-right: 1px solid var(--mantine-color-default-border);
 }
 
 .heatmapCell {
@@ -29,6 +42,11 @@
   text-align: center;
   font-size: 0.65em;
   border: 1px solid var(--mantine-color-default-border);
+}
+
+.heatmapRow:nth-child(even) .heatmapRowLabel,
+.heatmapRow:nth-child(even) .heatmapCell {
+  background-color: var(--mantine-color-default-hover);
 }
 
 .kpiTile {

--- a/server/src/components/pages/insights-security.tsx
+++ b/server/src/components/pages/insights-security.tsx
@@ -1,0 +1,549 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Alert,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  Group,
+  Menu,
+  SegmentedControl,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import {
+  faBell,
+  faDoorClosed,
+  faDoorOpen,
+  faPersonWalking,
+  faShieldHalved,
+  faSignal,
+} from '@fortawesome/free-solid-svg-icons';
+import { useDevices } from '../../hooks/queries/use-devices';
+import { useSecurity } from '../../hooks/queries/use-security';
+import { useAlarmMutation } from '../../hooks/mutations/use-security-mutations';
+import { useSecurityInsights } from '../../hooks/queries/use-security-insights';
+import { DateRangeProvider, DateRangeSelector, useDateRange } from '../date-range';
+import { forDeviceCapability } from '../../helpers/device';
+import { humanDate } from '../../helpers/date';
+import dayjs from '../../dayjs';
+import PageLoader from '../page-loader';
+import Security from '../security';
+import Timeline from '../timeline/timeline';
+import type { TimelineItem } from '../timeline/timeline';
+import type { AlarmMode, SecurityInsightsApiResponse } from '../../api/types';
+import styles from './insights-security.module.css';
+
+const MODE_LABELS: Record<AlarmMode, string> = { OFF: 'Home', NIGHT: 'Night', AWAY: 'Away' };
+const MODE_COLORS: Record<AlarmMode, string> = { OFF: 'green', NIGHT: 'grape', AWAY: 'red' };
+
+// ============================================================================
+// Live camera snapshots
+// ============================================================================
+
+function CameraRow() {
+  const { data, isLoading } = useDevices();
+
+  if (isLoading || !data) {
+    return null;
+  }
+
+  const cameras = forDeviceCapability(data.devices, 'CAMERA', (device, capability) => ({
+    id: device.id,
+    name: device.name,
+    snapshotUrl: capability.snapshotUrl.value,
+  }));
+
+  if (cameras.length === 0) {
+    return null;
+  }
+
+  return <Security cameras={cameras} />;
+}
+
+// ============================================================================
+// Alarm status card
+// ============================================================================
+
+function StatusCard({ currentArming }: { currentArming: SecurityInsightsApiResponse['currentArming'] }) {
+  const { data: security } = useSecurity();
+  const { mutate: updateAlarmMode, isPending: alarmMutating } = useAlarmMutation();
+
+  const mode = security?.alarmMode ?? currentArming.mode;
+
+  return (
+    <Card withBorder mt="lg" padding="lg">
+      <Group justify="space-between" wrap="wrap" gap="md">
+        <Group gap="md">
+          <FontAwesomeIcon icon={faShieldHalved} size="2x" />
+          <div>
+            <Badge color={MODE_COLORS[mode]} size="lg">{MODE_LABELS[mode]}</Badge>
+            {currentArming.start && (
+              <Text size="sm" c="dimmed" mt={4}>
+                Armed since {dayjs(currentArming.start).format('HH:mm')} {humanDate(dayjs(currentArming.start))}
+              </Text>
+            )}
+          </div>
+        </Group>
+
+        <SegmentedControl
+          value={mode}
+          onChange={(value) => updateAlarmMode({ alarmMode: value as AlarmMode })}
+          disabled={alarmMutating}
+          data={[
+            { label: 'Home', value: 'OFF' },
+            { label: 'Away', value: 'AWAY' },
+            { label: 'Night', value: 'NIGHT' },
+          ]}
+        />
+      </Group>
+
+      {currentArming.lastActivation && (
+        <Alert mt="md" color="red" icon={<FontAwesomeIcon icon={faBell} />}>
+          Alarm was triggered at {dayjs(currentArming.lastActivation.start).format('HH:mm')} {humanDate(dayjs(currentArming.lastActivation.start))}
+          {currentArming.lastActivation.triggeringDevice ? ` by ${currentArming.lastActivation.triggeringDevice.name}` : ''}.
+          {currentArming.lastActivation.end ? ` Further alerts suppressed until ${dayjs(currentArming.lastActivation.end).format('HH:mm')}.` : ''}
+        </Alert>
+      )}
+    </Card>
+  );
+}
+
+// ============================================================================
+// KPI strip
+// ============================================================================
+
+function KpiTile({ icon, label, value, color }: { icon: IconDefinition; label: string; value: string; color?: string }) {
+  return (
+    <Card withBorder padding="md" className={styles.kpiTile}>
+      <Group gap="sm" wrap="nowrap">
+        <FontAwesomeIcon icon={icon} size="lg" color={color} />
+        <Stack gap={0}>
+          <Text size="xs" c="dimmed">{label}</Text>
+          <Text fw={600}>{value}</Text>
+        </Stack>
+      </Group>
+    </Card>
+  );
+}
+
+function KpiStrip({ data }: { data: SecurityInsightsApiResponse }) {
+  const { data: devicesData } = useDevices();
+
+  const motionCount = data.motionEvents.length;
+  const activationCount = data.armings.reduce((sum, arming) => sum + arming.activations.length, 0);
+
+  const locks = devicesData
+    ? forDeviceCapability(devicesData.devices, 'LOCK', (device, cap) => ({ name: device.name, isLocked: cap.isLocked.value }))
+    : [];
+  const unlockedDoors = locks.filter((lock) => lock.isLocked !== true).map((lock) => lock.name);
+  const allLocked = locks.length > 0 && unlockedDoors.length === 0;
+
+  const contacts = devicesData
+    ? forDeviceCapability(devicesData.devices, 'CONTACT_SENSOR', (device, cap) => ({ name: device.name, isOpen: cap.isOpen.value }))
+    : [];
+  const openContacts = contacts.filter((contact) => contact.isOpen !== false).map((contact) => contact.name);
+  const allClosed = contacts.length > 0 && openContacts.length === 0;
+
+  return (
+    <SimpleGrid cols={{ base: 1, xs: 2, md: 4 }} mt="lg">
+      <KpiTile icon={faPersonWalking} label="Motion events" value={String(motionCount)} color="#04A7F4" />
+      <KpiTile
+        icon={faBell}
+        label="Alarm activations"
+        value={String(activationCount)}
+        color={activationCount > 0 ? '#e74c3c' : undefined}
+      />
+      <KpiTile
+        icon={allLocked ? faDoorClosed : faDoorOpen}
+        label="Doors"
+        value={locks.length === 0 ? '-' : allLocked ? 'All locked' : unlockedDoors.join(' · ')}
+        color={locks.length === 0 ? undefined : allLocked ? '#2ecc71' : '#e74c3c'}
+      />
+      <KpiTile
+        icon={allClosed ? faDoorClosed : faDoorOpen}
+        label="Windows & doors"
+        value={contacts.length === 0 ? '-' : allClosed ? 'All closed' : openContacts.join(' · ')}
+        color={contacts.length === 0 ? undefined : allClosed ? '#2ecc71' : '#f39c12'}
+      />
+    </SimpleGrid>
+  );
+}
+
+// ============================================================================
+// Motion-by-room heatmap
+// ============================================================================
+
+function MotionHeatmapCard({ data, rangeLabel }: { data: SecurityInsightsApiResponse['motionByRoomHour']; rangeLabel: string }) {
+  const rows = useMemo(() => {
+    const byLabel = new Map<string, number[]>();
+
+    for (const { label, hour, count } of data) {
+      if (!byLabel.has(label)) {
+        byLabel.set(label, new Array(24).fill(0));
+      }
+
+      byLabel.get(label)![hour] += count;
+    }
+
+    return [...byLabel.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  }, [data]);
+
+  const maxCount = Math.max(1, ...rows.flatMap(([, hours]) => hours));
+
+  return (
+    <Card withBorder mt="lg" padding="lg">
+      <Title order={4} mb="md">Motion by room · {rangeLabel}</Title>
+
+      {rows.length === 0 ? (
+        <Text c="dimmed">No motion recorded in this range.</Text>
+      ) : (
+        <div className={styles.heatmapScroll}>
+          <table className={styles.heatmapTable}>
+            <thead>
+              <tr>
+                <th></th>
+                {Array.from({ length: 24 }, (_, hour) => (
+                  <th key={hour} className={styles.heatmapHour}>{hour}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(([label, hours]) => (
+                <tr key={label}>
+                  <th className={styles.heatmapRowLabel}>{label}</th>
+                  {hours.map((count, hour) => (
+                    <td
+                      key={hour}
+                      className={styles.heatmapCell}
+                      style={{ backgroundColor: count === 0 ? undefined : `rgba(4, 167, 244, ${0.15 + 0.85 * (count / maxCount)})` }}
+                      title={`${count} motion event${count === 1 ? '' : 's'}`}
+                    >
+                      {count > 0 ? count : ''}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+// ============================================================================
+// Timeline card
+// ============================================================================
+
+type TimelineEventKind = 'arming' | 'activation' | 'motion' | 'lock' | 'contact' | 'doorbell' | 'connectivity';
+
+const KIND_LABELS: Record<TimelineEventKind, string> = {
+  arming: 'Alarm arming',
+  activation: 'Alarm triggered',
+  motion: 'Motion',
+  lock: 'Locks',
+  contact: 'Doors & windows',
+  doorbell: 'Doorbell',
+  connectivity: 'Connectivity',
+};
+
+const ALL_KINDS = Object.keys(KIND_LABELS) as TimelineEventKind[];
+
+interface MergedEvent {
+  kind: TimelineEventKind;
+  deviceId: number | null;
+  deviceName: string | null;
+  item: TimelineItem;
+}
+
+function buildTimelineEvents(data: SecurityInsightsApiResponse): MergedEvent[] {
+  const events: MergedEvent[] = [];
+
+  for (const arming of data.armings) {
+    events.push({
+      kind: 'arming',
+      deviceId: null,
+      deviceName: null,
+      item: {
+        timestamp: arming.start,
+        icon: faShieldHalved,
+        title: `Alarm set to ${arming.mode === 'AWAY' ? 'Away' : 'Night'}`,
+      },
+    });
+
+    if (arming.end) {
+      events.push({
+        kind: 'arming',
+        deviceId: null,
+        deviceName: null,
+        item: {
+          timestamp: arming.end,
+          icon: faShieldHalved,
+          title: 'Alarm turned off',
+        },
+      });
+    }
+
+    for (const activation of arming.activations) {
+      events.push({
+        kind: 'activation',
+        deviceId: activation.triggeringDevice?.id ?? null,
+        deviceName: activation.triggeringDevice?.name ?? null,
+        item: {
+          timestamp: activation.startedAt,
+          icon: faBell,
+          iconColor: '#e74c3c',
+          title: activation.triggeringDevice
+            ? `Alarm triggered by ${activation.triggeringDevice.name}`
+            : 'Alarm triggered',
+        },
+      });
+    }
+  }
+
+  for (const event of data.motionEvents) {
+    events.push({
+      kind: 'motion',
+      deviceId: event.deviceId,
+      deviceName: event.deviceName,
+      item: {
+        timestamp: event.start,
+        icon: faPersonWalking,
+        title: `Motion detected by ${event.deviceName}`,
+        renderControls: event.recordingId !== null ? ({ togglePanel }) => [
+          <a key="view" href="#" onClick={(e) => { e.preventDefault(); togglePanel('view'); }} className="card-link">view</a>,
+          <a key="download" href={`/api/recording/${event.recordingId}?download=true`} className="card-link">download</a>,
+        ] : undefined,
+        panels: event.recordingId !== null ? {
+          view: <video width="100%" controls src={`/api/recording/${event.recordingId}`} />,
+        } : undefined,
+      },
+    });
+  }
+
+  for (const event of data.lockEvents) {
+    events.push({
+      kind: 'lock',
+      deviceId: event.deviceId,
+      deviceName: event.deviceName,
+      item: {
+        timestamp: event.timestamp,
+        icon: event.isLocked ? faDoorClosed : faDoorOpen,
+        title: `${event.deviceName} was ${event.isLocked ? 'locked' : 'unlocked'}`,
+      },
+    });
+  }
+
+  for (const event of data.contactEvents) {
+    events.push({
+      kind: 'contact',
+      deviceId: event.deviceId,
+      deviceName: event.deviceName,
+      item: {
+        timestamp: event.timestamp,
+        icon: event.isOpen ? faDoorOpen : faDoorClosed,
+        title: `${event.deviceName} was ${event.isOpen ? 'opened' : 'closed'}`,
+      },
+    });
+  }
+
+  for (const event of data.doorbellRings) {
+    events.push({
+      kind: 'doorbell',
+      deviceId: event.deviceId,
+      deviceName: event.deviceName,
+      item: {
+        timestamp: event.timestamp,
+        icon: faBell,
+        title: `Someone rang the doorbell (${event.deviceName})`,
+        renderControls: event.hasThumbnail ? ({ togglePanel }) => [
+          <a key="view" href="#" onClick={(e) => { e.preventDefault(); togglePanel('view'); }} className="card-link">view</a>,
+        ] : undefined,
+        panels: event.hasThumbnail ? {
+          view: <img width="100%" src={`/api/event/${event.id}/thumbnail`} />,
+        } : undefined,
+      },
+    });
+  }
+
+  for (const event of data.connectivityEvents) {
+    events.push({
+      kind: 'connectivity',
+      deviceId: event.deviceId,
+      deviceName: event.deviceName,
+      item: {
+        timestamp: event.timestamp,
+        icon: faSignal,
+        iconColor: event.isConnected ? undefined : '#e74c3c',
+        title: `${event.deviceName} went ${event.isConnected ? 'online' : 'offline'}`,
+      },
+    });
+  }
+
+  return events;
+}
+
+function TimelineCard({ data }: { data: SecurityInsightsApiResponse }) {
+  const allEvents = useMemo(() => buildTimelineEvents(data), [data]);
+  const [selectedKinds, setSelectedKinds] = useState<Set<TimelineEventKind> | null>(null);
+  const [selectedDevices, setSelectedDevices] = useState<Set<number> | null>(null);
+
+  const deviceOptions = useMemo(() => {
+    const map = new Map<number, string>();
+
+    for (const event of allEvents) {
+      if (event.deviceId !== null && event.deviceName !== null) {
+        map.set(event.deviceId, event.deviceName);
+      }
+    }
+
+    return [...map.entries()].sort((a, b) => a[1].localeCompare(b[1]));
+  }, [allEvents]);
+
+  const filtered = allEvents.filter((event) =>
+    (selectedKinds === null || selectedKinds.has(event.kind))
+    && (selectedDevices === null || event.deviceId === null || selectedDevices.has(event.deviceId))
+  );
+
+  function toggleKind(kind: TimelineEventKind) {
+    setSelectedKinds((prev) => {
+      const next = new Set(prev ?? ALL_KINDS);
+
+      if (next.has(kind)) {
+        next.delete(kind);
+      } else {
+        next.add(kind);
+      }
+
+      return next;
+    });
+  }
+
+  function toggleDevice(id: number) {
+    setSelectedDevices((prev) => {
+      const next = new Set(prev ?? deviceOptions.map(([deviceId]) => deviceId));
+
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+
+      return next;
+    });
+  }
+
+  return (
+    <Card withBorder mt="lg" padding="lg">
+      <Group justify="space-between" mb="md" wrap="wrap">
+        <Title order={4}>Timeline</Title>
+
+        <Group gap="xs">
+          <Menu closeOnItemClick={false} shadow="md">
+            <Menu.Target>
+              <Button variant="default" size="xs">All types</Button>
+            </Menu.Target>
+            <Menu.Dropdown>
+              {ALL_KINDS.map((kind) => (
+                <Menu.Item key={kind} onClick={() => toggleKind(kind)}>
+                  <Checkbox
+                    readOnly
+                    size="xs"
+                    label={KIND_LABELS[kind]}
+                    checked={selectedKinds === null || selectedKinds.has(kind)}
+                  />
+                </Menu.Item>
+              ))}
+            </Menu.Dropdown>
+          </Menu>
+
+          <Menu closeOnItemClick={false} shadow="md">
+            <Menu.Target>
+              <Button variant="default" size="xs">All devices</Button>
+            </Menu.Target>
+            <Menu.Dropdown>
+              {deviceOptions.map(([id, name]) => (
+                <Menu.Item key={id} onClick={() => toggleDevice(id)}>
+                  <Checkbox
+                    readOnly
+                    size="xs"
+                    label={name}
+                    checked={selectedDevices === null || selectedDevices.has(id)}
+                  />
+                </Menu.Item>
+              ))}
+            </Menu.Dropdown>
+          </Menu>
+        </Group>
+      </Group>
+
+      {filtered.length === 0 ? (
+        <Text c="dimmed">No events in this range.</Text>
+      ) : (
+        <Timeline items={filtered.map((event) => event.item)} dayHeaderOrder={5} />
+      )}
+    </Card>
+  );
+}
+
+// ============================================================================
+// Page
+// ============================================================================
+
+function SecurityInsightsContent() {
+  const { globalRange, activePreset } = useDateRange();
+
+  const params = useMemo(() => ({
+    since: globalRange.since.toISOString(),
+    until: globalRange.until.toISOString(),
+  }), [globalRange.since, globalRange.until]);
+
+  const { data, isPending, isError } = useSecurityInsights(params);
+
+  if (isPending) {
+    return <PageLoader />;
+  }
+
+  if (isError || !data) {
+    return <Box style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>Error loading data</Box>;
+  }
+
+  const rangeLabel = activePreset === 'custom'
+    ? `${globalRange.since.format('D MMM')} – ${globalRange.until.format('D MMM')}`
+    : { last6hours: 'last 6 hours', today: 'today', yesterday: 'yesterday', lastMonth: 'last month' }[activePreset];
+
+  return (
+    <>
+      <StatusCard currentArming={data.currentArming} />
+      <KpiStrip data={data} />
+      <MotionHeatmapCard data={data.motionByRoomHour} rangeLabel={rangeLabel} />
+      <TimelineCard data={data} />
+    </>
+  );
+}
+
+export default function SecurityInsights() {
+  return (
+    <>
+      <Title order={2}>Security</Title>
+
+      <Box mt="md">
+        <CameraRow />
+      </Box>
+
+      <DateRangeProvider defaultPreset="today">
+        <Box mt="md">
+          <DateRangeSelector />
+        </Box>
+
+        <SecurityInsightsContent />
+      </DateRangeProvider>
+    </>
+  );
+}

--- a/server/src/components/pages/insights-security.tsx
+++ b/server/src/components/pages/insights-security.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import {
   Alert,
@@ -8,10 +8,10 @@ import {
   Button,
   Card,
   Checkbox,
+  Grid,
   Group,
   Menu,
   SegmentedControl,
-  SimpleGrid,
   Stack,
   Text,
   Title,
@@ -46,14 +46,33 @@ import styles from './insights-security.module.css';
 const MODE_LABELS: Record<AlarmMode, string> = { OFF: 'Home', NIGHT: 'Night', AWAY: 'Away' };
 const MODE_COLORS: Record<AlarmMode, string> = { OFF: 'green', NIGHT: 'grape', AWAY: 'red' };
 
+// Ticks the component every intervalMs, purely so time-relative UI (e.g. "is the alarm still
+// actively alerting") keeps itself up to date without requiring a full data refetch.
+function useTick(intervalMs: number) {
+  const [, forceUpdate] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => forceUpdate((n) => n + 1), intervalMs);
+    return () => clearInterval(interval);
+  }, [intervalMs]);
+}
+
 function StatusCard({ currentArming }: { currentArming: SecurityInsightsApiResponse['currentArming'] }) {
   const { data: security } = useSecurity();
   const { mutate: updateAlarmMode, isPending: alarmMutating } = useAlarmMutation();
 
+  useTick(30000);
+
   const mode = security?.alarmMode ?? currentArming.mode;
 
+  // "Alerting" = there's a recent activation whose alert window (loud siren, or the quiet
+  // grace period after a single motion trigger) hasn't elapsed yet - i.e. something just
+  // happened and is still live, as opposed to a historic activation from earlier this arming.
+  const isAlerting = currentArming.lastActivation !== null
+    && dayjs().isBefore(currentArming.lastActivation.end);
+
   return (
-    <Card withBorder mt="lg" padding="lg">
+    <Card withBorder padding="lg" h="100%">
       <Group justify="space-between" wrap="wrap" gap="md">
         <Group gap="md">
           <FontAwesomeIcon icon={faShieldHalved} size="2x" />
@@ -62,6 +81,13 @@ function StatusCard({ currentArming }: { currentArming: SecurityInsightsApiRespo
             {currentArming.start && (
               <Text size="sm" c="dimmed" mt={4}>
                 Armed since {dayjs(currentArming.start).format('HH:mm')} {humanDate(dayjs(currentArming.start))}
+              </Text>
+            )}
+            {mode !== 'OFF' && (
+              <Text size="sm" c="dimmed">
+                {currentArming.activationCount === 0
+                  ? 'No activations this arming'
+                  : `${currentArming.activationCount} activation${currentArming.activationCount === 1 ? '' : 's'} this arming, ${isAlerting ? 'ongoing since' : 'last at'} ${dayjs(currentArming.lastActivation!.start).format('HH:mm')} ${humanDate(dayjs(currentArming.lastActivation!.start))}`}
               </Text>
             )}
           </div>
@@ -79,11 +105,14 @@ function StatusCard({ currentArming }: { currentArming: SecurityInsightsApiRespo
         />
       </Group>
 
-      {currentArming.lastActivation && (
-        <Alert mt="md" color="red" icon={<FontAwesomeIcon icon={faBell} />}>
-          Alarm was triggered at {dayjs(currentArming.lastActivation.start).format('HH:mm')} {humanDate(dayjs(currentArming.lastActivation.start))}
-          {currentArming.lastActivation.triggeringDevice ? ` by ${currentArming.lastActivation.triggeringDevice.name}` : ''}.
-          {currentArming.lastActivation.end ? ` Further alerts suppressed until ${dayjs(currentArming.lastActivation.end).format('HH:mm')}.` : ''}
+      {isAlerting && (
+        <Alert
+          mt="md"
+          color={mode === 'NIGHT' ? 'grape' : 'red'}
+          icon={<FontAwesomeIcon icon={faBell} className={styles.alertBellIcon} />}
+        >
+          {currentArming.lastActivation!.triggeringDevice ? `Triggered by ${currentArming.lastActivation!.triggeringDevice.name}. ` : ''}
+          Further alerts suppressed until {dayjs(currentArming.lastActivation!.end).format('HH:mm')}.
         </Alert>
       )}
     </Card>
@@ -92,7 +121,7 @@ function StatusCard({ currentArming }: { currentArming: SecurityInsightsApiRespo
 
 function KpiTile({ icon, label, value, color }: { icon: IconDefinition; label: string; value: string; color?: string }) {
   return (
-    <Card withBorder padding="md" className={styles.kpiTile}>
+    <Card withBorder padding="md" h="100%" className={styles.kpiTile}>
       <Group gap="sm" wrap="nowrap">
         <FontAwesomeIcon icon={icon} size="lg" color={color} />
         <Stack gap={0}>
@@ -104,17 +133,27 @@ function KpiTile({ icon, label, value, color }: { icon: IconDefinition; label: s
   );
 }
 
-function KpiStrip({ data }: { data: SecurityInsightsApiResponse }) {
+function DoorsTile() {
   const { data: devicesData } = useDevices();
-
-  const motionCount = data.motionEvents.length;
-  const activationCount = data.armings.reduce((sum, arming) => sum + arming.activations.length, 0);
 
   const locks = devicesData
     ? forDeviceCapability(devicesData.devices, 'LOCK', (device, cap) => ({ name: device.name, isLocked: cap.isLocked.value }))
     : [];
   const unlockedDoors = locks.filter((lock) => lock.isLocked !== true).map((lock) => lock.name);
   const allLocked = locks.length > 0 && unlockedDoors.length === 0;
+
+  return (
+    <KpiTile
+      icon={allLocked ? faDoorClosed : faDoorOpen}
+      label="Doors"
+      value={locks.length === 0 ? '-' : allLocked ? 'All locked' : unlockedDoors.join(' · ')}
+      color={locks.length === 0 ? undefined : allLocked ? '#2ecc71' : '#e74c3c'}
+    />
+  );
+}
+
+function WindowsAndDoorsTile() {
+  const { data: devicesData } = useDevices();
 
   const contacts = devicesData
     ? forDeviceCapability(devicesData.devices, 'CONTACT_SENSOR', (device, cap) => ({ name: device.name, isOpen: cap.isOpen.value }))
@@ -123,27 +162,12 @@ function KpiStrip({ data }: { data: SecurityInsightsApiResponse }) {
   const allClosed = contacts.length > 0 && openContacts.length === 0;
 
   return (
-    <SimpleGrid cols={{ base: 1, xs: 2, md: 4 }} mt="lg">
-      <KpiTile icon={faPersonWalking} label="Motion events" value={String(motionCount)} color="#04A7F4" />
-      <KpiTile
-        icon={faBell}
-        label="Alarm activations"
-        value={String(activationCount)}
-        color={activationCount > 0 ? '#e74c3c' : undefined}
-      />
-      <KpiTile
-        icon={allLocked ? faDoorClosed : faDoorOpen}
-        label="Doors"
-        value={locks.length === 0 ? '-' : allLocked ? 'All locked' : unlockedDoors.join(' · ')}
-        color={locks.length === 0 ? undefined : allLocked ? '#2ecc71' : '#e74c3c'}
-      />
-      <KpiTile
-        icon={allClosed ? faDoorClosed : faDoorOpen}
-        label="Windows & doors"
-        value={contacts.length === 0 ? '-' : allClosed ? 'All closed' : openContacts.join(' · ')}
-        color={contacts.length === 0 ? undefined : allClosed ? '#2ecc71' : '#f39c12'}
-      />
-    </SimpleGrid>
+    <KpiTile
+      icon={allClosed ? faDoorClosed : faDoorOpen}
+      label="Windows & doors"
+      value={contacts.length === 0 ? '-' : allClosed ? 'All closed' : openContacts.join(' · ')}
+      color={contacts.length === 0 ? undefined : allClosed ? '#2ecc71' : '#f39c12'}
+    />
   );
 }
 
@@ -480,10 +504,17 @@ function StatusAndKpiSection({ range }: { range: DateRange }) {
   }
 
   return (
-    <>
-      <StatusCard currentArming={data.currentArming} />
-      <KpiStrip data={data} />
-    </>
+    <Grid mt="lg">
+      <Grid.Col span={{ base: 12, md: 6 }}>
+        <StatusCard currentArming={data.currentArming} />
+      </Grid.Col>
+      <Grid.Col span={{ base: 12, xs: 6, md: 3 }}>
+        <DoorsTile />
+      </Grid.Col>
+      <Grid.Col span={{ base: 12, xs: 6, md: 3 }}>
+        <WindowsAndDoorsTile />
+      </Grid.Col>
+    </Grid>
   );
 }
 

--- a/server/src/components/pages/insights-security.tsx
+++ b/server/src/components/pages/insights-security.tsx
@@ -14,6 +14,7 @@ import {
   SegmentedControl,
   Stack,
   Text,
+  ThemeIcon,
   Title,
 } from '@mantine/core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -57,6 +58,18 @@ function useTick(intervalMs: number) {
   }, [intervalMs]);
 }
 
+// Fixed-size icon badge shared by the status card and the KPI tiles, so the "headline" icon
+// reads at the same size and weight everywhere in this row, regardless of how much text sits
+// next to it - previously the shield used FontAwesomeIcon's "2x" size while the KPI tiles used
+// "lg", which made the row look mismatched as soon as the status card grew taller.
+function KpiIcon({ icon, color }: { icon: IconDefinition; color?: string }) {
+  return (
+    <ThemeIcon size={40} radius="xl" variant="light" color={color ?? 'gray'}>
+      <FontAwesomeIcon icon={icon} />
+    </ThemeIcon>
+  );
+}
+
 function StatusCard({ currentArming }: { currentArming: SecurityInsightsApiResponse['currentArming'] }) {
   const { data: security } = useSecurity();
   const { mutate: updateAlarmMode, isPending: alarmMutating } = useAlarmMutation();
@@ -73,10 +86,10 @@ function StatusCard({ currentArming }: { currentArming: SecurityInsightsApiRespo
 
   return (
     <Card withBorder padding="lg" h="100%">
-      <Group justify="space-between" wrap="wrap" gap="md">
-        <Group gap="md">
-          <FontAwesomeIcon icon={faShieldHalved} size="2x" />
-          <div>
+      <Group justify="space-between" wrap="wrap" gap="md" align="flex-start">
+        <Group gap="md" align="flex-start">
+          <KpiIcon icon={faShieldHalved} color={MODE_COLORS[mode]} />
+          <Stack gap={0} justify="center" className={styles.iconAlignedText}>
             <Badge color={MODE_COLORS[mode]} size="lg">{MODE_LABELS[mode]}</Badge>
             {currentArming.start && (
               <Text size="sm" c="dimmed" mt={4}>
@@ -90,7 +103,7 @@ function StatusCard({ currentArming }: { currentArming: SecurityInsightsApiRespo
                   : `${currentArming.activationCount} activation${currentArming.activationCount === 1 ? '' : 's'} this arming, ${isAlerting ? 'ongoing since' : 'last at'} ${dayjs(currentArming.lastActivation!.start).format('HH:mm')} ${humanDate(dayjs(currentArming.lastActivation!.start))}`}
               </Text>
             )}
-          </div>
+          </Stack>
         </Group>
 
         <SegmentedControl
@@ -122,9 +135,9 @@ function StatusCard({ currentArming }: { currentArming: SecurityInsightsApiRespo
 function KpiTile({ icon, label, value, color }: { icon: IconDefinition; label: string; value: string; color?: string }) {
   return (
     <Card withBorder padding="md" h="100%" className={styles.kpiTile}>
-      <Group gap="sm" wrap="nowrap">
-        <FontAwesomeIcon icon={icon} size="lg" color={color} />
-        <Stack gap={0}>
+      <Group gap="sm" wrap="nowrap" align="flex-start">
+        <KpiIcon icon={icon} color={color} />
+        <Stack gap={0} justify="center" className={styles.iconAlignedText}>
           <Text size="xs" c="dimmed">{label}</Text>
           <Text fw={600}>{value}</Text>
         </Stack>
@@ -147,7 +160,7 @@ function DoorsTile() {
       icon={allLocked ? faDoorClosed : faDoorOpen}
       label="Doors"
       value={locks.length === 0 ? '-' : allLocked ? 'All locked' : unlockedDoors.join(' · ')}
-      color={locks.length === 0 ? undefined : allLocked ? '#2ecc71' : '#e74c3c'}
+      color={locks.length === 0 ? undefined : allLocked ? 'green' : 'red'}
     />
   );
 }
@@ -166,7 +179,7 @@ function WindowsAndDoorsTile() {
       icon={allClosed ? faDoorClosed : faDoorOpen}
       label="Windows & doors"
       value={contacts.length === 0 ? '-' : allClosed ? 'All closed' : openContacts.join(' · ')}
-      color={contacts.length === 0 ? undefined : allClosed ? '#2ecc71' : '#f39c12'}
+      color={contacts.length === 0 ? undefined : allClosed ? 'green' : 'orange'}
     />
   );
 }

--- a/server/src/components/pages/insights-security.tsx
+++ b/server/src/components/pages/insights-security.tsx
@@ -172,21 +172,11 @@ function WindowsAndDoorsTile() {
 }
 
 function MotionHeatmapCard({ data }: { data: SecurityInsightsApiResponse['motionByDeviceHour'] }) {
-  const rows = useMemo(() => {
-    const byDevice = new Map<number, { label: string; hours: number[] }>();
+  const rows = useMemo(() => (
+    [...data].sort((a, b) => a.label.localeCompare(b.label))
+  ), [data]);
 
-    for (const { deviceId, label, hour, count } of data) {
-      if (!byDevice.has(deviceId)) {
-        byDevice.set(deviceId, { label, hours: new Array(24).fill(0) });
-      }
-
-      byDevice.get(deviceId)!.hours[hour] += count;
-    }
-
-    return [...byDevice.entries()].sort((a, b) => a[1].label.localeCompare(b[1].label));
-  }, [data]);
-
-  const maxCount = Math.max(1, ...rows.flatMap(([, { hours }]) => hours));
+  const maxCount = Math.max(1, ...rows.flatMap((row) => row.countByHour));
 
   return (
     <Card withBorder mt="lg" padding="lg">
@@ -206,12 +196,12 @@ function MotionHeatmapCard({ data }: { data: SecurityInsightsApiResponse['motion
               </tr>
             </thead>
             <tbody>
-              {rows.map(([deviceId, { label, hours }]) => (
+              {rows.map(({ deviceId, label, countByHour }) => (
                 <tr key={deviceId} className={styles.heatmapRow}>
                   <th className={styles.heatmapRowLabel}>
                     <Anchor component={Link} to={`/device/${deviceId}`}>{label}</Anchor>
                   </th>
-                  {hours.map((count, hour) => (
+                  {countByHour.map((count, hour) => (
                     <td
                       key={hour}
                       className={styles.heatmapCell}

--- a/server/src/components/pages/insights-security.tsx
+++ b/server/src/components/pages/insights-security.tsx
@@ -28,7 +28,7 @@ import { useDevices } from '../../hooks/queries/use-devices';
 import { useSecurity } from '../../hooks/queries/use-security';
 import { useAlarmMutation } from '../../hooks/mutations/use-security-mutations';
 import { useSecurityInsights } from '../../hooks/queries/use-security-insights';
-import { DateRangeProvider, DateRangeSelector, useDateRange } from '../date-range';
+import { DateRangeProvider, DateRangeSelector, getPresetRange, useDateRange } from '../date-range';
 import { forDeviceCapability } from '../../helpers/device';
 import { humanDate } from '../../helpers/date';
 import dayjs from '../../dayjs';
@@ -207,7 +207,7 @@ function MotionHeatmapCard({ data, rangeLabel }: { data: SecurityInsightsApiResp
           <table className={styles.heatmapTable}>
             <thead>
               <tr>
-                <th></th>
+                <th className={styles.heatmapCornerCell}></th>
                 {Array.from({ length: 24 }, (_, hour) => (
                   <th key={hour} className={styles.heatmapHour}>{hour}</th>
                 ))}
@@ -215,7 +215,7 @@ function MotionHeatmapCard({ data, rangeLabel }: { data: SecurityInsightsApiResp
             </thead>
             <tbody>
               {rows.map(([label, hours]) => (
-                <tr key={label}>
+                <tr key={label} className={styles.heatmapRow}>
                   <th className={styles.heatmapRowLabel}>{label}</th>
                   {hours.map((count, hour) => (
                     <td
@@ -411,6 +411,9 @@ function TimelineCard({ data }: { data: SecurityInsightsApiResponse }) {
     && (selectedDevices === null || event.deviceId === null || selectedDevices.has(event.deviceId))
   );
 
+  const selectedKindCount = selectedKinds === null ? ALL_KINDS.length : selectedKinds.size;
+  const selectedDeviceCount = selectedDevices === null ? deviceOptions.length : selectedDevices.size;
+
   function toggleKind(kind: TimelineEventKind) {
     setSelectedKinds((prev) => {
       const next = new Set(prev ?? ALL_KINDS);
@@ -447,7 +450,7 @@ function TimelineCard({ data }: { data: SecurityInsightsApiResponse }) {
         <Group gap="xs">
           <Menu closeOnItemClick={false} shadow="md">
             <Menu.Target>
-              <Button variant="default" size="xs">All types</Button>
+              <Button variant="default" size="xs">{selectedKindCount}/{ALL_KINDS.length} types</Button>
             </Menu.Target>
             <Menu.Dropdown>
               {ALL_KINDS.map((kind) => (
@@ -465,7 +468,7 @@ function TimelineCard({ data }: { data: SecurityInsightsApiResponse }) {
 
           <Menu closeOnItemClick={false} shadow="md">
             <Menu.Target>
-              <Button variant="default" size="xs">All devices</Button>
+              <Button variant="default" size="xs">{selectedDeviceCount}/{deviceOptions.length} devices</Button>
             </Menu.Target>
             <Menu.Dropdown>
               {deviceOptions.map(([id, name]) => (
@@ -496,7 +499,37 @@ function TimelineCard({ data }: { data: SecurityInsightsApiResponse }) {
 // Page
 // ============================================================================
 
-function SecurityInsightsContent() {
+// Status card + KPI strip always reflect "today", independent of the timeline's date range
+// selector below them, so switching the range never reloads/reflows anything above it.
+function StatusAndKpiSection() {
+  const params = useMemo(() => {
+    const range = getPresetRange('today');
+
+    return {
+      since: range.since.toISOString(),
+      until: range.until.toISOString(),
+    };
+  }, []);
+
+  const { data, isPending, isError } = useSecurityInsights(params);
+
+  if (isPending) {
+    return <PageLoader />;
+  }
+
+  if (isError || !data) {
+    return <Box style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>Error loading data</Box>;
+  }
+
+  return (
+    <>
+      <StatusCard currentArming={data.currentArming} />
+      <KpiStrip data={data} />
+    </>
+  );
+}
+
+function RangeDependentSection() {
   const { globalRange, activePreset } = useDateRange();
 
   const params = useMemo(() => ({
@@ -520,8 +553,6 @@ function SecurityInsightsContent() {
 
   return (
     <>
-      <StatusCard currentArming={data.currentArming} />
-      <KpiStrip data={data} />
       <MotionHeatmapCard data={data.motionByRoomHour} rangeLabel={rangeLabel} />
       <TimelineCard data={data} />
     </>
@@ -531,19 +562,21 @@ function SecurityInsightsContent() {
 export default function SecurityInsights() {
   return (
     <>
-      <Title order={2}>Security</Title>
+      <CameraRow />
 
-      <Box mt="md">
-        <CameraRow />
+      <Box p="md">
+        <Title order={2}>Security</Title>
+
+        <StatusAndKpiSection />
+
+        <DateRangeProvider defaultPreset="today">
+          <Box mt="lg">
+            <DateRangeSelector />
+          </Box>
+
+          <RangeDependentSection />
+        </DateRangeProvider>
       </Box>
-
-      <DateRangeProvider defaultPreset="today">
-        <Box mt="md">
-          <DateRangeSelector />
-        </Box>
-
-        <SecurityInsightsContent />
-      </DateRangeProvider>
     </>
   );
 }

--- a/server/src/components/pages/insights-security.tsx
+++ b/server/src/components/pages/insights-security.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo, useState } from 'react';
+import { Link } from 'react-router';
 import {
   Alert,
+  Anchor,
   Badge,
   Box,
   Button,
@@ -25,10 +27,12 @@ import {
   faSignal,
 } from '@fortawesome/free-solid-svg-icons';
 import { useDevices } from '../../hooks/queries/use-devices';
+import { useCameraDevices } from '../../hooks/queries/use-camera-devices';
 import { useSecurity } from '../../hooks/queries/use-security';
 import { useAlarmMutation } from '../../hooks/mutations/use-security-mutations';
 import { useSecurityInsights } from '../../hooks/queries/use-security-insights';
 import { DateRangeProvider, DateRangeSelector, getPresetRange, useDateRange } from '../date-range';
+import type { DateRange } from '../date-range';
 import { forDeviceCapability } from '../../helpers/device';
 import { humanDate } from '../../helpers/date';
 import dayjs from '../../dayjs';
@@ -41,34 +45,6 @@ import styles from './insights-security.module.css';
 
 const MODE_LABELS: Record<AlarmMode, string> = { OFF: 'Home', NIGHT: 'Night', AWAY: 'Away' };
 const MODE_COLORS: Record<AlarmMode, string> = { OFF: 'green', NIGHT: 'grape', AWAY: 'red' };
-
-// ============================================================================
-// Live camera snapshots
-// ============================================================================
-
-function CameraRow() {
-  const { data, isLoading } = useDevices();
-
-  if (isLoading || !data) {
-    return null;
-  }
-
-  const cameras = forDeviceCapability(data.devices, 'CAMERA', (device, capability) => ({
-    id: device.id,
-    name: device.name,
-    snapshotUrl: capability.snapshotUrl.value,
-  }));
-
-  if (cameras.length === 0) {
-    return null;
-  }
-
-  return <Security cameras={cameras} />;
-}
-
-// ============================================================================
-// Alarm status card
-// ============================================================================
 
 function StatusCard({ currentArming }: { currentArming: SecurityInsightsApiResponse['currentArming'] }) {
   const { data: security } = useSecurity();
@@ -113,10 +89,6 @@ function StatusCard({ currentArming }: { currentArming: SecurityInsightsApiRespo
     </Card>
   );
 }
-
-// ============================================================================
-// KPI strip
-// ============================================================================
 
 function KpiTile({ icon, label, value, color }: { icon: IconDefinition; label: string; value: string; color?: string }) {
   return (
@@ -175,30 +147,26 @@ function KpiStrip({ data }: { data: SecurityInsightsApiResponse }) {
   );
 }
 
-// ============================================================================
-// Motion-by-room heatmap
-// ============================================================================
-
-function MotionHeatmapCard({ data, rangeLabel }: { data: SecurityInsightsApiResponse['motionByRoomHour']; rangeLabel: string }) {
+function MotionHeatmapCard({ data }: { data: SecurityInsightsApiResponse['motionByDeviceHour'] }) {
   const rows = useMemo(() => {
-    const byLabel = new Map<string, number[]>();
+    const byDevice = new Map<number, { label: string; hours: number[] }>();
 
-    for (const { label, hour, count } of data) {
-      if (!byLabel.has(label)) {
-        byLabel.set(label, new Array(24).fill(0));
+    for (const { deviceId, label, hour, count } of data) {
+      if (!byDevice.has(deviceId)) {
+        byDevice.set(deviceId, { label, hours: new Array(24).fill(0) });
       }
 
-      byLabel.get(label)![hour] += count;
+      byDevice.get(deviceId)!.hours[hour] += count;
     }
 
-    return [...byLabel.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+    return [...byDevice.entries()].sort((a, b) => a[1].label.localeCompare(b[1].label));
   }, [data]);
 
-  const maxCount = Math.max(1, ...rows.flatMap(([, hours]) => hours));
+  const maxCount = Math.max(1, ...rows.flatMap(([, { hours }]) => hours));
 
   return (
     <Card withBorder mt="lg" padding="lg">
-      <Title order={4} mb="md">Motion by room · {rangeLabel}</Title>
+      <Title order={4} mb="md">Motion by device</Title>
 
       {rows.length === 0 ? (
         <Text c="dimmed">No motion recorded in this range.</Text>
@@ -214,9 +182,11 @@ function MotionHeatmapCard({ data, rangeLabel }: { data: SecurityInsightsApiResp
               </tr>
             </thead>
             <tbody>
-              {rows.map(([label, hours]) => (
-                <tr key={label} className={styles.heatmapRow}>
-                  <th className={styles.heatmapRowLabel}>{label}</th>
+              {rows.map(([deviceId, { label, hours }]) => (
+                <tr key={deviceId} className={styles.heatmapRow}>
+                  <th className={styles.heatmapRowLabel}>
+                    <Anchor component={Link} to={`/device/${deviceId}`}>{label}</Anchor>
+                  </th>
                   {hours.map((count, hour) => (
                     <td
                       key={hour}
@@ -236,10 +206,6 @@ function MotionHeatmapCard({ data, rangeLabel }: { data: SecurityInsightsApiResp
     </Card>
   );
 }
-
-// ============================================================================
-// Timeline card
-// ============================================================================
 
 type TimelineEventKind = 'arming' | 'activation' | 'motion' | 'lock' | 'contact' | 'doorbell' | 'connectivity';
 
@@ -495,21 +461,13 @@ function TimelineCard({ data }: { data: SecurityInsightsApiResponse }) {
   );
 }
 
-// ============================================================================
-// Page
-// ============================================================================
-
 // Status card + KPI strip always reflect "today", independent of the timeline's date range
 // selector below them, so switching the range never reloads/reflows anything above it.
-function StatusAndKpiSection() {
-  const params = useMemo(() => {
-    const range = getPresetRange('today');
-
-    return {
-      since: range.since.toISOString(),
-      until: range.until.toISOString(),
-    };
-  }, []);
+function StatusAndKpiSection({ range }: { range: DateRange }) {
+  const params = useMemo(() => ({
+    since: range.since.toISOString(),
+    until: range.until.toISOString(),
+  }), [range]);
 
   const { data, isPending, isError } = useSecurityInsights(params);
 
@@ -530,7 +488,7 @@ function StatusAndKpiSection() {
 }
 
 function RangeDependentSection() {
-  const { globalRange, activePreset } = useDateRange();
+  const { globalRange } = useDateRange();
 
   const params = useMemo(() => ({
     since: globalRange.since.toISOString(),
@@ -547,29 +505,32 @@ function RangeDependentSection() {
     return <Box style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>Error loading data</Box>;
   }
 
-  const rangeLabel = activePreset === 'custom'
-    ? `${globalRange.since.format('D MMM')} – ${globalRange.until.format('D MMM')}`
-    : { last6hours: 'last 6 hours', today: 'today', yesterday: 'yesterday', lastMonth: 'last month' }[activePreset];
-
   return (
     <>
-      <MotionHeatmapCard data={data.motionByRoomHour} rangeLabel={rangeLabel} />
+      <MotionHeatmapCard data={data.motionByDeviceHour} />
       <TimelineCard data={data} />
     </>
   );
 }
 
 export default function SecurityInsights() {
+  // Computed once and shared as the date range selector's initial value, so the KPI section's
+  // fixed "today" request and the range section's default "today" request are identical (and
+  // therefore deduped by react-query into a single fetch) rather than two near-identical ones
+  // that only differ by the millisecond each independently called getPresetRange('today').
+  const [todayRange] = useState<DateRange>(() => getPresetRange('today'));
+  const { cameras, isLoading: camerasLoading } = useCameraDevices();
+
   return (
     <>
-      <CameraRow />
+      {!camerasLoading && cameras.length > 0 && <Security cameras={cameras} />}
 
       <Box p="md">
         <Title order={2}>Security</Title>
 
-        <StatusAndKpiSection />
+        <StatusAndKpiSection range={todayRange} />
 
-        <DateRangeProvider defaultPreset="today">
+        <DateRangeProvider defaultPreset="today" defaultRange={todayRange}>
           <Box mt="lg">
             <DateRangeSelector />
           </Box>

--- a/server/src/hooks/queries/use-camera-devices.ts
+++ b/server/src/hooks/queries/use-camera-devices.ts
@@ -1,0 +1,22 @@
+import { useDevices } from './use-devices';
+import { forDeviceCapability } from '../../helpers/device';
+
+export interface CameraDevice {
+  id: number;
+  name: string;
+  snapshotUrl: string;
+}
+
+export function useCameraDevices(): { cameras: CameraDevice[]; isLoading: boolean } {
+  const { data, isLoading } = useDevices();
+
+  const cameras = data
+    ? forDeviceCapability(data.devices, 'CAMERA', (device, capability) => ({
+      id: device.id,
+      name: device.name,
+      snapshotUrl: capability.snapshotUrl.value,
+    }))
+    : [];
+
+  return { cameras, isLoading: isLoading || !data };
+}

--- a/server/src/hooks/queries/use-security-insights.ts
+++ b/server/src/hooks/queries/use-security-insights.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import type { SecurityInsightsApiResponse } from '../../api/types';
+import { fetchApi } from '../fetch-api';
+
+export function useSecurityInsights(params: { since: string; until: string }) {
+  return useQuery({
+    queryKey: ['security-insights', params],
+    queryFn: () => fetchApi<SecurityInsightsApiResponse>('/insights/security', params),
+  });
+}

--- a/server/src/migrations/24-add-triggering-device-to-alarm-activations.js
+++ b/server/src/migrations/24-add-triggering-device-to-alarm-activations.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: async function(queryInterface, Sequelize) {
+    await queryInterface.addColumn('alarm_activations', 'triggeringDeviceId', {
+      type: Sequelize.INTEGER,
+      allowNull: true
+    });
+  },
+
+  down: async function(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('alarm_activations', 'triggeringDeviceId');
+  }
+};

--- a/server/src/models/alarm_activation.ts
+++ b/server/src/models/alarm_activation.ts
@@ -1,14 +1,17 @@
-import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional, HasOneGetAssociationMixin } from 'sequelize';
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional, HasOneGetAssociationMixin, BelongsToGetAssociationMixin } from 'sequelize';
 import dayjs from '../dayjs';
 import { Arming } from './arming';
+import { Device } from './device';
 
 export class AlarmActivation extends Model<InferAttributes<AlarmActivation>, InferCreationAttributes<AlarmActivation>> {
   declare id: CreationOptional<number>;
   declare armingId: CreationOptional<number>;
   declare startedAt: CreationOptional<Date>;
   declare suppressFurtherAlertsUntil: Date;
+  declare triggeringDeviceId: CreationOptional<number | null>;
 
   declare getArming: HasOneGetAssociationMixin<Arming>;
+  declare getTriggeringDevice: BelongsToGetAssociationMixin<Device>;
 
   isSuppressingFurtherAlerts(at: Date = new Date()): boolean {
     return dayjs(at).isBefore(this.suppressFurtherAlertsUntil);
@@ -38,6 +41,11 @@ export default function (sequelize: Sequelize) {
     suppressFurtherAlertsUntil: {
       type: DataTypes.DATE,
       allowNull: false
+    },
+
+    triggeringDeviceId: {
+      type: DataTypes.INTEGER,
+      allowNull: true
     }
   }, {
     sequelize,

--- a/server/src/models/device.ts
+++ b/server/src/models/device.ts
@@ -27,6 +27,7 @@ import {
   ElectricVehicleCapability,
   BinCollectionCapability,
   ButtonCapability,
+  DoorbellCapability,
   AlarmSensorCapability,
   ContactSensorCapability,
   ConnectivityCapability,
@@ -138,6 +139,10 @@ export class Device extends Model<InferAttributes<Device>, InferCreationAttribut
 
   getButtonCapability(): ButtonCapability {
     return this.#getCapabilityOrThrow(() => new ButtonCapability(this));
+  }
+
+  getDoorbellCapability(): DoorbellCapability {
+    return this.#getCapabilityOrThrow(() => new DoorbellCapability(this));
   }
 
   getAlarmSensorCapability(): AlarmSensorCapability {

--- a/server/src/models/event.ts
+++ b/server/src/models/event.ts
@@ -145,6 +145,7 @@ export default function (sequelize: Sequelize) {
 export class BooleanEvent {
   protected event: Event;
 
+  public id: number;
   public value: boolean;
   public start: Date;
   public end: Date | null;
@@ -153,6 +154,7 @@ export class BooleanEvent {
 
   constructor(e: Event) {
     this.event = e;
+    this.id = e.id;
     this.value = !!e.value;
     this.start = e.start;
     this.end = e.end;
@@ -167,11 +169,16 @@ export class BooleanEvent {
   getDevice() {
     return this.event.getDevice();
   }
+
+  getRecording() {
+    return this.event.getRecording();
+  }
 }
 
 export class NumericEvent {
   protected event: Event;
 
+  public id: number;
   public value: number;
   public start: Date;
   public end: Date | null;
@@ -180,6 +187,7 @@ export class NumericEvent {
 
   constructor(e: Event) {
     this.event = e;
+    this.id = e.id;
     this.value = e.value;
     this.start = e.start;
     this.end = e.end;
@@ -190,11 +198,16 @@ export class NumericEvent {
   getDevice() {
     return this.event.getDevice();
   }
+
+  getRecording() {
+    return this.event.getRecording();
+  }
 }
 
 export class StringEvent {
   protected event: Event;
 
+  public id: number;
   public value: string;
   public start: Date;
   public end: Date | null;
@@ -203,6 +216,7 @@ export class StringEvent {
 
   constructor(e: Event) {
     this.event = e;
+    this.id = e.id;
     this.value = e.stringValue ?? '';
     this.start = e.start;
     this.end = e.end;
@@ -212,5 +226,9 @@ export class StringEvent {
 
   getDevice() {
     return this.event.getDevice();
+  }
+
+  getRecording() {
+    return this.event.getRecording();
   }
 }

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -54,5 +54,9 @@ AlarmActivation.belongsTo(Arming);
 Arming.hasMany(AlarmActivation, {
   as: 'AlarmActivations'
 });
+AlarmActivation.belongsTo(Device, {
+  foreignKey: 'triggeringDeviceId',
+  as: 'triggeringDevice'
+});
 
 export { Op } from 'sequelize';

--- a/server/src/routes/api/index.ts
+++ b/server/src/routes/api/index.ts
@@ -19,6 +19,7 @@ import deviceSwitchRouter from './device/switch';
 import deviceTelevisionRouter from './device/television';
 import eventsRouter from './events';
 import insightsHeatingHandler from './insights/heating';
+import insightsSecurityHandler from './insights/security';
 import { usageHandler as insightsEnergyUsageHandler, costHandler as insightsEnergyCostHandler } from './insights/energy';
 
 const router = express.Router();
@@ -39,6 +40,7 @@ router.use('/device/:id/vehicle', deviceVehicleRouter);
 router.use('/device/:id/switch', deviceSwitchRouter);
 router.use('/device/:id/television', deviceTelevisionRouter);
 router.get('/insights/heating', insightsHeatingHandler);
+router.get('/insights/security', insightsSecurityHandler);
 router.get('/insights/energy/usage', insightsEnergyUsageHandler);
 router.get('/insights/energy/cost', insightsEnergyCostHandler);
 

--- a/server/src/routes/api/insights/security.ts
+++ b/server/src/routes/api/insights/security.ts
@@ -1,0 +1,289 @@
+import { Request, Response } from 'express';
+import { Device, Arming, Room, Op } from '../../../models';
+import { SecurityInsightsApiResponse, AlarmMode } from '../../../api/types';
+import { Capability } from '../../../models/capabilities';
+import { HistorySelector } from '../../../models/capabilities/helpers';
+import { asyncMap } from '../../../helpers/array';
+import dayjs from '../../../dayjs';
+
+const SECURITY_RELEVANT_CAPABILITIES: Capability[] = ['MOTION_SENSOR', 'CAMERA', 'CONTACT_SENSOR', 'LOCK', 'DOORBELL'];
+
+export default async function (req: Request, res: Response) {
+  const selector: HistorySelector = {
+    since: new Date(req.query.since as string),
+    until: new Date(req.query.until as string)
+  };
+
+  const [
+    motionDevices,
+    doorbellDevices,
+    lockDevices,
+    contactDevices,
+    cameraDevices,
+    connectivityDevices,
+    armingRows,
+    activeArming,
+    rooms
+  ] = await Promise.all([
+    Device.findByCapability('MOTION_SENSOR'),
+    Device.findByCapability('DOORBELL'),
+    Device.findByCapability('LOCK'),
+    Device.findByCapability('CONTACT_SENSOR'),
+    Device.findByCapability('CAMERA'),
+    Device.findByCapability('CONNECTIVITY'),
+    Arming.findAll({
+      where: {
+        start: { [Op.lt]: selector.until },
+        [Op.or]: [
+          { end: null },
+          { end: { [Op.gt]: selector.since } }
+        ]
+      },
+      order: [['start', 'DESC']]
+    }),
+    Arming.getActiveArming(),
+    Room.findAll()
+  ]);
+
+  const roomNamesById = new Map(rooms.map(room => [room.id as number, room.name]));
+
+  // Motion history, per device, hydrated with the recording (if the source device is a camera).
+  const motionEventLists = await asyncMap(motionDevices, async (device) => {
+    const history = await device.getMotionSensorCapability().getHasMotionHistory(selector);
+
+    return asyncMap(history, async (event) => {
+      const recording = await event.getRecording();
+
+      return {
+        id: event.id,
+        deviceId: device.id,
+        deviceName: device.name,
+        roomId: (device.roomId as number | null) ?? null,
+        start: event.start.toISOString(),
+        end: event.end?.toISOString() ?? null,
+        recordingId: recording?.id ?? null
+      };
+    });
+  });
+
+  const motionEvents = motionEventLists.flat();
+
+  // Boolean capability history only stores "on" segments (start/end pairs) - unpack each into
+  // a "locked"/"unlocked" (or "open"/"closed") pair of timeline points, mirroring the way
+  // routes/api/timeline.ts turns light 'on' events into light-on/light-off pairs.
+  const lockEventLists = await asyncMap(lockDevices, async (device) => {
+    const history = await device.getLockCapability().getIsLockedHistory(selector);
+    const entries: SecurityInsightsApiResponse['lockEvents'] = [];
+
+    for (const event of history) {
+      entries.push({
+        id: event.id,
+        deviceId: device.id,
+        deviceName: device.name,
+        timestamp: event.start.toISOString(),
+        isLocked: true
+      });
+
+      if (event.end) {
+        entries.push({
+          id: event.id,
+          deviceId: device.id,
+          deviceName: device.name,
+          timestamp: event.end.toISOString(),
+          isLocked: false
+        });
+      }
+    }
+
+    return entries;
+  });
+
+  const lockEvents = lockEventLists.flat();
+
+  const contactEventLists = await asyncMap(contactDevices, async (device) => {
+    const history = await device.getContactSensorCapability().getIsOpenHistory(selector);
+    const entries: SecurityInsightsApiResponse['contactEvents'] = [];
+
+    for (const event of history) {
+      entries.push({
+        id: event.id,
+        deviceId: device.id,
+        deviceName: device.name,
+        timestamp: event.start.toISOString(),
+        isOpen: true
+      });
+
+      if (event.end) {
+        entries.push({
+          id: event.id,
+          deviceId: device.id,
+          deviceName: device.name,
+          timestamp: event.end.toISOString(),
+          isOpen: false
+        });
+      }
+    }
+
+    return entries;
+  });
+
+  const contactEvents = contactEventLists.flat();
+
+  const doorbellEventLists = await asyncMap(doorbellDevices, async (device) => {
+    const history = await device.getDoorbellCapability().getRingHistory(selector);
+
+    return history.map((event) => ({
+      id: event.id,
+      deviceId: device.id,
+      deviceName: device.name,
+      timestamp: event.start.toISOString(),
+      hasThumbnail: true
+    }));
+  });
+
+  const doorbellRings = doorbellEventLists.flat();
+
+  const cameras = await asyncMap(cameraDevices, async (device) => {
+    const isConnected = await device.getConnectivityCapability().getIsConnected();
+
+    return {
+      id: device.id,
+      name: device.name,
+      roomId: (device.roomId as number | null) ?? null,
+      isConnected,
+      snapshotUrl: `/api/snapshot/${device.providerId}`
+    };
+  });
+
+  // Connectivity offline/online, but only for devices that are also security-relevant -
+  // connectivity for e.g. a light isn't interesting on this page.
+  const securityRelevantConnectivityDevices = connectivityDevices.filter((device) =>
+    device.getCapabilities().some((capability) => SECURITY_RELEVANT_CAPABILITIES.includes(capability))
+  );
+
+  const connectivityEventLists = await asyncMap(securityRelevantConnectivityDevices, async (device) => {
+    const history = await device.getConnectivityCapability().getIsConnectedHistory(selector);
+    const entries: SecurityInsightsApiResponse['connectivityEvents'] = [];
+
+    for (const event of history) {
+      entries.push({
+        id: event.id,
+        deviceId: device.id,
+        deviceName: device.name,
+        timestamp: event.start.toISOString(),
+        isConnected: true
+      });
+
+      if (event.end) {
+        entries.push({
+          id: event.id,
+          deviceId: device.id,
+          deviceName: device.name,
+          timestamp: event.end.toISOString(),
+          isConnected: false
+        });
+      }
+    }
+
+    return entries;
+  });
+
+  const connectivityEvents = connectivityEventLists.flat();
+
+  // Armings + their activations, overlapping the selected range.
+  const armings = await asyncMap(armingRows, async (arming) => {
+    const activationRows = await arming.getAlarmActivations();
+
+    const activations = await asyncMap(activationRows, async (activation) => {
+      const triggeringDevice = activation.triggeringDeviceId !== null
+        ? await activation.getTriggeringDevice()
+        : null;
+
+      return {
+        id: activation.id,
+        startedAt: activation.startedAt.toISOString(),
+        suppressFurtherAlertsUntil: activation.suppressFurtherAlertsUntil.toISOString(),
+        triggeringDevice: triggeringDevice ? { id: triggeringDevice.id, name: triggeringDevice.name } : null
+      };
+    });
+
+    return {
+      id: arming.id,
+      mode: arming.mode as 'NIGHT' | 'AWAY',
+      start: arming.start.toISOString(),
+      end: arming.end ? arming.end.toISOString() : null,
+      activations
+    };
+  });
+
+  // Current arming status, independent of the selected date range.
+  let currentArming: SecurityInsightsApiResponse['currentArming'];
+
+  if (!activeArming) {
+    currentArming = { mode: 'OFF', start: null, lastActivation: null };
+  } else {
+    const mostRecentActivation = await activeArming.getMostRecentActivation();
+    let lastActivation: SecurityInsightsApiResponse['currentArming']['lastActivation'] = null;
+
+    if (mostRecentActivation) {
+      const triggeringDevice = mostRecentActivation.triggeringDeviceId !== null
+        ? await mostRecentActivation.getTriggeringDevice()
+        : null;
+
+      lastActivation = {
+        start: mostRecentActivation.startedAt.toISOString(),
+        end: mostRecentActivation.suppressFurtherAlertsUntil.toISOString(),
+        ...(triggeringDevice ? { triggeringDevice: { id: triggeringDevice.id, name: triggeringDevice.name } } : {})
+      };
+    }
+
+    currentArming = {
+      mode: activeArming.mode as AlarmMode,
+      start: activeArming.start.toISOString(),
+      lastActivation
+    };
+  }
+
+  // Motion-by-room-hour heatmap, aggregated across every day in the selected range.
+  const motionLabelByDeviceId = new Map(motionDevices.map((device) => {
+    const roomId = (device.roomId as number | null) ?? null;
+    const key = roomId ?? -device.id;
+    const label = roomId !== null ? (roomNamesById.get(roomId) ?? device.name) : device.name;
+
+    return [device.id, { key, label }];
+  }));
+
+  const motionByRoomHourBuckets = new Map<string, { roomId: number | null; label: string; hour: number; count: number }>();
+
+  for (const event of motionEvents) {
+    const bucketInfo = motionLabelByDeviceId.get(event.deviceId)!;
+    const hour = dayjs(event.start).hour();
+    const bucketKey = `${bucketInfo.key}|${hour}`;
+    const existing = motionByRoomHourBuckets.get(bucketKey);
+
+    if (existing) {
+      existing.count += 1;
+    } else {
+      motionByRoomHourBuckets.set(bucketKey, {
+        roomId: event.roomId,
+        label: bucketInfo.label,
+        hour,
+        count: 1
+      });
+    }
+  }
+
+  const response: SecurityInsightsApiResponse = {
+    currentArming,
+    armings,
+    motionEvents,
+    lockEvents,
+    contactEvents,
+    doorbellRings,
+    cameras,
+    motionByRoomHour: [...motionByRoomHourBuckets.values()],
+    connectivityEvents
+  };
+
+  res.json(response);
+}

--- a/server/src/routes/api/insights/security.ts
+++ b/server/src/routes/api/insights/security.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { Device, Arming, Room, Op } from '../../../models';
+import { Device, Arming, Op } from '../../../models';
 import { SecurityInsightsApiResponse, AlarmMode } from '../../../api/types';
 import { Capability } from '../../../models/capabilities';
 import { HistorySelector } from '../../../models/capabilities/helpers';
@@ -22,8 +22,7 @@ export default async function (req: Request, res: Response) {
     cameraDevices,
     connectivityDevices,
     armingRows,
-    activeArming,
-    rooms
+    activeArming
   ] = await Promise.all([
     Device.findByCapability('MOTION_SENSOR'),
     Device.findByCapability('DOORBELL'),
@@ -41,11 +40,8 @@ export default async function (req: Request, res: Response) {
       },
       order: [['start', 'DESC']]
     }),
-    Arming.getActiveArming(),
-    Room.findAll()
+    Arming.getActiveArming()
   ]);
-
-  const roomNamesById = new Map(rooms.map(room => [room.id as number, room.name]));
 
   // Motion history, per device, hydrated with the recording (if the source device is a camera).
   const motionEventLists = await asyncMap(motionDevices, async (device) => {
@@ -244,29 +240,20 @@ export default async function (req: Request, res: Response) {
     };
   }
 
-  // Motion-by-room-hour heatmap, aggregated across every day in the selected range.
-  const motionLabelByDeviceId = new Map(motionDevices.map((device) => {
-    const roomId = (device.roomId as number | null) ?? null;
-    const key = roomId ?? -device.id;
-    const label = roomId !== null ? (roomNamesById.get(roomId) ?? device.name) : device.name;
-
-    return [device.id, { key, label }];
-  }));
-
-  const motionByRoomHourBuckets = new Map<string, { roomId: number | null; label: string; hour: number; count: number }>();
+  // Motion-by-device-hour heatmap, aggregated across every day in the selected range.
+  const motionByDeviceHourBuckets = new Map<string, { deviceId: number; label: string; hour: number; count: number }>();
 
   for (const event of motionEvents) {
-    const bucketInfo = motionLabelByDeviceId.get(event.deviceId)!;
     const hour = dayjs(event.start).hour();
-    const bucketKey = `${bucketInfo.key}|${hour}`;
-    const existing = motionByRoomHourBuckets.get(bucketKey);
+    const bucketKey = `${event.deviceId}|${hour}`;
+    const existing = motionByDeviceHourBuckets.get(bucketKey);
 
     if (existing) {
       existing.count += 1;
     } else {
-      motionByRoomHourBuckets.set(bucketKey, {
-        roomId: event.roomId,
-        label: bucketInfo.label,
+      motionByDeviceHourBuckets.set(bucketKey, {
+        deviceId: event.deviceId,
+        label: event.deviceName,
         hour,
         count: 1
       });
@@ -274,13 +261,12 @@ export default async function (req: Request, res: Response) {
   }
 
   // Every motion sensor should still get a row on the heatmap even if it hasn't recorded any
-  // motion in the selected range - seed a zero-count bucket for any label not already present.
-  const labelsWithMotion = new Set([...motionByRoomHourBuckets.values()].map(bucket => bucket.label));
+  // motion in the selected range - seed a zero-count bucket for any device not already present.
+  const deviceIdsWithMotion = new Set([...motionByDeviceHourBuckets.values()].map(bucket => bucket.deviceId));
 
-  for (const { key, label } of motionLabelByDeviceId.values()) {
-    if (!labelsWithMotion.has(label)) {
-      motionByRoomHourBuckets.set(`${key}|empty`, { roomId: null, label, hour: 0, count: 0 });
-      labelsWithMotion.add(label);
+  for (const device of motionDevices) {
+    if (!deviceIdsWithMotion.has(device.id)) {
+      motionByDeviceHourBuckets.set(`${device.id}|empty`, { deviceId: device.id, label: device.name, hour: 0, count: 0 });
     }
   }
 
@@ -292,7 +278,7 @@ export default async function (req: Request, res: Response) {
     contactEvents,
     doorbellRings,
     cameras,
-    motionByRoomHour: [...motionByRoomHourBuckets.values()],
+    motionByDeviceHour: [...motionByDeviceHourBuckets.values()],
     connectivityEvents
   };
 

--- a/server/src/routes/api/insights/security.ts
+++ b/server/src/routes/api/insights/security.ts
@@ -216,9 +216,13 @@ export default async function (req: Request, res: Response) {
   let currentArming: SecurityInsightsApiResponse['currentArming'];
 
   if (!activeArming) {
-    currentArming = { mode: 'OFF', start: null, lastActivation: null };
+    currentArming = { mode: 'OFF', start: null, activationCount: 0, lastActivation: null };
   } else {
-    const mostRecentActivation = await activeArming.getMostRecentActivation();
+    const activations = await activeArming.getAlarmActivations();
+    const mostRecentActivation = activations.length === 0 ? null : activations.reduce((mostRecent, curr) =>
+      mostRecent.startedAt > curr.startedAt ? mostRecent : curr
+    );
+
     let lastActivation: SecurityInsightsApiResponse['currentArming']['lastActivation'] = null;
 
     if (mostRecentActivation) {
@@ -236,6 +240,7 @@ export default async function (req: Request, res: Response) {
     currentArming = {
       mode: activeArming.mode as AlarmMode,
       start: activeArming.start.toISOString(),
+      activationCount: activations.length,
       lastActivation
     };
   }

--- a/server/src/routes/api/insights/security.ts
+++ b/server/src/routes/api/insights/security.ts
@@ -245,34 +245,15 @@ export default async function (req: Request, res: Response) {
     };
   }
 
-  // Motion-by-device-hour heatmap, aggregated across every day in the selected range.
-  const motionByDeviceHourBuckets = new Map<string, { deviceId: number; label: string; hour: number; count: number }>();
+  // Motion-by-device-hour heatmap, aggregated across every day in the selected range. Seed
+  // every motion sensor up front so it still gets a row even with zero motion in the range.
+  const motionByDeviceHour = new Map(motionDevices.map((device) =>
+    [device.id, { deviceId: device.id, label: device.name, countByHour: new Array(24).fill(0) }]
+  ));
 
   for (const event of motionEvents) {
     const hour = dayjs(event.start).hour();
-    const bucketKey = `${event.deviceId}|${hour}`;
-    const existing = motionByDeviceHourBuckets.get(bucketKey);
-
-    if (existing) {
-      existing.count += 1;
-    } else {
-      motionByDeviceHourBuckets.set(bucketKey, {
-        deviceId: event.deviceId,
-        label: event.deviceName,
-        hour,
-        count: 1
-      });
-    }
-  }
-
-  // Every motion sensor should still get a row on the heatmap even if it hasn't recorded any
-  // motion in the selected range - seed a zero-count bucket for any device not already present.
-  const deviceIdsWithMotion = new Set([...motionByDeviceHourBuckets.values()].map(bucket => bucket.deviceId));
-
-  for (const device of motionDevices) {
-    if (!deviceIdsWithMotion.has(device.id)) {
-      motionByDeviceHourBuckets.set(`${device.id}|empty`, { deviceId: device.id, label: device.name, hour: 0, count: 0 });
-    }
+    motionByDeviceHour.get(event.deviceId)!.countByHour[hour] += 1;
   }
 
   const response: SecurityInsightsApiResponse = {
@@ -283,7 +264,7 @@ export default async function (req: Request, res: Response) {
     contactEvents,
     doorbellRings,
     cameras,
-    motionByDeviceHour: [...motionByDeviceHourBuckets.values()],
+    motionByDeviceHour: [...motionByDeviceHour.values()],
     connectivityEvents
   };
 

--- a/server/src/routes/api/insights/security.ts
+++ b/server/src/routes/api/insights/security.ts
@@ -273,6 +273,17 @@ export default async function (req: Request, res: Response) {
     }
   }
 
+  // Every motion sensor should still get a row on the heatmap even if it hasn't recorded any
+  // motion in the selected range - seed a zero-count bucket for any label not already present.
+  const labelsWithMotion = new Set([...motionByRoomHourBuckets.values()].map(bucket => bucket.label));
+
+  for (const { key, label } of motionLabelByDeviceId.values()) {
+    if (!labelsWithMotion.has(label)) {
+      motionByRoomHourBuckets.set(`${key}|empty`, { roomId: null, label, hour: 0, count: 0 });
+      labelsWithMotion.add(label);
+    }
+  }
+
   const response: SecurityInsightsApiResponse = {
     currentArming,
     armings,

--- a/server/src/services/synology/index.ts
+++ b/server/src/services/synology/index.ts
@@ -126,9 +126,9 @@ export async function onDoorbellRing(cameraId: string) {
     sound: 'doorbell'
   });
 
-  const event = (await device.getDoorbellCapability().setRingState(true, now))!;
+  const event = await device.getDoorbellCapability().setRingState(true, now);
 
-  await s3.store(event.id.toString(), image, 'image/jpeg');
+  await s3.store(event!.id.toString(), image, 'image/jpeg');
 }
 
 setInterval(createBackgroundTransaction('synology:clear-old-recordings', async () => {

--- a/server/src/services/synology/index.ts
+++ b/server/src/services/synology/index.ts
@@ -126,9 +126,7 @@ export async function onDoorbellRing(cameraId: string) {
     sound: 'doorbell'
   });
 
-  await device.getDoorbellCapability().setRingState(true, now);
-
-  const event = (await device.getLatestEvent('ring'))!;
+  const event = (await device.getDoorbellCapability().setRingState(true, now))!;
 
   await s3.store(event.id.toString(), image, 'image/jpeg');
 }

--- a/server/src/services/synology/index.ts
+++ b/server/src/services/synology/index.ts
@@ -27,32 +27,27 @@ type SynologyCamera = { id: number; status: number; enabled: boolean; vendor: st
 
 // Download footage from start -> end, +- 5 seconds.
 
-async function createEvent(device: Device, now: Dayjs) {
-  const latestCameraEvent = await device.getLatestEvent('motion');
-  let activeCameraEvent = latestCameraEvent && !latestCameraEvent.end ? latestCameraEvent : null;
+async function extendOrCreateMotionEvent(device: Device, now: Dayjs): Promise<Event> {
+  const motion = device.getMotionSensorCapability();
+  const latestMotionEvent = await device.getLatestEvent('motion');
+  const activeCameraEvent = latestMotionEvent && !latestMotionEvent.end ? latestMotionEvent : null;
 
   if (activeCameraEvent) {
     const cutoffForExtension = dayjs(now).subtract(config.synology.maximum_length_of_event_in_seconds, 's');
     const canExtendActiveCameraEvent = cutoffForExtension.isBefore(activeCameraEvent.start);
 
     if (!canExtendActiveCameraEvent) {
-      activeCameraEvent.end = now.toDate();
-      await activeCameraEvent.save();
-
-      activeCameraEvent = null;
+      // Close out the event that's grown too long - the setHasMotionState(true, ...) call
+      // below will then open a fresh one, rather than extending this one further.
+      await motion.setHasMotionState(false, now.toDate());
     }
   }
 
-  if (!activeCameraEvent) {
-    activeCameraEvent = await Event.create({
-      start: now.toDate(),
-      lastReported: now.toDate(),
-      deviceId: device.id,
-      type: 'motion'
-    });
-  }
+  // If there's no active event, this creates one. If the active event can still be extended,
+  // setBooleanProperty's same-value handling just bumps lastReported rather than writing a new row.
+  await motion.setHasMotionState(true, now.toDate());
 
-  return activeCameraEvent;
+  return (await device.getLatestEvent('motion'))!;
 }
 
 async function captureRecording(event: Event, providerId: string, startOfRecording: Dayjs, endOfRecording: Dayjs) {
@@ -103,7 +98,7 @@ async function captureRecording(event: Event, providerId: string, startOfRecordi
 
 export async function onMotionDetected(cameraId: string, startOfDetectedMotion: Dayjs) {
   const device = await Device.findByProviderIdOrError('synology', cameraId);
-  const event = await createEvent(device, startOfDetectedMotion);
+  const event = await extendOrCreateMotionEvent(device, startOfDetectedMotion);
 
   latestCameraEvents.set(device.id, startOfDetectedMotion);
 
@@ -111,8 +106,7 @@ export async function onMotionDetected(cameraId: string, startOfDetectedMotion: 
     const now = new Date();
 
     if (latestCameraEvents.get(device.id) === startOfDetectedMotion) {
-      event.end = now;
-      await event.save();
+      await device.getMotionSensorCapability().setHasMotionState(false, now);
     }
 
     enqueueWorkItem(() => captureRecording(event, device.providerId, dayjs(event.start).subtract(2, 's'), dayjs(now).add(2, 's')));
@@ -132,14 +126,9 @@ export async function onDoorbellRing(cameraId: string) {
     sound: 'doorbell'
   });
 
-  const event = await Event.create({
-    deviceId: device.id,
-    start: now,
-    end: now,
-    lastReported: now,
-    type: 'ring',
-    value: 1
-  });
+  await device.getDoorbellCapability().setRingState(true, now);
+
+  const event = (await device.getLatestEvent('ring'))!;
 
   await s3.store(event.id.toString(), image, 'image/jpeg');
 }
@@ -201,7 +190,7 @@ export async function onConnectivityChanged() {
 
 Device.registerProvider('synology', {
   getCapabilities(device) {
-    return ['CAMERA', 'CONNECTIVITY'];
+    return ['CAMERA', 'CONNECTIVITY', 'MOTION_SENSOR', 'DOORBELL'];
   },
 
   async synchronize() {

--- a/server/src/services/synology/index.ts
+++ b/server/src/services/synology/index.ts
@@ -1,7 +1,7 @@
 import dayjs, { Dayjs } from '../../dayjs';
 import config from '../../config';
 import logger from '../../logger';
-import { Event, Recording, Stay, Device, Op } from '../../models';
+import { Event, BooleanEvent, Recording, Stay, Device, Op } from '../../models';
 import s3 from '../s3';
 import makeSynologyRequest from './instance';
 import { v4 as uuidv4 } from 'uuid';
@@ -27,30 +27,32 @@ type SynologyCamera = { id: number; status: number; enabled: boolean; vendor: st
 
 // Download footage from start -> end, +- 5 seconds.
 
-async function extendOrCreateMotionEvent(device: Device, now: Dayjs): Promise<Event> {
+async function extendOrCreateMotionEvent(device: Device, now: Dayjs): Promise<BooleanEvent> {
   const motion = device.getMotionSensorCapability();
-  const latestMotionEvent = await device.getLatestEvent('motion');
+  const latestMotionEvent = await motion.getHasMotionEvent();
   const activeCameraEvent = latestMotionEvent && !latestMotionEvent.end ? latestMotionEvent : null;
 
   if (activeCameraEvent) {
     const cutoffForExtension = dayjs(now).subtract(config.synology.maximum_length_of_event_in_seconds, 's');
     const canExtendActiveCameraEvent = cutoffForExtension.isBefore(activeCameraEvent.start);
 
-    if (!canExtendActiveCameraEvent) {
-      // Close out the event that's grown too long - the setHasMotionState(true, ...) call
-      // below will then open a fresh one, rather than extending this one further.
-      await motion.setHasMotionState(false, now.toDate());
+    if (canExtendActiveCameraEvent) {
+      // setBooleanProperty's same-value handling just bumps lastReported rather than writing a
+      // new row, so there's nothing new to return - the active event is still this one.
+      await motion.setHasMotionState(true, now.toDate());
+
+      return activeCameraEvent;
     }
+
+    // Close out the event that's grown too long - the setHasMotionState(true, ...) call
+    // below will then open a fresh one, rather than extending this one further.
+    await motion.setHasMotionState(false, now.toDate());
   }
 
-  // If there's no active event, this creates one. If the active event can still be extended,
-  // setBooleanProperty's same-value handling just bumps lastReported rather than writing a new row.
-  await motion.setHasMotionState(true, now.toDate());
-
-  return (await device.getLatestEvent('motion'))!;
+  return (await motion.setHasMotionState(true, now.toDate()))!;
 }
 
-async function captureRecording(event: Event, providerId: string, startOfRecording: Dayjs, endOfRecording: Dayjs) {
+async function captureRecording(event: BooleanEvent, providerId: string, startOfRecording: Dayjs, endOfRecording: Dayjs) {
   const existingRecording = await event.getRecording();
   let attempts = 10;
   let cameraRecording;


### PR DESCRIPTION
## Summary

Adds a **Security** page under Insights (`/insights/security`) with a selectable date range (default: Today):

- **Live camera snapshots** row at the top, reusing the existing `Security` component.
- **Alarm status card** — current mode (Home/Away/Night), when it was armed, and the most recent activation for the active arming (including the device that triggered it, and the suppression window), with quick mode-switch controls.
- **KPI strip** — motion events and alarm activations in range, plus "Doors" and "Windows & doors" tiles derived from current `LOCK`/`CONTACT_SENSOR` state (all locked/closed, or naming what isn't).
- **Motion-by-room heatmap** — hour-of-day motion counts, aggregated across every day in the selected range.
- **Timeline** — merges alarm arming/activation, motion, lock, contact-sensor, doorbell-ring and connectivity (online/offline) events for security-relevant devices into one filterable feed, reusing the existing `Timeline` component. Motion/doorbell rows expand inline video/image panels where a recording or thumbnail exists.

## Backend changes enabling the above

- New `Doorbell` capability (momentary `Ring` boolean) — the Synology doorbell write path now goes through `getDoorbellCapability().setRingState()` instead of writing an `Event` row directly.
- Synology cameras now also declare `MOTION_SENSOR`; the motion write path (`onMotionDetected`) is refactored to go through `getMotionSensorCapability().setHasMotionState()` instead of hand-rolled `Event` create/save. Behaviour (including the "extend if within max length" logic) is unchanged.
- `AlarmActivation` gains a nullable `triggeringDeviceId`, populated in the automation's hot path (`automations/security.ts`) at the point the activation is created — not computed retrospectively.
- `BooleanEvent`/`NumericEvent`/`StringEvent` gain a `getRecording()` accessor (mirroring the existing `getDevice()`), so the new endpoint can resolve a motion event's recording without dropping to `Event.findAll`.
- New `/api/insights/security` endpoint — reads exclusively through capability history getters (`getHasMotionHistory`, `getIsLockedHistory`, `getIsOpenHistory`, `getRingHistory`, `getIsConnectedHistory`) per this repo's convention of not querying `Event` directly from routes.

## Test plan

- [x] `npm run codegen && npm run lint && npm run test && npm run build` all pass (zero-warning lint policy).
- [ ] Manual: run migrations, start dev server, verify `/insights/security` renders and the date-range selector refetches.
- [ ] Manual: trigger a real alarm activation and confirm the triggering device shows on the status card.
- [ ] Manual: confirm Synology motion detection and doorbell rings still produce `Recording`s / thumbnails after the write-path refactor (regression check — visible on both this page and the existing Timeline page).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBLELxCB4kGYvcQqCgH98L)_