### PR TITLE
Clarify and shorten silencing-window motion suppression alert

### DIFF
--- a/server/src/automations/security.ts
+++ b/server/src/automations/security.ts
@@ -142,7 +142,7 @@ export default async function ({
         });
 
         bus.emit(NOTIFICATION_TO_ALL, {
-          message: `🔕 ${device.name} triggered motion, but alerts are suppressed until ${dayjs(suppressFurtherAlertsUntil).format('HH:mm')}.`
+          message: `🔕 Motion detected by the ${device.name} at ${dayjs(event.start).format('HH:mm:ss')}. Further alerts will be suppressed until ${dayjs(suppressFurtherAlertsUntil).format('HH:mm')}.`
         });
 
         return;

--- a/server/src/automations/security.ts
+++ b/server/src/automations/security.ts
@@ -133,14 +133,16 @@ export default async function ({
       const silencingWindow = findActiveSilencingWindow(silencingWindows, event.start);
 
       if (silencingWindow) {
+        const suppressFurtherAlertsUntil = getSilencingWindowEndsAt(silencingWindow, event.start);
+
         await AlarmActivation.create({
           armingId: arming.id,
           startedAt: event.start,
-          suppressFurtherAlertsUntil: getSilencingWindowEndsAt(silencingWindow, event.start)
+          suppressFurtherAlertsUntil
         });
 
         bus.emit(NOTIFICATION_TO_ALL, {
-          message: `🔕 Motion detected by the ${device.name} at ${dayjs(event.start).format('HH:mm:ss')} was suppressed by the "${silencingWindow.name}" silencing window`
+          message: `🔕 ${device.name} triggered motion, suppressed by "${silencingWindow.name}". No further alerts until ${dayjs(suppressFurtherAlertsUntil).format('HH:mm')}.`
         });
 
         return;

--- a/server/src/automations/security.ts
+++ b/server/src/automations/security.ts
@@ -142,7 +142,7 @@ export default async function ({
         });
 
         bus.emit(NOTIFICATION_TO_ALL, {
-          message: `🔕 ${device.name} triggered motion, suppressed by "${silencingWindow.name}". No further alerts until ${dayjs(suppressFurtherAlertsUntil).format('HH:mm')}.`
+          message: `🔕 ${device.name} triggered motion, but alerts are suppressed until ${dayjs(suppressFurtherAlertsUntil).format('HH:mm')}.`
         });
 
         return;


### PR DESCRIPTION
## Summary
- The "🔕 ... was suppressed by the silencing window" notification didn't tell you when alerts would resume, so it wasn't obvious you'd stay blind to motion until the window ended.
- Reworked into two short sentences: what happened (motion detected, with the precise time), and what happens next (further alerts suppressed until the window ends). Dropped the silencing window's name, since it's identifiable from the day/time and was redundant.

Before:
> 🔕 Motion detected by the Wardrobe Motion Sensor at 12:33:18 was suppressed by the "Tara - Cleaner" silencing window

After:
> 🔕 Motion detected by the Wardrobe Motion Sensor at 12:33:18. Further alerts will be suppressed until 14:00.

## Test plan
- [ ] Trigger motion during an active silencing window in a dev environment and confirm the notification text reads as expected.